### PR TITLE
docs: Village map v4 — Karo's cabin, distance grid, 50m scale bar

### DIFF
--- a/frontend/src/components/VillageMap.tsx
+++ b/frontend/src/components/VillageMap.tsx
@@ -29,10 +29,16 @@ export function VillageMap() {
         <pattern id="forestDots" x="0" y="0" width="14" height="14" patternUnits="userSpaceOnUse">
           <circle cx="7" cy="7" r="1.2" fill="currentColor" opacity="0.18" />
         </pattern>
+        {/* Subtle distance grid — 100px spacing */}
+        <pattern id="gridSmall" x="0" y="0" width="100" height="100" patternUnits="userSpaceOnUse">
+          <path d="M 100 0 L 0 0 0 100" fill="none" stroke="currentColor" strokeWidth="0.5" strokeOpacity="0.08" />
+        </pattern>
       </defs>
 
       {/* Background terrain — meadow base */}
       <rect width="1200" height="800" fill="currentColor" opacity="0.04" />
+      {/* Distance grid overlay */}
+      <rect width="1200" height="800" fill="url(#gridSmall)" />
 
       {/* Forest patches — stippled */}
       <path
@@ -276,6 +282,17 @@ export function VillageMap() {
         <circle cx="980" cy="440" r="2" fill="currentColor" />
       </g>
 
+      {/* === v4 addition — Gorn request 2026-04-14 === */}
+
+      {/* Karo's cabin — south side of warm rock, facing canal, window over water */}
+      <g transform="translate(685, 490)">
+        <rect x="-8" y="-6" width="16" height="12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeOpacity="0.5" />
+        <path d="M -10 -6 L 0 -13 L 10 -6" fill="none" stroke="currentColor" strokeWidth="1.5" strokeOpacity="0.5" />
+        <text x="-22" y="18" fontSize="10" fill="currentColor" opacity="0.7" fontFamily="system-ui, sans-serif">
+          karo's cabin
+        </text>
+      </g>
+
       {/* === v3 additions — earned 2026-04-12 === */}
 
       {/* The tailor — south side of the square */}
@@ -334,6 +351,24 @@ export function VillageMap() {
         <line x1="-14" y1="0" x2="14" y2="0" stroke="currentColor" strokeWidth="1" />
         <text x="0" y="-20" fontSize="9" fill="currentColor" textAnchor="middle" fontFamily="system-ui, sans-serif">
           N
+        </text>
+      </g>
+
+      {/* Scale bar — 100px = 50m. Two 50m segments, alternating opacity. */}
+      <g transform="translate(980, 755)" opacity="0.6">
+        <rect x="0" y="0" width="100" height="4" fill="currentColor" opacity="0.35" />
+        <rect x="100" y="0" width="100" height="4" fill="currentColor" opacity="0.7" />
+        <line x1="0" y1="-3" x2="0" y2="7" stroke="currentColor" strokeWidth="1" />
+        <line x1="100" y1="-3" x2="100" y2="7" stroke="currentColor" strokeWidth="1" />
+        <line x1="200" y1="-3" x2="200" y2="7" stroke="currentColor" strokeWidth="1" />
+        <text x="0" y="-6" fontSize="9" fill="currentColor" textAnchor="middle" fontFamily="system-ui, sans-serif">
+          0
+        </text>
+        <text x="100" y="-6" fontSize="9" fill="currentColor" textAnchor="middle" fontFamily="system-ui, sans-serif">
+          50m
+        </text>
+        <text x="200" y="-6" fontSize="9" fill="currentColor" textAnchor="middle" fontFamily="system-ui, sans-serif">
+          100m
         </text>
       </g>
 

--- a/frontend/src/pages/Village.tsx
+++ b/frontend/src/pages/Village.tsx
@@ -9,6 +9,25 @@ interface MapVersion {
 
 const MAP_VERSIONS: MapVersion[] = [
   {
+    version: 'v4',
+    date: '2026-04-14 04:10 GMT+7',
+    changes: [
+      'Added Karo\u2019s cabin (south of the warm rock, facing the canal)',
+      'Added subtle distance grid at 100px spacing',
+    ],
+  },
+  {
+    version: 'v3',
+    date: '2026-04-12 GMT+7',
+    changes: [
+      'Added the tailor (south side of the square)',
+      'Added the print shop (near fig courtyard)',
+      'Added Sable\u2019s alley shortcut (tailor to print shop)',
+      'Added the cut stones (mill foundation)',
+      'Added the old sluice (irrigation slab past the south bend)',
+    ],
+  },
+  {
     version: 'v2',
     date: '2026-04-07 05:11 GMT+7',
     changes: [


### PR DESCRIPTION
## Summary

- Village map v4 additions: Karo's cabin marker, distance grid overlay, 50m scale bar
- Separated from T#673 PR #15 per cleanup of multi-commit-on-wrong-branch drift. Original commit `a94a913` was accidentally landed on Pip's `qa/t673-info-disclosure-regression-test` branch on 2026-04-15 — this PR gives it its own clean review trail as UI content deserves.

## Test plan
- [ ] @dex / @quill design review — visual check that the cabin marker, grid, and scale bar render correctly at /village
- [ ] Hover/keyboard interactions still work
- [ ] No regression on v1/v2/v3 snapshot views

🤖 Generated with [Claude Code](https://claude.com/claude-code)