### PR TITLE
T#679: extend generic 403 bodies to non-beast auth-gated endpoints

### DIFF
--- a/src/info-disclosure.test.ts
+++ b/src/info-disclosure.test.ts
@@ -95,6 +95,18 @@ const TOKEN_TERM_EXEMPT_PATHS = [
   '/api/auth/tokens',
 ];
 
+/**
+ * Spoof-detection 403 responses ("Identity spoof blocked. ?as=/body.beast must
+ * match authenticated caller...") legitimately mention "as=" because the
+ * attempted spoof IS the diagnostic — owner-debug-affordance preserves the
+ * specific message so legit code with auth-shape mismatch can be debugged.
+ *
+ * These are in-flow owner messages, not external attack surface. Whether to
+ * also flatten them (security-by-obscurity over owner-debug-affordance) is a
+ * separate scope decision — file follow-up if desired.
+ */
+const SPOOF_DETECTION_PATTERN = /Identity spoof blocked/i;
+
 interface ErrorMatch {
   line: number;
   errorText: string;
@@ -201,23 +213,28 @@ test('T#673: no info-disclosure in 403 responses on /api/beast/:name/* endpoints
   expect(beastMatches.length).toBe(0);
 });
 
-test('T#673: info-disclosure audit on non-beast 403 responses (advisory)', () => {
+test('T#679: no info-disclosure in 403 responses on non-beast endpoints (post-T#679 hardening)', () => {
   const { otherMatches } = scanForInfoDisclosure();
 
-  // This test is advisory — it logs findings but does not fail.
-  // Non-beast endpoints are outside T#673 scope but the scan catches them
-  // for future hardening tasks.
-  if (otherMatches.length > 0) {
-    const summary = otherMatches
+  // Filter out spoof-detection messages — owner-debug-affordance, not external
+  // attack surface. See SPOOF_DETECTION_PATTERN definition for rationale.
+  const enforceableMatches = otherMatches.filter(
+    (m) => !SPOOF_DETECTION_PATTERN.test(m.errorText)
+  );
+
+  if (enforceableMatches.length > 0) {
+    const summary = enforceableMatches
       .map((m) => `  server.ts:${m.line} [${m.routePath}] "${m.errorText}" (term: ${m.term})`)
       .join('\n');
 
-    console.log(
-      `\n[T#673 advisory] Found ${otherMatches.length} potential info-disclosure in non-beast 403 responses:\n${summary}\n` +
-        `These are outside T#673 scope. Consider a follow-up task for full-server hardening.\n`
+    throw new Error(
+      `[T#679] Found ${enforceableMatches.length} info-disclosure leak(s) in non-beast 403 responses ` +
+        `(spoof-detection messages excluded — see SPOOF_DETECTION_PATTERN):\n${summary}\n` +
+        `Replace verbose 403 message with { error: 'forbidden' } per T#679.\n`
     );
   }
 
-  // Always passes — this is informational
-  expect(true).toBe(true);
+  // Hard-fail (post-T#679) — was advisory soft-pass under T#673, flipped per
+  // T#679 acceptance criterion 2.
+  expect(enforceableMatches.length).toBe(0);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -883,7 +883,7 @@ app.post('/api/auth/logout', (c) => {
 // Create guest account
 app.post('/api/guests', async (c) => {
   if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
-    return c.json({ error: 'Guest account management requires owner session' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const body = await c.req.json();
@@ -908,7 +908,7 @@ app.post('/api/guests', async (c) => {
 // List guest accounts
 app.get('/api/guests', (c) => {
   if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
-    return c.json({ error: 'Guest account management requires owner session' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const guests = listGuests(sqlite).map(g => {
@@ -936,7 +936,7 @@ app.get('/api/guests', (c) => {
 // Get single guest account
 app.get('/api/guests/:id', (c) => {
   if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
-    return c.json({ error: 'Guest account management requires owner session' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const id = parseInt(c.req.param('id'), 10);
@@ -966,7 +966,7 @@ app.get('/api/guests/:id', (c) => {
 // Update guest account (expiry, disable, display name)
 app.patch('/api/guests/:id', (c) => {
   if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
-    return c.json({ error: 'Guest account management requires owner session' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const id = parseInt(c.req.param('id'), 10);
@@ -986,7 +986,7 @@ app.patch('/api/guests/:id', (c) => {
 // Owner reset guest password (T#566)
 app.patch('/api/guests/:id/password', async (c) => {
   if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
-    return c.json({ error: 'Guest account management requires owner session' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const id = parseInt(c.req.param('id'), 10);
@@ -1007,7 +1007,7 @@ app.patch('/api/guests/:id/password', async (c) => {
 // Delete guest account (T#570 — with cascade notification)
 app.delete('/api/guests/:id', (c) => {
   if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
-    return c.json({ error: 'Guest account management requires owner session' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const id = parseInt(c.req.param('id'), 10);
@@ -1031,7 +1031,7 @@ app.post('/api/guests/:id/ban', async (c) => {
   const isOwner = hasSessionAuth(c) && (c.get as any)('role') !== 'guest';
   const isBeast = (c.get as any)('authMethod') === 'token' && (c.get as any)('role') === 'beast';
   if (!isOwner && !isBeast) {
-    return c.json({ error: 'Ban requires owner session or Beast token' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const id = parseInt(c.req.param('id'), 10);
@@ -1065,7 +1065,7 @@ app.post('/api/guests/:id/ban', async (c) => {
 app.post('/api/guests/:id/unban', async (c) => {
   // Owner session only — unbanning is a sensitive operation
   if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
-    return c.json({ error: 'Unban requires owner session' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const id = parseInt(c.req.param('id'), 10);
@@ -1100,11 +1100,11 @@ app.post('/api/guests/:id/unban', async (c) => {
 // Create token — Gorn session auth only
 app.post('/api/auth/tokens', async (c) => {
   if (!hasSessionAuth(c)) {
-    return c.json({ error: 'Token creation requires Gorn session auth' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
   // Block ?as= on this endpoint
   if (c.req.query('as')) {
-    return c.json({ error: 'Token creation does not accept ?as= parameter' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const body = await c.req.json();
@@ -1129,7 +1129,7 @@ app.post('/api/auth/tokens', async (c) => {
 // List tokens — Gorn session auth only (no hashes exposed)
 app.get('/api/auth/tokens', (c) => {
   if (!hasSessionAuth(c)) {
-    return c.json({ error: 'Token listing requires Gorn session auth' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
   return c.json({ tokens: listTokens() });
 });
@@ -1137,7 +1137,7 @@ app.get('/api/auth/tokens', (c) => {
 // Revoke token — Gorn session auth only
 app.delete('/api/auth/tokens/:id', (c) => {
   if (!hasSessionAuth(c)) {
-    return c.json({ error: 'Token revocation requires Gorn session auth' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
   const tokenId = parseInt(c.req.param('id'), 10);
   if (isNaN(tokenId)) {
@@ -1158,7 +1158,7 @@ app.post('/api/auth/tokens/rotate', (c) => {
   const tokenId = (c.get as any)('tokenId') as number;
 
   if (authMethod !== 'token' || !beast || !tokenId) {
-    return c.json({ error: 'Token rotation requires Bearer token auth' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
 
   const result = rotateToken(tokenId, beast);
@@ -3244,7 +3244,7 @@ app.get('/api/remote/status', (c) => {
 app.post('/api/remote/attach', async (c) => {
   // Remote attach requires local tmux access — reject non-local requests cleanly
   if (!isLocalNetwork(c) && !hasSessionAuth(c)) {
-    return c.json({ error: 'Remote attach requires local access' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
   try {
     const data = await c.req.json();
@@ -7224,7 +7224,7 @@ function runDbMaintenance() {
 app.post('/api/db/maintenance', (c) => {
   const requester = c.req.query('as');
   if (requester) {
-    return c.json({ error: 'DB maintenance is restricted to Gorn (session auth required)' }, 403);
+    return c.json({ error: 'forbidden' }, 403);
   }
   runDbMaintenance();
   return c.json({ status: 'ok', retention_days: DB_RETENTION_DAYS });


### PR DESCRIPTION
## Context

T#679 follow-up hygiene from T#673 (info-disclosure regression test, PR #16). Advisory arm of T#673 flagged 15 verbose 403 messages outside beast scope that match the FORBIDDEN_IN_ERROR_BODY allowlist (session, bearer, as=, local access). Same pattern T#666 addressed for beast endpoints.

Task assigned reviewer: @bertus. Tier 2 per Decree #71 (security-touch on auth-gated endpoints) — natural-pair = **Bertus + Talon** (security lane).

## What

`src/server.ts` — 15 verbose 403 messages flattened to `{ error: 'forbidden' }`:

- `/api/guests/**` — 6× "Guest account management requires owner session"
- `/api/guests/:id/ban` — "Ban requires owner session or Beast token"
- `/api/guests/:id/unban` — "Unban requires owner session"
- `/api/auth/tokens` × 5 — Token CRUD verbose messages (Gorn session auth, ?as= leak, Bearer leak)
- `/api/remote/attach` — "Remote attach requires local access"
- `/api/db/maintenance` — "DB maintenance is restricted to Gorn (session auth required)"

`src/info-disclosure.test.ts`:
- Renamed second test `T#673 advisory` → `T#679 hardening (post-T#673)`
- Flipped soft-pass advisory → hard-fail per T#679 acceptance criterion 2
- Added `SPOOF_DETECTION_PATTERN` exclusion for owner-debug-affordance messages (`Identity spoof blocked...`) — these are in-flow owner-debug responses, not external attack surface
- Test passes post-fix: 21 hits → 0 enforceable hits (6 remaining spoof-detection messages excluded by pattern)

## Tier classification

**Tier 2** — security hardening on auth-gated endpoints. Per Decree #71 §Tier 2 + WORKFLOW.md v0.2 Tier 2 row: `security → Bertus + Talon` natural pair. Pip QA-handoff fires in parallel per Norm #68 (info-disclosure tests count as QA-class).

## Test plan

- [ ] Reviewer reads diff, verifies all 15 sites flattened to `{ error: 'forbidden' }`
- [ ] Reviewer runs `bun test src/info-disclosure.test.ts` — both tests pass (T#673 beast endpoints stays 0 hits, T#679 non-beast hits = 0 enforceable)
- [ ] Reviewer verifies SPOOF_DETECTION_PATTERN scope-decision is acceptable (preserves owner-debug-affordance vs full-flatten security-by-obscurity)
- [ ] Reviewer flags any 403 sites not in the 15 that should also flatten
- [ ] Manual smoke: `curl -i http://localhost:47778/api/guests/1` (no session) → 403 with `{"error":"forbidden"}` body

## Out-of-scope (filed for follow-up if desired)

6 spoof-detection sites preserve verbose messages for owner-debug-affordance:
- `/api/dm/messages/:id` (line 5236)
- `/api/library/shelves` (line 5334)
- `/api/library/:id` (line 5613)
- `/api/schedules/:id/run` (line 6839)
- `/api/rules/:id` (line 11436)
- `/api/rules/:id/archive` (line 11473)

Whether to also flatten these (security-by-obscurity over owner-debug-affordance) is a separate scope decision — separate task if pack reads it as worth doing.

## Workflow self-meta

Third dogfood of WORKFLOW.md v0.2 cycle. First Tier 2. Exercises:
- Two-reviewer natural-pair flow (Bertus + Talon)
- Norm #68 parallel QA-handoff (Pip if she picks up)
- Restart-required deploy (code change to server.ts)
- Smoke battery includes manual curl on hardened endpoint

Per WORKFLOW.md v0.2 §Step 4 board-state hygiene: task #679 status moved to in_review, reviewer set to bertus.

— Karo 🦴 (codebase-owner pen, T#679 implementation)