### PR TITLE
fix: Forge auth — read requester from bearer-token actor (T#718-aligned)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9761,14 +9761,32 @@ const FORGE_BEAST_MODES: Record<string, 'read' | 'write'> = {
 
 // Auth helper: Gorn (session) + allowlisted beasts per FORGE_BEAST_MODES.
 // mode='read' permits any allowlisted beast; mode='write' requires write-mode beast.
+//
+// T#718-aligned: prefers bearer-token-derived actor (set by auth middleware) over
+// the legacy ?as= query param shape. Bearer-token-actor path is checked first;
+// ?as= path retained for backwards-compat with existing callers (Sable TG flows,
+// legacy scripts) until follow-up T# removes it post-migration audit.
 function isForgeAuthorized(c: any, options: { mode: 'read' | 'write' } = { mode: 'write' }): boolean {
   if (hasSessionAuth(c)) return true; // Gorn browser session — owner, full write
+
+  // T#718 path: read requester from authenticated bearer-token actor (no ?as= needed)
+  const actor = ((c.get as any)('actor') as string | undefined)?.toLowerCase();
+  if (actor) {
+    const beastMode = FORGE_BEAST_MODES[actor];
+    if (!beastMode) return false;
+    if (options.mode === 'read') return true; // either mode satisfies read
+    return beastMode === 'write';              // write requires write
+  }
+
+  // Backwards-compat: ?as= query param + isTrustedRequest local-network bypass.
+  // Retained so existing callers (Sable scripts, legacy curl flows) don't break
+  // pre-migration. Follow-up T# removes after callers migrate to bearer-only.
   if (isTrustedRequest(c)) {
     const as = (c.req.query('as') || '').toLowerCase();
     const beastMode = FORGE_BEAST_MODES[as];
     if (!beastMode) return false;
-    if (options.mode === 'read') return true; // either mode satisfies read
-    return beastMode === 'write';              // write requires write
+    if (options.mode === 'read') return true;
+    return beastMode === 'write';
   }
   return false;
 }


### PR DESCRIPTION
## Context

Per Bear directive on Discord 20:33 BKK: *"Better fix the underlying problem fluff. Make forge auth read api requester from auth token."*

**Origin**: Boro reported (via Bear) at 20:29 BKK that he could not access Forge endpoints. Diagnosis: `isForgeAuthorized()` predates T#718 bearer-token-actor pattern — it requires `?as=<beast>` query param + `isTrustedRequest()` local-network bypass, but Boro was calling with bearer-only (T#718 shape his recruitment trained him on).

Verified the diagnosis pre-fix:
- `curl '/api/routine/today?as=boro'` → 200 ✓
- `curl -H 'Bearer $boro_token' '/api/routine/today'` → 403 "Forge is private to Gorn and Sable" ✗

## What

`src/server.ts` `isForgeAuthorized()` — added bearer-token-actor path FIRST, then falls through to legacy `?as=` for backwards-compat:

1. `hasSessionAuth(c)` — Gorn browser session (unchanged)
2. **NEW**: bearer-token actor → FORGE_BEAST_MODES lookup
3. Backwards-compat: `?as=` + `isTrustedRequest()` (unchanged, retained)

## Why backwards-compat retained

Existing callers — Sable TG flows, scheduler-fired Forge writes, legacy shell scripts — use the `?as=` shape. Removing it now would break those. Follow-up T# files for full removal after migration audit.

## Tier classification

**Tier 2** — auth-touch on Forge data surface. Per Decree #71 §Tier 2 + WORKFLOW.md v0.2 row: `security → Bertus + Talon` natural-pair (security lane).

## Test plan

- [ ] `curl -H 'Bearer $(cat ~/.oracle/tokens/boro)' /api/routine/today` → 200 (was 403)
- [ ] `curl '/api/routine/today?as=boro'` → 200 (unchanged backwards-compat)
- [ ] `curl /api/routine/today` (no auth) → 403 (unchanged)
- [ ] `curl -X POST -H 'Bearer $(cat ~/.oracle/tokens/karo)' /api/routine/logs` (write-mode) → succeeds
- [ ] `curl -X POST -H 'Bearer $(cat ~/.oracle/tokens/boro)' /api/routine/logs` (read-mode) → 403 (boro is read-only per FORGE_BEAST_MODES)
- [ ] Reviewer manually checks no other Forge auth path bypassed

## Sequencing note

PR #22 (T#679 generic 403 bodies, also Tier 2 + same reviewer pair) still in-flight. This PR is **parallel** — different file region (line 9764 vs 880-7227 range), independent code path. Per `feedback_one_at_a_time.md` discipline normally one-PR-at-a-time, but this is **Bear-direct** + **Boro-blocked** so parallel land is justified. Bertus + Talon can review both in parallel.

## Architecture observation (post-merge follow-up candidates)

1. **Telegram-cache auth** (`isTelegramAuthorized`, `TELEGRAM_READ_MODES`) has the same pre-T#718 shape — bearer-token-actor migration would be parallel work, separate scope decision per Library #96 lever 1.
2. **T#719 Phase 1.5 sweep** should include other auth-derive identity sites that still use `?as=` query param scaffolding.

— Karo 🦴 (codebase-owner pen, Boro-unblocking + T#718 alignment)