### PR TITLE
debug(TEMP): log Hevy webhook auth-fail shape for diagnosis

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11244,7 +11244,14 @@ app.post('/api/webhooks/hevy', async (c) => {
   const expectedBuf = Buffer.from(expectedHeader);
   const valid = authBuf.length === expectedBuf.length && timingSafeEqual(authBuf, expectedBuf);
   if (!valid) {
-    console.warn('[Hevy webhook] auth failed — bad bearer');
+    // DEBUG (TEMP — revert post-diagnosis): log header shape WITHOUT leaking full secret.
+    // Logs length + first/last 4 chars to triage paste-mismatch vs format-mismatch vs missing-header.
+    const headerPreview = authHeader.length > 8
+      ? `${authHeader.slice(0, 4)}...${authHeader.slice(-4)}`
+      : authHeader || '(empty)';
+    const expectedPreview = `${expectedHeader.slice(0, 4)}...${expectedHeader.slice(-4)}`;
+    const allHeaderNames = Array.from(c.req.raw.headers.keys()).join(',');
+    console.warn(`[Hevy webhook] auth failed — bad bearer. authHeader length=${authHeader.length} preview=${headerPreview} | expected length=${expectedHeader.length} preview=${expectedPreview} | all headers=[${allHeaderNames}]`);
     return c.json({ error: 'forbidden' }, 401);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11244,14 +11244,14 @@ app.post('/api/webhooks/hevy', async (c) => {
   const expectedBuf = Buffer.from(expectedHeader);
   const valid = authBuf.length === expectedBuf.length && timingSafeEqual(authBuf, expectedBuf);
   if (!valid) {
-    // DEBUG (TEMP — revert post-diagnosis): log header shape WITHOUT leaking full secret.
-    // Logs length + first/last 4 chars to triage paste-mismatch vs format-mismatch vs missing-header.
+    // DEBUG (TEMP — revert post-diagnosis): log received-header shape WITHOUT leaking expected.
+    // Per Bertus #10507 debug-asymmetry — log what you got, not what you expected. Logs length +
+    // first/last 4 chars to triage paste-mismatch vs format-mismatch vs missing-header.
     const headerPreview = authHeader.length > 8
       ? `${authHeader.slice(0, 4)}...${authHeader.slice(-4)}`
       : authHeader || '(empty)';
-    const expectedPreview = `${expectedHeader.slice(0, 4)}...${expectedHeader.slice(-4)}`;
     const allHeaderNames = Array.from(c.req.raw.headers.keys()).join(',');
-    console.warn(`[Hevy webhook] auth failed — bad bearer. authHeader length=${authHeader.length} preview=${headerPreview} | expected length=${expectedHeader.length} preview=${expectedPreview} | all headers=[${allHeaderNames}]`);
+    console.warn(`[Hevy webhook] auth failed — bad bearer. authHeader length=${authHeader.length} preview=${headerPreview} | expected length=${expectedHeader.length} | all headers=[${allHeaderNames}]`);
     return c.json({ error: 'forbidden' }, 401);
   }
 


### PR DESCRIPTION
## Context

Bear's Hevy webhook is firing 3+ times against /api/webhooks/hevy with bad-bearer 401. Token in `~/.oracle/.env` matches what was DM'd. Need to see what shape the inbound Authorization header has to triage:

- length mismatch (whitespace/newline/extra chars in pasted bearer)
- format mismatch (Hevy uses different scheme than `Bearer X`)
- missing header (Hevy stripping or sending under different header name)

## What

Single addition on the auth-fail path of `/api/webhooks/hevy`:

```ts
const headerPreview = authHeader.length > 8
  ? `${authHeader.slice(0, 4)}...${authHeader.slice(-4)}`
  : authHeader || '(empty)';
const expectedPreview = `${expectedHeader.slice(0, 4)}...${expectedHeader.slice(-4)}`;
const allHeaderNames = Array.from(c.req.raw.headers.keys()).join(',');
console.warn(`[Hevy webhook] auth failed — bad bearer. authHeader length=${authHeader.length} preview=${headerPreview} | expected length=${expectedHeader.length} preview=${expectedPreview} | all headers=[${allHeaderNames}]`);
```

**Preview-only**: first/last 4 chars + length only — does NOT log the full secret on either side.

## Tier

**Tier 2** — touches `/api/webhooks/hevy` auth path. Bertus + Gnarl natural-pair (Talon-retired post-Decree #71 second amendment). Logging-only on the failure-path; no behavior-change to the auth gate.

## Test plan

- [ ] Reviewer verifies preview shape doesn't leak full secret
- [ ] Bear triggers Hevy webhook from Hevy app
- [ ] Server log shows length + previews + header names → root-cause identified
- [ ] Follow-up revert PR once root-cause folded into proper fix

## Sequencing

Bear-direct urgent diagnostic. PR-shape preserved per WORKFLOW.md v0.2 (no direct-to-main even for hot-debug). Will revert via separate PR post-fix.

— Karo 🦴 (codebase-owner pen, debug-only)