### PR TITLE
fix: exempt Hevy webhook from global auth + revert PR #25 diagnostic

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -423,6 +423,9 @@ app.use('/api/*', async (c, next) => {
     '/api/auth/status',
     '/api/auth/login',
     '/api/health',
+    // Webhook endpoints — third-party callers cannot present Beast bearer tokens.
+    // Each handler validates its own provider-shared-secret via constant-time compare.
+    '/api/webhooks/hevy',
   ];
   if (publicPaths.some(p => path === p)) {
     return next();
@@ -11244,14 +11247,7 @@ app.post('/api/webhooks/hevy', async (c) => {
   const expectedBuf = Buffer.from(expectedHeader);
   const valid = authBuf.length === expectedBuf.length && timingSafeEqual(authBuf, expectedBuf);
   if (!valid) {
-    // DEBUG (TEMP — revert post-diagnosis): log received-header shape WITHOUT leaking expected.
-    // Per Bertus #10507 debug-asymmetry — log what you got, not what you expected. Logs length +
-    // first/last 4 chars to triage paste-mismatch vs format-mismatch vs missing-header.
-    const headerPreview = authHeader.length > 8
-      ? `${authHeader.slice(0, 4)}...${authHeader.slice(-4)}`
-      : authHeader || '(empty)';
-    const allHeaderNames = Array.from(c.req.raw.headers.keys()).join(',');
-    console.warn(`[Hevy webhook] auth failed — bad bearer. authHeader length=${authHeader.length} preview=${headerPreview} | expected length=${expectedHeader.length} | all headers=[${allHeaderNames}]`);
+    console.warn('[Hevy webhook] auth failed — bad bearer');
     return c.json({ error: 'forbidden' }, 401);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -423,8 +423,12 @@ app.use('/api/*', async (c, next) => {
     '/api/auth/status',
     '/api/auth/login',
     '/api/health',
-    // Webhook endpoints — third-party callers cannot present Beast bearer tokens.
-    // Each handler validates its own provider-shared-secret via constant-time compare.
+    // Webhook endpoints — third-party callers cannot present Beast bearer tokens
+    // (Beast tokens are `den_`-prefixed; provider-issued shared-secrets are not).
+    // Each handler validates its own provider-shared-secret via crypto.timingSafeEqual
+    // constant-time compare against an env-var token. Middleware bypass is correct
+    // shape here — auth still happens, just at the handler layer where the
+    // shared-secret lives. Path-level allowlist (not pattern) keeps the surface narrow.
     '/api/webhooks/hevy',
   ];
   if (publicPaths.some(p => path === p)) {


### PR DESCRIPTION
## Root cause (today's Hevy webhook auth-fail saga)

Global `/api/*` auth middleware (`src/server.ts:433`) only treats Authorization headers prefixed with `Bearer den_*` as bearer-token attempts (Beast tokens are `den_`-prefixed by design — T#546). Hevy sends `Authorization: Bearer <HEVY_WEBHOOK_TOKEN>` where the token is hex (not `den_`-prefixed), so the header is silently ignored by the middleware. Request then hits the final fallthrough at `src/server.ts:463` and returns `401 {"error":"Unauthorized","requiresAuth":true}` BEFORE the webhook handler runs.

This is why PR #25's diagnostic logging captured zero Hevy entries despite Hevy actively retrying — the request never reached the handler's own auth block at `src/server.ts:11246`.

### Verified externally

```bash
curl -X POST https://denbook.online/api/webhooks/hevy \
  -H "Authorization: Bearer test123" \
  -H "Content-Type: application/json" \
  -d '{"workoutId":"00000000-0000-0000-0000-000000000000"}'
# → 401 {"error":"Unauthorized","requiresAuth":true}
```

The `{"error":"Unauthorized"}` body shape matches the global middleware response, not the webhook handler's `{"error":"forbidden"}` (which would be the response if the handler ran).

## Fix

1. **Add `/api/webhooks/hevy` to publicPaths** exempt list. Handler does its own `crypto.timingSafeEqual` constant-time compare against `HEVY_WEBHOOK_TOKEN` (`src/server.ts:11245`), so middleware-bypass is the correct shape — auth still happens, just at the handler layer where the shared-secret lives.
2. **Revert PR #25 diagnostic block** back to the original simple warn. The diagnostic was deployed to capture auth-header shape from inside the handler, but since the request never reached the handler the diagnostic never produced data. With the publicPaths fix the handler runs and the simple warn is sufficient. Per Bertus #10507 debug-asymmetry reminder.

## Out of scope (filed as follow-up)

Same gap likely exists for `/api/webhooks/withings` — Withings webhook has no `Authorization` header at all (form-encoded, validates by `userid` match against stored token). Webhook would also be 401-blocked by global middleware before reaching handler. Not bundled here to keep this PR minimal — Hevy is the live blocker; Withings has the auto-sync cron as a workaround.

## Test plan

- [ ] Pre-merge: external curl with **bad bearer** → 401 with body \`{"error":"forbidden"}\` (handler-level, NOT middleware) and \`[Hevy webhook] auth failed — bad bearer\` in server log
- [ ] Pre-merge: external curl with **correct bearer** + valid UUID workoutId → 200 OK + log entry \`[Hevy webhook] received workoutId=...\`
- [ ] Post-merge: Bear triggers from Hevy app → server log + Forge entry present + dedupe holds on re-fire

## Tier classification

**Tier 3** — auth-middleware touch (\`publicPaths\` array directly affects which endpoints bypass authentication). Per Decree #71, requires Bertus security CLEAR + Pip QA CLEAR + Bear T3 stamp via Sable Prowl.

## Reviewer asks

- **Bertus** (security): verify the publicPaths-bypass is sound shape vs alternatives (e.g., signature-header pattern, IP allowlist, separate webhook-only middleware). Confirm handler-layer \`timingSafeEqual\` is sufficient given middleware bypass. Flag if the comment line ("third-party callers cannot present Beast bearer tokens") undersells anything.
- **Pip** (QA): verify the diagnostic revert keeps the \`console.warn\` line for log signal on auth-fail. Confirm test plan covers handler-vs-middleware response-shape distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)