### PR TITLE
debug(TEMP): re-arm Hevy webhook auth-fail diagnostic for round 2

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11251,7 +11251,19 @@ app.post('/api/webhooks/hevy', async (c) => {
   const expectedBuf = Buffer.from(expectedHeader);
   const valid = authBuf.length === expectedBuf.length && timingSafeEqual(authBuf, expectedBuf);
   if (!valid) {
-    console.warn('[Hevy webhook] auth failed — bad bearer');
+    // DEBUG (TEMP — revert post-diagnosis): re-armed for round 2 of Hevy webhook
+    // auth-fail diagnosis. PR #26 fixed middleware-blocks-before-handler so requests
+    // now reach this block and the diagnostic will actually fire (PR #25's diagnostic
+    // never produced data because the request never got here). Per Bertus #10507
+    // debug-asymmetry: log what you got, not what you expected — only authHeader-side
+    // preview, no expected-side leak. authHeader length + first 4 + last 4 chars +
+    // all-header-names enumerated to triage paste-mismatch vs invisible-char vs
+    // format-mismatch vs missing-header.
+    const headerPreview = authHeader.length > 8
+      ? `${authHeader.slice(0, 4)}...${authHeader.slice(-4)}`
+      : authHeader || '(empty)';
+    const allHeaderNames = Array.from(c.req.raw.headers.keys()).join(',');
+    console.warn(`[Hevy webhook] auth failed — bad bearer. authHeader length=${authHeader.length} preview=${headerPreview} | all headers=[${allHeaderNames}]`);
     return c.json({ error: 'forbidden' }, 401);
   }
 


### PR DESCRIPTION
## Context

PR #26 (Hevy webhook publicPaths fix) merged + deployed at 00:16 BKK. Bear retried Hevy webhook → 8 `[Hevy webhook] auth failed — bad bearer` entries in server log. Bug class verified gone (handler IS now reached — pre-fix would have shown 0 entries since middleware blocked first), but the actual `crypto.timingSafeEqual` compare against `HEVY_WEBHOOK_TOKEN` is failing.

## Pre-diagnosis state

- **Server env-var token**: 64-char hex, first4=`bdfe`, last4=`ad20`, no whitespace, valid hex (verified via `/home/gorn/.oracle/.env` read)
- **DM #9457 token**: same 64-char hex (matches env-var)
- **Bear's Hevy-pasted version**: bear DM-confirmed via redacted-middle compare — pasted token matches expected exactly when his `xxxx` redaction = `4549`

So one of:
1. Invisible char in the paste (newline, tab, leading/trailing space, NBSP, etc.)
2. Hevy stripping/transforming on save
3. Different auth scheme than `Bearer <token>` (Hevy might prefix/wrap)
4. Missing header (Hevy uses different header name)

## Fix shape

Re-arm the PR #25 diagnostic block at the auth-fail path. Same post-fold shape as PR #25 final state per @bertus #10507 debug-asymmetry doctrine — no `expectedPreview` leak, only authHeader-side:

- `authHeader.length` (catches length-mismatch class — invisible char would tick this)
- first 4 + last 4 chars of authHeader (catches paste-typo / scheme-prefix)
- `Array.from(c.req.raw.headers.keys())` enumerated (catches Hevy-uses-different-header-name)

This time it WILL produce data — PR #26 unblocked the path to the handler. PR #25's diagnostic never fired because the middleware 401-blocked first; that silence-is-the-data-point pointed at the middleware bug. Round 2 diagnoses the bearer-compare gap.

## Tier classification

**Tier 2** — logging-only on fail-path. Auth-gate logic UNCHANGED. Same shape as PR #25 (Bertus security CLEAR + Gnarl architect FULL CLEAR).

## Reviewer asks

- **Bertus** (security): same security carve-out as PR #25 review. 32-bit leak from 256-bit secret (handler-side, not env-side) is bounded; bear's pasted version is the diagnostic target, not our env-var. Confirm parity with PR #25 fold-state — no expectedPreview, fail-path only, behavior unchanged.
- **Gnarl** (architect): same shape as PR #25 architect-pen review. Confirm temp-revert tracking (will file via separate PR after root-cause + Hevy-side fix).

## Revert tracking

After bear's Hevy retry produces diagnostic data → root-cause → Hevy-side fix verified → separate PR reverts this block back to single-line `console.warn`. Same revert pattern as PR #26 ran for PR #25.

## Test plan

- Pre-merge: external curl with bad bearer → 401 + diagnostic line in log with length + preview + header-names
- Post-merge: bear triggers from Hevy app → log captures exact incoming auth-header shape → root-cause from the data

🤖 Generated with [Claude Code](https://claude.com/claude-code)