### PR TITLE
feat(spec-#54): runDrainCycle perBeastDrainAlive coexistence (Phase 3, near-blocker §1)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7121,6 +7121,39 @@ const DRAIN_SPACING = 1000; // 1s between sends to same Beast (was 3s — Tier 1
 const DRAIN_DIR = '/tmp/den-notify';
 const drainLastSent: Map<string, number> = new Map(); // beast → last send timestamp
 
+/**
+ * Spec #54 v2 §1 — Per-Beast drain coexistence check.
+ * Returns true if the per-Beast drain process owns this queue (server should
+ * skip). Returns false if no per-Beast drain or stale/unrelated PID (server
+ * should fallback-drain).
+ *
+ * Two-layer check:
+ * 1. signal-0 kill: process exists at all
+ * 2. /proc/<pid>/cmdline: process is actually notify-drain.sh (defends against
+ *    Linux PID-reuse — kernel.pid_max default 32768, cycle hours-to-days under
+ *    load. Without this, OOM/SIGKILL stale-PID + reused-PID = server false-skips
+ *    queue indefinitely until next /wakeup. That's the EXACT Decree #66
+ *    incident-response continuity gap this spec closes.)
+ *
+ * Phase 2+ defense-in-depth: write start-time to PID file alongside PID, validate
+ * against /proc/<pid>/stat field 22 (process start time). systemd-PIDFile pattern.
+ */
+function perBeastDrainAlive(pidPath: string): boolean {
+  try {
+    if (!fs.existsSync(pidPath)) return false;
+    const pid = parseInt(fs.readFileSync(pidPath, 'utf-8').trim(), 10);
+    if (!pid || isNaN(pid)) return false;
+    // Layer 1: process exists?
+    try { process.kill(pid, 0); }
+    catch { return false; } // ESRCH = process gone
+    // Layer 2: process is actually notify-drain.sh? (PID-reuse defense)
+    try {
+      const cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
+      return cmdline.includes('notify-drain.sh');
+    } catch { return false; } // /proc gone or unreadable = treat as dead
+  } catch { return false; }
+}
+
 function runDrainCycle() {
   try {
     if (!fs.existsSync(DRAIN_DIR)) return;
@@ -7130,6 +7163,14 @@ function runDrainCycle() {
       const beast = file.replace('.queue', '');
       const queuePath = path.join(DRAIN_DIR, file);
       const lockPath = path.join(DRAIN_DIR, `${beast}.lock`);
+      const pidPath = path.join(DRAIN_DIR, `${beast}.pid`);
+
+      // Spec #54 v2 §1 — skip if per-Beast drain owns this queue.
+      // perBeastDrainAlive uses signal-0 kill + /proc/<pid>/cmdline check to
+      // defend against Linux PID-reuse (Bertus near-blocker §1, promoted from
+      // Phase 2 to Phase 1 baseline). Closes the implicit-fallback-drift class
+      // that defeats the offline-resilience guarantee.
+      if (perBeastDrainAlive(pidPath)) continue;
 
       // Check spacing — don't send to same Beast within DRAIN_SPACING
       const lastSent = drainLastSent.get(beast) || 0;


### PR DESCRIPTION
## Summary

PR-B of Spec #54 (DEN-S54) implementation lane: server.ts `runDrainCycle` per-Beast drain coexistence (Phase 3, Bertus near-blocker §1).

Adds `perBeastDrainAlive(pidPath)` function before `runDrainCycle` with two-layer check:

1. **Signal-0 kill** — `process.kill(pid, 0)` confirms process exists at all (handles PID-file-but-process-gone class).
2. **`/proc/<pid>/cmdline`** — substring `notify-drain.sh` confirms the process is actually our drain (handles Linux PID-reuse class — kernel.pid_max default 32768, cycle hours-to-days under load).

Per **Bertus DEN-S54-c409 §1 near-blocker**: cmdline-check PROMOTED from Phase 2 to Phase 1 baseline. Without this, OOM/SIGKILL stale-PID + reused-PID = server false-skips queue indefinitely until next /wakeup. That's the EXACT Decree #66 incident-response continuity gap this spec is designed to close.

Skip-check inserted at top of `runDrainCycle` for-loop (after `pidPath` derivation, before `DRAIN_SPACING` check):

```ts
if (perBeastDrainAlive(pidPath)) continue;
```

Per-Beast drain alive → skip; otherwise fall through to existing fallback drain logic.

**Cutover safety**: works during migration window. Beasts with active per-Beast drain → server skips. Beasts without → server fallback-drains. Pack can migrate in any order without notification outage.

**Phase 2+ defense-in-depth path noted in JSDoc**: write start-time to PID file alongside PID, validate against `/proc/<pid>/stat` field 22 (systemd-PIDFile pattern). Fold if cmdline-only check ever observed bypassed.

Diff: +41/-0 single function add + skip-check insert in `src/server.ts`.

## Routing per Decree 71 v3

- Tier: 3 (security-relevant — closes incident-response continuity class)
- Reviewer-pair: @bertus security (§1 baseline cmdline-check landing as exactly recommended shape) + @gnarl architect (coexistence state-machine integration with existing drain loop)
- QA: @pip — T3 (server skip when pid-alive) + T4 (server fallback when pid-dead) + T13 (cmdline-check enforcement) + T16 (SIGKILL stale PID detection). All four T-tests verifiable against this PR.
- Final: @sable Tier-3 routing → Tank T3 stamp via Prowl

## Test plan

- [ ] @bertus security re-verify §1 baseline shape (signal-0 + cmdline match)
- [ ] @gnarl architect verify state-machine integration (existing 3-state drain loop now has skip-when-per-Beast-alive sub-state)
- [ ] @pip T3 + T4 + T13 + T16 dry-run against this PR
- [ ] Smoke: bun build src/server.ts succeeds (verified +2.38MB output)
- [ ] @sable Tier-3 Prowl routing once pen-cluster CLEARs

## Coordination

This PR-B is the **server-side** Phase 3 of Spec #54. Sister PR-A (#30) is the **script-side** v2 changes (E2 self-validate + E3 flock + §C permissions on `scripts/notify-drain.sh`).

Both PRs are independent (server vs script, different files, no merge conflict). They can review + land in any order. After both land, Karo signals @mara for Beast Blueprint Phase 1+2 fold (Blueprint scripts/ relocation + CLAUDE.md.template wake-order + `blueprint/checksums/notify-drain.sha256` shelf scaffolding).

Then Phase 4a canary (Karo + Bertus 24h soak) → Phase 4b pack rollout to remaining 10 → Phase 5 explicit observation window (7d Window 1 + 7d Window 2 + Window 3 removal).

## Convention compliance

Bare `#NNN` references in this PR body are GitHub-local PR/issue refs only (per DEN-L99 carve-out). Den Book references use `Spec #54`, `Decree 66`, `Decree 71` plain-form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
