### PR TITLE
chore(phase-3): server-side oracle-v2 → denbook string-literal sweep

### DIFF
--- a/src/chroma-mcp.ts
+++ b/src/chroma-mcp.ts
@@ -85,7 +85,7 @@ export class ChromaMcpClient {
       });
 
       this.client = new Client({
-        name: 'oracle-v2-chroma',
+        name: 'denbook-chroma',
         version: '1.0.0'
       }, {
         capabilities: {}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,7 +22,7 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
   supersededReason: text('superseded_reason'), // Why (optional)
   // Provenance tracking (Issue #22)
   origin: text('origin'),                   // 'mother' | 'arthur' | 'volt' | 'human' | null (legacy)
-  project: text('project'),                 // ghq-style: 'github.com/laris-co/oracle-v2'
+  project: text('project'),                 // ghq-style: 'github.com/alliedgorn/denbook'
   createdBy: text('created_by'),            // 'indexer' | 'oracle_learn' | 'manual'
 }, (table) => [
   index('idx_source').on(table.sourceFile),

--- a/src/integration/database.test.ts
+++ b/src/integration/database.test.ts
@@ -1,6 +1,6 @@
 /**
  * Database Integration Tests
- * Tests oracle-v2 database operations with Drizzle ORM
+ * Tests denbook database operations with Drizzle ORM
  * Uses isolated test database with proper migrations
  */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";

--- a/src/integration/http.test.ts
+++ b/src/integration/http.test.ts
@@ -1,6 +1,6 @@
 /**
  * HTTP API Integration Tests
- * Tests oracle-v2 server endpoints
+ * Tests denbook server endpoints
  */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import type { Subprocess } from "bun";

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -1,6 +1,6 @@
 /**
  * MCP (Model Context Protocol) Integration Tests
- * Tests oracle-v2 MCP tools via stdio transport
+ * Tests denbook MCP tools via stdio transport
  *
  * Requires MCP server to be startable. If the server can't connect,
  * tests fail with a clear message rather than silently skipping.

--- a/src/integration/specs.test.ts
+++ b/src/integration/specs.test.ts
@@ -57,18 +57,18 @@ describe("Specs API Integration", () => {
     });
 
     test("GET /api/specs with repo filter", async () => {
-      const res = await fetch(`${BASE_URL}/api/specs?repo=oracle-v2`);
+      const res = await fetch(`${BASE_URL}/api/specs?repo=denbook`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.specs).toBeInstanceOf(Array);
       for (const spec of data.specs) {
-        expect(spec.repo).toBe("oracle-v2");
+        expect(spec.repo).toBe("denbook");
       }
     });
 
     test("GET /api/specs with both filters", async () => {
       const res = await fetch(
-        `${BASE_URL}/api/specs?status=pending&repo=oracle-v2`
+        `${BASE_URL}/api/specs?status=pending&repo=denbook`
       );
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -132,7 +132,7 @@ describe("Specs API Integration", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          repo: "oracle-v2",
+          repo: "denbook",
           file_path: `docs/specs/${TEST_PREFIX}${TEST_RUN_ID}.md`,
           task_id: "T999",
           title: `${TEST_PREFIX}Test Spec`,
@@ -152,7 +152,7 @@ describe("Specs API Integration", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          repo: "oracle-v2",
+          repo: "denbook",
           // missing file_path, title, author
         }),
       });
@@ -179,7 +179,7 @@ describe("Specs API Integration", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          repo: "oracle-v2",
+          repo: "denbook",
           file_path: `docs/specs/${TEST_PREFIX}${TEST_RUN_ID}.md`,
           title: `${TEST_PREFIX}Duplicate`,
           author: "pip",
@@ -193,7 +193,7 @@ describe("Specs API Integration", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          repo: "oracle-v2",
+          repo: "denbook",
           file_path: `docs/specs/${TEST_PREFIX}mismatch_${TEST_RUN_ID}.md`,
           title: "Mismatch Test",
           author: "pip",

--- a/src/integration/specs.test.ts
+++ b/src/integration/specs.test.ts
@@ -74,6 +74,25 @@ describe("Specs API Integration", () => {
       const data = await res.json();
       expect(data.specs).toBeInstanceOf(Array);
     });
+
+    // Spec #54 v2 (Pip DEN-FM10717 dual-allowlist coverage-gap fold):
+    // ALLOWED_SPEC_REPOS = ['denbook', 'oracle-v2', ...] keeps oracle-v2 valid for
+    // transitional compat with existing DB rows (Spec #51, #52, #54 etc.) until
+    // DB migration `UPDATE specs SET repo='denbook' WHERE repo='oracle-v2'` runs.
+    // Test verifies the legacy path still serves so dual-allowlist regressions
+    // don't land silently. Per *enumerate-the-class* doctrine (DEN-L99) — the
+    // class is `repo-allowlist serves all valid values`, not just the new value.
+    // Post-DB-migration, oracle-v2 disappears from allowlist + this test
+    // becomes obsolete (deleted in cleanup PR same cycle).
+    test("GET /api/specs with repo=oracle-v2 (transitional dual-allowlist)", async () => {
+      const res = await fetch(`${BASE_URL}/api/specs?repo=oracle-v2`);
+      expect(res.ok).toBe(true);
+      const data = await res.json();
+      expect(data.specs).toBeInstanceOf(Array);
+      // No length assertion — DB may or may not have oracle-v2 rows depending
+      // on migration timing. Empty-array still proves the allowlist accepted
+      // the request (would 400 reject if oracle-v2 was removed prematurely).
+    });
   });
 
   // =====================

--- a/src/reachability.test.ts
+++ b/src/reachability.test.ts
@@ -1,10 +1,10 @@
 /**
  * T#664 Part 2 — Reachability regression test (CI gate)
  *
- * DRAFT — target location in oracle-v2: `src/reachability.test.ts`
+ * DRAFT — target location in denbook: `src/reachability.test.ts`
  *
  * Asserts that the vulnerable API surface identified in the T#663 reachability
- * sweep (thread #20, msg #8113 / #8115 / #8116) stays unused in oracle-v2.
+ * sweep (thread #20, msg #8113 / #8115 / #8116) stays unused in denbook.
  * If any of these patterns appears in `src/` (via a future PR adding dynamic
  * queries, HTTP transport, or auth handlers), this test fails and the
  * reachability claim from the T#663 downgrade must be re-evaluated before
@@ -30,7 +30,7 @@
  * express-rate-limit, and path-to-regexp are dead code because their
  * importers (`server/streamableHttp.js`, `server/webStandardStreamableHttp.js`,
  * `server/sse.js`, `server/express.js`, `server/auth/router.js`) are never
- * loaded by oracle-v2's static import chain (verified in thread #20 msg #8116
+ * loaded by denbook's static import chain (verified in thread #20 msg #8116
  * and Bertus's msg #8122 review extension). This gate locks that in.
  *
  * Doctrine: **stdio-only MCP transport**. All HTTP-ish transports in the SDK
@@ -74,14 +74,14 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Target root is `src/` relative to the oracle-v2 repo root when this lives at
+// Target root is `src/` relative to the denbook repo root when this lives at
 // `src/reachability.test.ts`. Adjust if the file moves.
 //
 // Use fileURLToPath rather than new URL('.', import.meta.url).pathname — the
 // raw .pathname URL-encodes non-ASCII characters in the path (e.g. `ψ` becomes
 // `%CF%88`), which fs can't resolve. fileURLToPath decodes them correctly.
 // Caught when smoke-testing the test from pip's lab directory (which has `ψ`
-// in its path) before handoff to oracle-v2. Oracle-v2's path is plain ASCII
+// in its path) before handoff to denbook. Denbook's path is plain ASCII
 // so the raw .pathname would work there, but the correct form handles both.
 const SRC_ROOT = dirname(fileURLToPath(import.meta.url));
 

--- a/src/server-legacy.ts
+++ b/src/server-legacy.ts
@@ -298,7 +298,7 @@ const server = http.createServer(async (req, res) => {
         return;
 
       case '/api/health':
-        result = { status: 'ok', server: 'oracle-v2', port: PORT, oracleV2: 'connected' };
+        result = { status: 'ok', server: 'denbook', port: PORT, denbook: 'connected' };
         break;
 
       case '/api/search':

--- a/src/server.ts
+++ b/src/server.ts
@@ -7928,7 +7928,7 @@ try {
   }
 } catch { /* migration already done or no data */ }
 
-const ALLOWED_SPEC_REPOS = ['oracle-v2', 'supply-chain-tool', 'karo', 'zaghnal', 'gnarl', 'bertus', 'flint', 'pip', 'dex', 'talon', 'quill', 'sable', 'nyx', 'vigil', 'rax', 'leonard', 'mara', 'snap', 'beast-blueprint'];
+const ALLOWED_SPEC_REPOS = ['denbook', 'oracle-v2', 'supply-chain-tool', 'karo', 'zaghnal', 'gnarl', 'bertus', 'flint', 'pip', 'dex', 'talon', 'quill', 'sable', 'nyx', 'vigil', 'rax', 'leonard', 'mara', 'snap', 'beast-blueprint'];
 
 function resolveSpecPath(repo: string, filePath: string): string | null {
   if (!ALLOWED_SPEC_REPOS.includes(repo)) return null;


### PR DESCRIPTION
## Summary

Phase 3 doc/code sweep per DEN-FT549 plan post-Phase-2 local-dir rename. Consolidated 9 file changes into single PR-E.

## LOAD-BEARING fixes

- `src/server.ts:7931` ALLOWED_SPEC_REPOS — added `'denbook'` to allowed list (kept `'oracle-v2'` for transition compat until DB migration completes; cleanup PR will remove `'oracle-v2'` post-migration verify)
- `src/server-legacy.ts:301` — health-check JSON label oracle-v2 → denbook
- `src/integration/specs.test.ts` (4 refs) — `repo='oracle-v2'` → `'denbook'` in test fixtures + `?repo=` query strings
- `src/chroma-mcp.ts:88` — Chroma MCP service name `'oracle-v2-chroma'` → `'denbook-chroma'`

## DOC-ONLY fixes

- `src/db/schema.ts:25` — ghq-style example comment
- `src/integration/{database,mcp,http}.test.ts` — file header comments
- `src/reachability.test.ts` — 5 inline comment refs

## Out of scope (intentional upstream-historical refs preserved)

- `src/scripts/fix-oracle-learn-project.ts` — `Soul-Brews-Studio/oracle-v2` (upstream parent fork)
- `src/tools/__tests__/learn.test.ts` — normalization test for upstream URL shape
- `src/server/context.ts:10-13` — `laris-co/oracle-v2` example comments (upstream historical)
- `src/vector/__tests__/benchmark.ts:45` — historical retro fixture text
- `src/vault/cli.ts:6` — `@laris-co/oracle-v2` npm package reference (upstream)

## DB migration deferred

`UPDATE specs SET repo='denbook' WHERE repo='oracle-v2'` deferred to separate operation since the SQL hits production data — needs Bear-stamp + verify cycle. ALLOWED_SPEC_REPOS keeps `'oracle-v2'` in transition allowlist so existing spec records (DEN-S52, DEN-S54, etc.) don't break on resubmit during the transition window.

## Routing per Decree 71 v3

- Tier: 2 (string-literal sweep, no auth/security shape changes)
- Reviewer-pair: @bertus security (confirm no secrets/auth changes) + @gnarl architect (confirm two-allowed-repos transitional shape is acceptable)
- QA: @pip — integration/specs.test.ts test-update doesn't break coverage; tests should pass against new ALLOWED_SPEC_REPOS shape

## Test plan

- [ ] @bertus security verify no secret/auth shape changes in the 9 files
- [ ] @gnarl architect confirm transitional dual-allowlist (denbook + oracle-v2) approach
- [ ] @pip QA verify integration/specs.test.ts tests still pass against new shape
- [ ] @sable Tier-2 routing per Decree #71 (or self-merge if Tier 2 + 3-pen CLEAR)

## Convention compliance

Bare `#NNN` references in this PR body are GitHub-local issue/PR refs only (per DEN-L99 carve-out). Den Book references use `Spec #54`, `Decree 71`, `DEN-FT549`, `DEN-L99` plain-form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
