### PR TITLE
fix(test-baseline): bunfig.toml preload forces test DB to :memory:, refuses prod path

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,3 +2,7 @@
 # Only run unit and integration tests with bun test
 # E2E tests use Playwright (run with: bun run test:e2e)
 root = "src"
+# Force ORACLE_DB_PATH=:memory: + ORACLE_DATA_DIR=/tmp before any test module
+# imports — code-level baseline so production DB cannot be wiped by test runs
+# regardless of shell env or which command is used. See scripts/test-preload.ts.
+preload = ["./scripts/test-preload.ts"]

--- a/scripts/test-preload.ts
+++ b/scripts/test-preload.ts
@@ -1,0 +1,45 @@
+/**
+ * Bun test preload — runs before any test module imports.
+ *
+ * Forces ORACLE_DB_PATH and ORACLE_DATA_DIR to safe in-memory / /tmp values
+ * so `bun test <anything>` (script-wrapped OR direct path invocation) cannot
+ * touch the production SQLite at ~/.oracle/oracle.db.
+ *
+ * Wired via bunfig.toml `[test] preload`. Runs once per `bun test` invocation,
+ * before src/db/index.ts is imported anywhere. Per-Bun-process scope: every
+ * test file in the run sees the same in-memory DB.
+ *
+ * Background: 2026-04-28 incidents (Karo wiped beast_tokens twice via
+ * `bun test src/server/__tests__/beast-tokens.test.ts`). Bear directive:
+ * make the test DB a code-level baseline, not a script-level convention.
+ *
+ * Override path: if a developer explicitly wants to test against a real DB
+ * file (e.g. for migration testing), set ORACLE_DB_PATH BEFORE invoking
+ * `bun test` — the preload only sets defaults if unset, never overrides.
+ */
+
+if (!process.env.ORACLE_DB_PATH) {
+  process.env.ORACLE_DB_PATH = ':memory:';
+}
+if (!process.env.ORACLE_DATA_DIR) {
+  process.env.ORACLE_DATA_DIR = '/tmp/oracle-test-data';
+}
+
+// Defensive guard: refuse to proceed if ORACLE_DB_PATH points at a real
+// production-shaped path. Catches the case where a developer exports
+// ORACLE_DB_PATH=~/.oracle/oracle.db in their shell and forgets to unset.
+const dbPath = process.env.ORACLE_DB_PATH;
+if (
+  dbPath !== ':memory:' &&
+  !dbPath.startsWith('/tmp/') &&
+  !dbPath.startsWith('/var/folders/') && // macOS temp
+  !dbPath.includes('/test')
+) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `[test-preload] REFUSING to run tests against non-test DB path: ${dbPath}\n` +
+    `  Set ORACLE_DB_PATH=:memory: (default) OR a /tmp/* path to proceed.\n` +
+    `  See WORKFLOW.md §"Test discipline".`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Bear directive 2026-04-28 ~16:04 BKK after the **second** prod-wipe incident (Karo ran `bun test src/server/__tests__/beast-tokens.test.ts` from a branch that lacked PR #36's package.json env-var prefix): make the test DB a **code-level baseline**, not a script-convention.

## Approach

`bunfig.toml [test] preload = ["./scripts/test-preload.ts"]` runs the preload before any test module imports. The preload sets:

- `ORACLE_DB_PATH=:memory:` (default)
- `ORACLE_DATA_DIR=/tmp/oracle-test-data` (default)

…only if unset — explicit overrides still work for migration testing.

**Defensive guard**: if `ORACLE_DB_PATH` is explicitly set to a non-test-shaped path (not `:memory:`, not `/tmp/*`, not `/var/folders/*`, not containing `/test`), the preload exits 1 with a clear error pointing at `WORKFLOW.md §Test discipline`. Catches the "developer exported prod path in shell and forgot to unset" class.

## Verification

- ✅ `bun test src/server/__tests__/beast-tokens.test.ts` (ad-hoc, no script wrapper) now hits `:memory:` via preload — the EXACT command that wiped prod twice is now safe.
- ✅ Production `~/.oracle/oracle.db` `beast_tokens` count unchanged after running the previously-destructive command directly (14 rows preserved).
- ✅ Defensive guard tested: `ORACLE_DB_PATH=/home/gorn/.oracle/oracle.db bun test ...` refuses with explanatory error + exit 1.

## Relationship to PR #36

PR #36 (package.json env-var prefixes) becomes redundant defense-in-depth once this lands — bunfig preload runs regardless of which command is used. Both PRs work in parallel; PR #36 can be cleaned up later or kept as belt-and-suspenders. Either way the wipe-class is closed at the bunfig layer.

## Tier

Tier 2 — affects test infrastructure but no runtime behavior change. Code-level guard for a known-incident class.

## Test plan

- [x] All existing tests still pass with preload active
- [x] Ad-hoc `bun test path/to/file.ts` (no script wrapper) hits `:memory:`
- [x] Production DB row count unchanged after running previously-destructive ad-hoc command
- [x] Defensive guard refuses explicit prod-path override
- [ ] Manual: verify on a fresh worktree clone that preload triggers correctly

## Why this approach

The package.json env-var prefix (PR #36) requires every test script to opt-in. A new branch that doesn't pull PR #36 (or a forgotten new test script) bypasses the protection. The bunfig preload is **always** loaded — it's the floor, not the ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)