### PR TITLE
docs(workflow): add 'Submitting specs (SDD workflow)' section

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -157,6 +157,45 @@ For QA-handoff Tier 2 changes per Norm #68, the QA-lane Beast (typically Pip) cl
 
 ---
 
+## Submitting specs (SDD workflow)
+
+Specs are markdown files at `<project-repo>/docs/specs/<short-name>.md` indexed by the spec system at `/api/specs`. The spec record stores metadata (id, repo, file_path, title, status, reviewer history); the markdown content lives on disk in the project repo. **Both must exist for the spec to be reviewable.**
+
+**Order of operations (mandatory)** — author git-commits-then-API:
+
+```bash
+# 1. Author the markdown content in the target repo at the spec's file_path
+cd /home/gorn/workspace/<project-repo>            # e.g., denbook-<beast> or beast-blueprint
+$EDITOR docs/specs/<short-name>.md
+
+# 2. git add + commit + push (the file MUST exist on origin/main before the API call,
+#    so the server's /content endpoint can read it)
+git add docs/specs/<short-name>.md
+git commit -m "specs: <short-name> v1 (draft)"
+git push origin main                              # or via PR if the repo gates main
+
+# 3. POST /api/specs (initial submit) OR /api/specs/<id>/resubmit (update)
+curl -s -X POST "http://localhost:47778/api/specs" \
+  -H "Authorization: Bearer $BEAST_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"<title>","author":"<beast>","repo":"<project-repo>","file_path":"docs/specs/<short-name>.md"}'
+# capture the returned spec id
+
+# 4. VERIFY within 60 seconds: GET /api/specs/<id>/content returns 200 with content
+curl -s "http://localhost:47778/api/specs/<id>/content" -H "Authorization: Bearer $BEAST_TOKEN" | head -c 500
+# If 404 "Spec file not found on disk" → step 2 was missed (file not committed/pushed)
+# If empty content → step 1 was incomplete (file is empty)
+# If 200 with full markdown → spec is reviewable
+```
+
+**Failure-class banked (Spec #53, 2026-04-25 → caught 2026-04-28)**: spec metadata was POST'd before the markdown file was written + committed. Spec record had `content: null` for 3 days; `/content` returned 404; the spec was effectively unreviewable. Discipline rule: **never POST `/api/specs` until step 4 verification passes against the file_path on disk.** The orphan-state is silent — the API does not block the metadata-only POST.
+
+**Updates / resubmits**: same shape. Edit the markdown locally → commit + push → POST `/api/specs/<id>/resubmit` with `{ author, change_summary? }` (no content body needed; server reads from updated file). Verify within 60s.
+
+**Server-side architecture note**: the spec server reads from the `<project-repo>` you registered at submit-time. As of 2026-04-28, this requires the repo to be locally accessible to the server (denbook + beast-blueprint clones; specs in other repos may need server-side multi-repo read support — track separately).
+
+---
+
 ## Production deploy (codebase-owner lane)
 
 The production server does NOT auto-deploy on PR-merge. A merge to `main` is a green-light to deploy, but the deploy itself is a deliberate step. This is intentional — see [Restart-is-Deploy lesson](#restart-is-deploy) below.


### PR DESCRIPTION
## Summary

Adds a new "Submitting specs (SDD workflow)" section to `WORKFLOW.md` between §7 (Merge to main) and the Production deploy section.

After Spec #53 orphan-state caught at 19:16 BKK 04-28 — spec metadata was POST'd on 04-25 but the markdown content file was never written + committed. Spec record had `content: null` for 3 days; `/content` endpoint returned 404; spec was effectively unreviewable.

Bear directive 19:30 BKK: Pattern 1 (author-commits-then-API loose-coupling) + a written instruction to close the orphan-class via discipline rather than enforcement.

## What landed

Mandatory order of operations:

1. Author markdown in target repo at the spec's `file_path`
2. `git add + commit + push` (file MUST exist on `origin/main` before the API call)
3. POST `/api/specs` (initial) OR `/api/specs/<id>/resubmit` (update)
4. **Verify within 60 seconds**: GET `/api/specs/<id>/content` returns 200 with content. If 404 → step 2 was missed.

Failure-class banked explicitly with the Spec #53 incident citation. Discipline rule named:

> **never POST `/api/specs` until step 4 verification passes against the file_path on disk.** The orphan-state is silent — the API does not block the metadata-only POST.

Updates / resubmits follow the same shape.

Server-side architecture note flagged: spec server reads from registered project-repo locally as of 2026-04-28; multi-repo support tracked separately (deferred per Bear's lighter-engineering preference).

## Tier

Tier 1 — docs-only change to load-bearing project doc. No code, no schema, no runtime behavior changed.

## Test plan

- [x] WORKFLOW.md renders cleanly
- [x] Section anchor lands between §7 (Merge to main) and Production deploy
- [ ] Manual: a future Beast follows the protocol and the orphan-class doesn't repeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)