### PR TITLE
feat(tasks): add 'backlog' to valid task status enum

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -5916,7 +5916,7 @@ app.post('/api/tasks', async (c) => {
   if (!assigned_to) return c.json({ error: 'assigned_to required — every task must have an assignee' }, 400);
   if (!reviewer) return c.json({ error: 'reviewer required — every task must have a reviewer for the in_review workflow' }, 400);
 
-  const validStatuses = ['todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
+  const validStatuses = ['todo', 'backlog', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
   const validPriorities = ['critical', 'high', 'medium', 'low'];
   const taskStatus = validStatuses.includes(status) ? status : 'todo';
   const taskPriority = validPriorities.includes(priority) ? priority : 'medium';
@@ -5985,7 +5985,7 @@ app.patch('/api/tasks/:id', async (c) => {
 
   const data = await c.req.json();
 
-  const validStatuses = ['todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
+  const validStatuses = ['todo', 'backlog', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
   const validPriorities = ['critical', 'high', 'medium', 'low'];
   if (data.status && !validStatuses.includes(data.status)) return c.json({ error: `Invalid status. Valid: ${validStatuses.join(', ')}` }, 400);
   if (data.priority && !validPriorities.includes(data.priority)) return c.json({ error: `Invalid priority. Valid: ${validPriorities.join(', ')}` }, 400);
@@ -6053,7 +6053,7 @@ app.post('/api/tasks/bulk-status', async (c) => {
   const { task_ids, status } = data;
   if (!Array.isArray(task_ids) || !status) return c.json({ error: 'task_ids and status required' }, 400);
 
-  const validStatuses = ['todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
+  const validStatuses = ['todo', 'backlog', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
   if (!validStatuses.includes(status)) return c.json({ error: 'Invalid status' }, 400);
 
   // SDD enforcement for bulk status


### PR DESCRIPTION
## Summary

Adds `'backlog'` to the task status enum so the PM Board can separate **actively-queued work** (`todo`) from **parked-for-later work** (`backlog`).

## Bear directive

Discord 2026-04-29 15:14 BKK: *"Lets do it now. We need that so we can clean out all Todo tasks. any low priorities we can park in Backlog and review later."*

## Change

Add `'backlog'` to the three `validStatuses` arrays in `src/server.ts` (task creation + task update + task status endpoints — lines 5919, 5988, 6056). Updated via `replace_all` since all three have the same array literal.

## Why no DB migration needed

The `tasks.status` column is `TEXT NOT NULL DEFAULT 'todo'` with **no `CHECK` constraint** (verified via grep — only `risk_level` and `risks.status` have CHECK constraints). The status column accepts any TEXT value at the SQL layer; validation lives in the API layer, which is what we're updating.

## Subsequent work (NOT in this PR)

1. **Triage pass**: move low-priority tasks from `todo` → `backlog` (manual review with Bear, or scripted by priority field)
2. **Frontend**: separate column / view for backlog board state → Dex's lane

## Routing per Decree #71 v3

- **Tier**: 2 (API surface change, no auth/security shape change)
- **Reviewer-pair**: @bertus security + @pip QA
- **Tier-2 second-reviewer-merges** per convention banked from PR #42/#43

## Test plan

- [x] `bun run test:integration` — 36 pre-existing fails on main baseline, 36 on PR branch, no new regressions
- [ ] @bertus security verify: enum addition doesn't bypass any auth path, status-based filtering still works
- [ ] @pip QA verify: same fail count on PR branch (test by NAME not just count), no new test surfaces
- [ ] Post-merge functional smoke: `POST /api/tasks status:"backlog"` returns 200 (was 400); `PATCH /api/tasks/:id status:"backlog"` returns 200; `GET /api/tasks?status=backlog` returns filtered list

🤖 Generated with [Claude Code](https://claude.com/claude-code)