### PR TITLE
feat(frontend): add 'backlog' to Board STATUSES enum

### DIFF
--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -51,8 +51,9 @@ interface BoardData {
 
 const API_BASE = '/api';
 
-const STATUSES = ['todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'] as const;
+const STATUSES = ['backlog', 'todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'] as const;
 const STATUS_LABELS: Record<string, string> = {
+  backlog: 'Backlog',
   todo: 'To Do',
   in_progress: 'In Progress',
   in_review: 'In Review',


### PR DESCRIPTION
## Summary

Mirrors server-side PR #44 (`feat(tasks): add 'backlog' to valid task status enum`) on the frontend Board view.

## Change

Single file (`frontend/src/pages/Board.tsx`):
- Add `'backlog'` as first element of `STATUSES` tuple (line 54)
- Add `backlog: 'Backlog'` to `STATUS_LABELS` record (line 56)

Renders backlog as the leftmost kanban column (parked → ready-to-work flow: `backlog → todo → in_progress → in_review → done`).

The kanban column rendering at line 535 (`{STATUSES.map(status => ...)}`) auto-renders a Backlog column from the const update — no per-column code change needed. Status select dropdowns at lines 479 + 641 also auto-include the new value.

## Bear directive

Discord 2026-04-29 15:58 BKK — *"Ok can we fold in frontend as well?"* (after server-side PR #44 deploy + smoke confirmed).

## Decree #71 routing

Tier 1 (frontend-only enum addition, no behavior change beyond what the server already accepts post-PR #44). Self-merge after build verify per Tier 1 §discipline.

## Pip flagged this exact follow-up

In PR #44 review: *"frontend/src/pages/Board.tsx:54 STATUSES doesn't include backlog — Tier 1 Dex follow-up"*. Bear directed Karo to take it directly rather than queue Dex.

## Verification

- [x] `bun run build` succeeds (frontend `dist/` builds clean — 20.84s, no errors)
- [ ] Manual smoke post-merge: Board view renders 7 columns (was 6), Backlog leftmost; status select dropdowns include Backlog option; existing tasks unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)