### PR TITLE
fix(api/board): include 'backlog' key in columns object so backlog tasks render

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6155,7 +6155,7 @@ app.get('/api/board', (c) => {
   const tasks = sqlite.prepare(query).all(...params) as any[];
 
   const columns: Record<string, any[]> = {
-    todo: [], in_progress: [], in_review: [], done: [], blocked: [], cancelled: [],
+    backlog: [], todo: [], in_progress: [], in_review: [], done: [], blocked: [], cancelled: [],
   };
   for (const task of tasks) {
     if (columns[task.status]) columns[task.status].push(task);


### PR DESCRIPTION
## Summary

`/api/board` was silently dropping backlog-status tasks because the columns object initialization didn't include a `backlog` key.

## Bug

`/api/board` at `src/server.ts:6157` hardcodes:
```ts
const columns: Record<string, any[]> = {
  todo: [], in_progress: [], in_review: [], done: [], blocked: [], cancelled: [],
};
```

Then dispatches:
```ts
for (const task of tasks) {
  if (columns[task.status]) columns[task.status].push(task);  // ← drops 'backlog'
}
```

After PR #44 + #45 added `'backlog'` to validStatuses + frontend STATUSES, tasks with `status='backlog'` were correctly stored in the DB but never reached the rendered Board column.

## Fix

1-line change: add `backlog: []` to the columns init.

## Bear-caught

Discord 2026-04-29 16:14 BKK after I moved 16 todos to backlog and pointed him at the UI: *"i dont see them showing up on the backlog column"*.

## Class for forward-bank

**enum-additions-have-three-surfaces-not-two**: validation enum (PR #44 server) + render enum (PR #45 frontend) + grouping/dispatch tables (this PR). Worth a discipline note in the next PM API hardening cycle alongside the silent-coerce-vs-400-reject + missing-regression-test items already banked from PR #44 review.

## Routing per Decree #71 v3

- **Tier**: 1 (1-line bugfix, no auth/security/data shape change, GET endpoint dispatch table fix only)
- **Self-merge** after build verify per Tier 1 §discipline

## Verification

- [x] TypeScript compiles
- [ ] Post-merge: `GET /api/board` returns columns object with `backlog` key + the 16 already-moved tasks render in the frontend Backlog column

🤖 Generated with [Claude Code](https://claude.com/claude-code)