### PR TITLE
feat(openapi): Phase 1 foundation — T#731

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,8 @@
       "name": "oracle-v2-mcp",
       "dependencies": {
         "@hono/node-server": "^1.19.14",
+        "@hono/swagger-ui": "^0.6.1",
+        "@hono/zod-openapi": "^1.3.0",
         "@lancedb/lancedb": "^0.26.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@qdrant/js-client-rest": "^1.17.0",
@@ -15,6 +17,7 @@
         "meilisearch": "^0.56.0",
         "sharp": "^0.34.5",
         "sqlite-vec": "^0.1.9",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -33,6 +36,8 @@
     "undici": "^6.24.0",
   },
   "packages": {
+    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
+
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
@@ -94,6 +99,12 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@hono/swagger-ui": ["@hono/swagger-ui@0.6.1", "", { "peerDependencies": { "hono": ">=4.0.0" } }, "sha512-sJTvldu1GPeEPfyeLG7gRj+W4vEuD+JDi+JjJ3TJs/DvMUtBLs0KJO5yokGegWWdy5qrbdnQGekbhgNRmPmYKQ=="],
+
+    "@hono/zod-openapi": ["@hono/zod-openapi@1.3.0", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.7.6", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.3.6", "zod": "^4.0.0" } }, "sha512-loDVevfMaaNa0slskhpMcqjSdidVXba2QJwNVmnS5Dp6L8AqSgtjJxWGJfRZtosyzYOb5gx4ZzXNCe+QhwY7xw=="],
+
+    "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -385,6 +396,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "openapi3-ts": ["openapi3-ts@4.5.0", "", { "dependencies": { "yaml": "^2.8.0" } }, "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -507,9 +520,13 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@types/better-sqlite3/@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.14",
+    "@hono/swagger-ui": "^0.6.1",
+    "@hono/zod-openapi": "^1.3.0",
     "@lancedb/lancedb": "^0.26.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@qdrant/js-client-rest": "^1.17.0",
@@ -61,7 +63,8 @@
     "hono": "^4.12.15",
     "meilisearch": "^0.56.0",
     "sharp": "^0.34.5",
-    "sqlite-vec": "^0.1.9"
+    "sqlite-vec": "^0.1.9",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,10 @@
  * Same handlers, same DB, just cleaner HTTP layer.
  */
 
-import { Hono, type Context, type Next } from 'hono';
+import { type Context, type Next } from 'hono';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { swaggerUI } from '@hono/swagger-ui';
+import { healthRoute, authStatusRoute, authLoginRoute, authLogoutRoute, OPENAPI_INFO } from './server/openapi.ts';
 import { cors } from 'hono/cors';
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import { createHmac, timingSafeEqual } from 'crypto';
@@ -190,7 +193,8 @@ registerSignalHandlers(async () => {
 });
 
 // Create Hono app
-const app = new Hono();
+type AppEnv = { Variables: Record<string, any> };
+const app = new OpenAPIHono<AppEnv>();
 
 // Custom 404 with did-you-mean hints for API routes
 // Uses HELP_ENDPOINTS (defined below with /api/help) for path matching
@@ -1524,8 +1528,8 @@ app.get('/api/docs', (c) => {
   });
 });
 
-// Health check
-app.get('/api/health', (c) => {
+// Health check (OpenAPI — Spec #55 Phase 1 proof-of-pattern)
+app.openapi(healthRoute, (c) => {
   return c.json({ status: 'ok', server: 'oracle-nightly', port: PORT, oracleV2: 'connected' });
 });
 
@@ -12933,6 +12937,24 @@ app.get('/api/telegram/message/:id', (c) => {
 
 // Start polling on server boot
 startTelegramPolling();
+
+// ============================================================================
+// OpenAPI Schema + Swagger UI (Spec #55 Phase 1)
+// ============================================================================
+
+app.doc('/openapi.json', (c) => {
+  if (!isAuthenticated(c)) {
+    return c.json({ error: 'Authentication required' }, 401) as any;
+  }
+  return OPENAPI_INFO;
+});
+
+app.get('/docs', (c) => {
+  if (!isAuthenticated(c)) {
+    return c.json({ error: 'Authentication required' }, 401);
+  }
+  return swaggerUI({ url: '/openapi.json' })(c, async () => {});
+});
 
 // ============================================================================
 // Static Frontend (production build)

--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -1,0 +1,95 @@
+import { createRoute, z } from '@hono/zod-openapi';
+
+export const healthRoute = createRoute({
+  method: 'get',
+  path: '/api/health',
+  tags: ['system'],
+  summary: 'Server health check',
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.object({ status: z.string(), server: z.string(), port: z.number(), oracleV2: z.string() }) } },
+      description: 'Server is healthy',
+    },
+  },
+});
+
+export const authStatusRoute = createRoute({
+  method: 'get',
+  path: '/api/auth/status',
+  tags: ['auth'],
+  summary: 'Check if session is authenticated',
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            authenticated: z.boolean(),
+            authEnabled: z.boolean(),
+            hasPassword: z.boolean().optional(),
+            localBypass: z.boolean().optional(),
+            isLocal: z.boolean().optional(),
+            role: z.string().optional(),
+            guestName: z.string().optional(),
+            guestUsername: z.string().optional(),
+          }),
+        },
+      },
+      description: 'Auth status response',
+    },
+  },
+});
+
+export const authLoginRoute = createRoute({
+  method: 'post',
+  path: '/api/auth/login',
+  tags: ['auth'],
+  summary: 'Login with password',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            password: z.string(),
+            username: z.string().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.object({ success: z.boolean() }) } },
+      description: 'Login successful',
+    },
+    401: {
+      content: { 'application/json': { schema: z.object({ success: z.boolean(), error: z.string() }) } },
+      description: 'Invalid credentials',
+    },
+    429: {
+      content: { 'application/json': { schema: z.object({ success: z.boolean(), error: z.string() }) } },
+      description: 'Rate limited',
+    },
+  },
+});
+
+export const authLogoutRoute = createRoute({
+  method: 'post',
+  path: '/api/auth/logout',
+  tags: ['auth'],
+  summary: 'Logout current session',
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.object({ success: z.boolean() }) } },
+      description: 'Logout successful',
+    },
+  },
+});
+
+export const OPENAPI_INFO = {
+  openapi: '3.0.0' as const,
+  info: {
+    title: 'Den Book API',
+    version: '1.0.0',
+    description: 'Internal API for Den Book — Beast communication, forum, tasks, and village life.',
+  },
+};


### PR DESCRIPTION
## Summary
- Add `@hono/zod-openapi` + `@hono/swagger-ui` + `zod` dependencies
- Swap main app from `Hono` to `OpenAPIHono` (backwards compatible — all existing routes unchanged)
- Create `src/server/openapi.ts` with zod-based route definitions for `/api/health` + `/api/auth/*`
- Convert `/api/health` to `app.openapi()` as proof-of-pattern
- Add `/openapi.json` (auto-generated schema) and `/docs` (Swagger UI) — both behind `isAuthenticated()` per Bertus C1
- `bun audit` clean (0 vulns) per Bertus C3
- Type errors reduced from 36 (baseline main) to 28 (this branch)

Spec #55 Phase 1. Bertus CLEAR conditions C1 (auth gate) + C3 (dependency audit) verified.

// no skill change required because this adds new endpoints (/openapi.json, /docs) not used by any Beast skill yet

## Test plan
- [ ] `bunx tsc --noEmit` — type errors ≤ baseline
- [ ] `bun audit` — 0 vulns
- [ ] POST-deploy: `curl -s localhost:47778/openapi.json` returns 401 without auth
- [ ] POST-deploy: `curl -s -H "Authorization: Bearer <token>" localhost:47778/openapi.json` returns valid OpenAPI schema
- [ ] POST-deploy: `/docs` renders Swagger UI with health endpoint
- [ ] POST-deploy: `/api/health` still returns `{"status":"ok",...}`
- [ ] POST-deploy: `/api/help` still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)