### PR TITLE
spec(#54) Phase 2d: server adaptor invokes per-Beast notify.sh

### DIFF
--- a/src/notify.ts
+++ b/src/notify.ts
@@ -95,6 +95,10 @@ export function enqueueNotification(beast: string, message: string, opts?: Enque
     if (result.exitCode === 0) return true;
     // Quiet during migration window — exit 127 (file not found) is expected
     // for un-migrated Beasts. Only log non-127 unexpected failures.
+    // TODO(Phase 4b cleanup, Bertus DEN-PR55-bertus C-PR55-1): remove the
+    // `if (result.exitCode !== 127)` silence after all Beasts migrate to
+    // Blueprint v0.6.3+. Post-migration, exit 127 indicates a real failure
+    // (deleted script, broken symlink) and should always log.
     if (result.exitCode !== 127) {
       console.error(`[notify] Per-Beast notify failed for ${beastLower} (exit ${result.exitCode})`);
     }

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,22 +1,60 @@
 /**
- * Centralized tmux notification queue (Spec #29).
- * All notification senders use this instead of direct tmux send-keys.
- * Messages are queued to /tmp/den-notify/<beast>.queue and drained
- * by notify-drain.sh with 3s spacing to prevent prompt corruption.
+ * Centralized tmux notification adaptor (Spec #54 v4 — was Spec #29).
  *
- * Every queued message is prefixed with `[YYYY-MM-DD HH:MM:SS UTC+7]` so
- * Beasts can tell at a glance when a notification was sent, even across
- * rest boundaries. Seconds precision matters for the crossed-message rule
- * — within-minute collisions (common on fast turn-taking) were ambiguous
- * at minute granularity. Callers that care about send-time vs. enqueue-time
- * (e.g. Telegram polling, where msg.date is meaningful on bad connectivity)
- * can pass `opts.sentAt` to stamp the source event time.
+ * Server-side thin adaptor: invokes the TARGET Beast's own notify.sh
+ * (`/home/gorn/workspace/<beast>/scripts/notify.sh`) instead of a
+ * server-owned shell script. Per Spec #54 v4 sovereignty pattern,
+ * notify.sh is Beast-owned (lives in Beast brain worktree, ported via
+ * Beast Blueprint v0.6.3). Both ends of the notification stack now
+ * Beast-sovereign — server is coordinator, not bottleneck.
+ *
+ * Timestamp stamping moved INTO notify.sh (per spec) — all callers get
+ * consistent `[YYYY-MM-DD HH:MM:SS UTC+7] [from <sender>] <message>`
+ * format regardless of entry point.
+ *
+ * Sender attribution via `opts.from` (default 'server'). Honor-system
+ * v4 — cryptographic auth is sister-spec follow-up.
+ *
+ * Drain side: per-Beast `notify-drain.sh` reads `/tmp/den-notify/<beast>.queue`
+ * and pastes to tmux session via `tmux send-keys -l` + 200ms race-pause + Enter.
  */
 
 import path from 'path';
 
-const NOTIFY_SCRIPT = path.join(import.meta.dir, '..', 'scripts', 'notify.sh');
+const WORKSPACE_ROOT = '/home/gorn/workspace';
 
+/**
+ * Legacy server-side notify.sh path (Spec #29 era). Used as the middle
+ * fallback during Phase 4 canary migration window — when a Beast hasn't
+ * pulled Blueprint v0.6.3 yet, the per-Beast notify.sh doesn't exist.
+ * Removed in Spec #54 Phase 4b cleanup once all Beasts migrate.
+ */
+const LEGACY_NOTIFY_SCRIPT = path.join(import.meta.dir, '..', 'scripts', 'notify.sh');
+
+/**
+ * Beast-name validation: alphanumeric lowercase only. Anti-traversal at
+ * the adaptor boundary (defense-in-depth — notify.sh also self-validates
+ * via `readlink -f $0` derivation, but adaptor validates before path.join).
+ */
+const BEAST_NAME_RE = /^[a-z]+$/;
+
+export interface EnqueueOpts {
+  /** Sender attribution. Defaults to 'server'. Honor-system v4. */
+  from?: string;
+  /**
+   * Event time. Currently unused — timestamp is stamped by notify.sh on
+   * enqueue (Spec #54 v4 design). If a caller cares about sent-time vs
+   * enqueue-time (e.g., delayed TG polling), they should incorporate the
+   * sent-time into the message body itself. Reserved for future.
+   */
+  sentAt?: Date;
+}
+
+/**
+ * Format a UTC+7 timestamp for the fallback path. notify.sh handles its
+ * own stamping in the happy path; this is only used when we fall back to
+ * direct tmux send-keys (e.g., notify.sh fails or beast worktree missing).
+ */
 function formatUtc7Timestamp(date: Date): string {
   const utc7 = new Date(date.getTime() + 7 * 60 * 60 * 1000);
   const y = utc7.getUTCFullYear();
@@ -28,31 +66,59 @@ function formatUtc7Timestamp(date: Date): string {
   return `[${y}-${mo}-${d} ${h}:${mi}:${s} UTC+7]`;
 }
 
-export interface EnqueueOpts {
-  /** Event time to stamp on the notification. Defaults to now. */
-  sentAt?: Date;
-}
-
 /**
- * Enqueue a notification for a Beast via the file-based queue.
- * Falls back to direct tmux send-keys if the queue script fails.
+ * Enqueue a notification for a Beast by invoking the target Beast's own notify.sh.
+ *
+ * Per Spec #54 v4 (Phase 2d): this is a thin adaptor. Target script content
+ * lives in the Beast's brain worktree, not in this repo. Beasts can also call
+ * each other's notify.sh directly — this adaptor is just the server-originated
+ * path. Server-down does not break beast-to-beast notification.
+ *
+ * Falls back to direct tmux send-keys if the spawn fails (e.g., beast worktree
+ * missing during canary migration).
  */
 export function enqueueNotification(beast: string, message: string, opts?: EnqueueOpts): boolean {
   const beastLower = beast.toLowerCase();
-  const stamp = formatUtc7Timestamp(opts?.sentAt ?? new Date());
-  const stamped = `${stamp} ${message}`;
 
-  try {
-    const result = Bun.spawnSync(['bash', NOTIFY_SCRIPT, beastLower, stamped]);
-    if (result.exitCode === 0) return true;
-    console.error(`[notify] Queue failed for ${beastLower}, falling back to direct send`);
-  } catch (err) {
-    console.error(`[notify] Queue error for ${beastLower}:`, err);
+  // Anti-traversal at adaptor boundary (Bertus DEN-S54-v4-bertus C-NEW-1 sister)
+  if (!BEAST_NAME_RE.test(beastLower)) {
+    console.error(`[notify] Invalid beast name: ${beast}`);
+    return false;
   }
 
-  // Fallback: direct tmux send-keys (better than dropping the notification)
+  const targetScript = path.join(WORKSPACE_ROOT, beastLower, 'scripts', 'notify.sh');
+  const sender = opts?.from ?? 'server';
+
+  // Tier 1: per-Beast notify.sh (Spec #54 v4 sovereignty path)
+  try {
+    const result = Bun.spawnSync(['bash', targetScript, message, '--from', sender]);
+    if (result.exitCode === 0) return true;
+    // Quiet during migration window — exit 127 (file not found) is expected
+    // for un-migrated Beasts. Only log non-127 unexpected failures.
+    if (result.exitCode !== 127) {
+      console.error(`[notify] Per-Beast notify failed for ${beastLower} (exit ${result.exitCode})`);
+    }
+  } catch (err) {
+    console.error(`[notify] Per-Beast notify error for ${beastLower}:`, err);
+  }
+
+  // Tier 2: legacy server-side notify.sh (preserves queue+drain pipeline
+  // during Phase 4 canary migration window). Removed in Phase 4b cleanup.
+  try {
+    const stamp = formatUtc7Timestamp(opts?.sentAt ?? new Date());
+    const stamped = `${stamp} [from ${sender}] ${message}`;
+    const result = Bun.spawnSync(['bash', LEGACY_NOTIFY_SCRIPT, beastLower, stamped]);
+    if (result.exitCode === 0) return true;
+    console.error(`[notify] Legacy notify failed for ${beastLower} (exit ${result.exitCode})`);
+  } catch (err) {
+    console.error(`[notify] Legacy notify error for ${beastLower}:`, err);
+  }
+
+  // Tier 3: direct tmux send-keys with synthesized stamp. Final fallback.
   try {
     const sessionName = beastLower.charAt(0).toUpperCase() + beastLower.slice(1);
+    const stamp = formatUtc7Timestamp(opts?.sentAt ?? new Date());
+    const stamped = `${stamp} [from ${sender}] ${message}`;
     Bun.spawnSync(['tmux', 'send-keys', '-t', sessionName, '-l', stamped]);
     // T#714 (follow-up to T#713 scope-miss): sleep 200ms between text-paste and
     // Enter to break the Claude Code Ink-TUI race. Same fix as runDrainCycle.


### PR DESCRIPTION
## Summary
Refactor `src/notify.ts` `enqueueNotification()` to invoke target Beast's `<beast>/scripts/notify.sh` (Spec #54 v4 sovereignty path). Three-tier fallback: per-Beast → legacy server-side → direct tmux.

## Why
Both ends of the notification stack now Beast-sovereign. Server becomes thin coordinator, not bottleneck. Beast→beast direct calls allowed (no server in the wire). Phase 4 canary unblocked once this lands.

## Changes
- `src/notify.ts`: refactored `enqueueNotification()` (91 added, 25 removed)
- Anti-traversal regex `/^[a-z]+$/` BEFORE `path.join` (Bertus DEN-S54-v4-bertus C-NEW-1 sister)
- Sender attribution via `opts.from` (default 'server', honor-system v4)
- Tier 1 silent on exit 127 (expected during canary migration)
- Tier 2 preserves queue+drain pipeline during migration window

## Test plan
- [x] Type-check clean (`bun build` 12.38KB)
- [x] Functional test live against `karo` beast (no per-Beast notify.sh yet, fell to Tier 2 as expected). Queue line written + drained to tmux within 3s SPACING. Sender attribution `[from phase2d-test]` verified.
- [ ] Bertus security review — Tier 1+2+3 fallback shape, regex anti-traversal, exit-127 silence
- [ ] Gnarl architect review — three-tier fallback ordering vs spec, deprecation path for Tier 2

## Tier 2 reviewers
- @bertus security-pen
- @gnarl architect-pen

Per Decree #71 v3 + WORKFLOW v0.2 cross-spec phase delegation. Spec stamp = go-ahead. Class 1 PATCH for the spec phase but server-code touching auth/spawn boundary so dual-pen review is appropriate.

## Spec ref
- Spec #54 v4 §Producer: Server adaptor — design source
- Spec #54 v4 §Build phases — Phase 2d ownership = Karo

🤖 Generated with [Claude Code](https://claude.com/claude-code)