### PR TITLE
fix(tasks): exclude deleted tasks from GET /api/tasks (T#759)

### DIFF
--- a/src/integration/tasks.test.ts
+++ b/src/integration/tasks.test.ts
@@ -271,4 +271,48 @@ describe("Tasks & Board API Integration", () => {
       expect(data).toBeTruthy();
     });
   });
+
+  // T#759: deleted tasks excluded from list by default
+  describe("Deleted task exclusion (T#759)", () => {
+    test("GET /api/tasks excludes deleted tasks by default", async () => {
+      const { data: task } = await createTask();
+      // Delete it
+      await fetch(`${BASE_URL}/api/tasks/${task.id}`, { method: "DELETE" });
+      // List should not include deleted task
+      const listRes = await fetch(`${BASE_URL}/api/tasks`);
+      const listData = await listRes.json();
+      const found = listData.tasks.find((t: any) => t.id === task.id);
+      expect(found).toBeUndefined();
+    });
+
+    test("GET /api/tasks?include_deleted=true returns deleted tasks", async () => {
+      const { data: task } = await createTask();
+      await fetch(`${BASE_URL}/api/tasks/${task.id}`, { method: "DELETE" });
+      const listRes = await fetch(`${BASE_URL}/api/tasks?include_deleted=true`);
+      const listData = await listRes.json();
+      const found = listData.tasks.find((t: any) => t.id === task.id);
+      expect(found).toBeTruthy();
+      expect(found.status).toBe("deleted");
+    });
+
+    test("GET /api/board excludes deleted tasks", async () => {
+      const { data: task } = await createTask();
+      await fetch(`${BASE_URL}/api/tasks/${task.id}`, { method: "DELETE" });
+      const boardRes = await fetch(`${BASE_URL}/api/board`);
+      const boardData = await boardRes.json();
+      const allTasks = Object.values(boardData.columns || {}).flat() as any[];
+      const found = allTasks.find((t: any) => t.id === task.id);
+      expect(found).toBeUndefined();
+    });
+
+    test("GET /api/tasks/:id/subtree excludes deleted subtasks", async () => {
+      const { data: parent } = await createTask({ title: `${TEST_PREFIX}parent_${Date.now()}` });
+      const { data: child } = await createTask({ title: `${TEST_PREFIX}child_${Date.now()}`, parent_task_id: parent.id });
+      await fetch(`${BASE_URL}/api/tasks/${child.id}`, { method: "DELETE" });
+      const subtreeRes = await fetch(`${BASE_URL}/api/tasks/${parent.id}/subtree`);
+      const subtreeData = await subtreeRes.json();
+      const found = subtreeData.subtasks.find((t: any) => t.id === child.id);
+      expect(found).toBeUndefined();
+    });
+  });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1601,7 +1601,7 @@ const HELP_ENDPOINTS = [
     { method: 'GET', path: '/api/dm/dashboard', desc: 'DM dashboard stats', params: null },
     { method: 'GET', path: '/api/dm/unread-count', desc: 'Get unread DM count', params: null },
     // Tasks (PM Board)
-    { method: 'GET', path: '/api/tasks', desc: 'List tasks (Spec #56: parent_id filter)', params: '?assignee=&reviewer=&status=&parent_id=&limit=100&offset=0' },
+    { method: 'GET', path: '/api/tasks', desc: 'List tasks (Spec #56: parent_id filter)', params: '?assignee=&reviewer=&status=&parent_id=&limit=100&offset=0&include_deleted=true' },
     { method: 'GET', path: '/api/tasks/:id', desc: 'Get task by ID (includes subtasks summary if parent)', params: null },
     { method: 'GET', path: '/api/tasks/:id/subtree', desc: 'Get parent task + all direct subtasks (Spec #56)', params: null },
     { method: 'POST', path: '/api/tasks', desc: 'Create task (Spec #56: parent_task_id for subtasks)', params: 'body: { title, assigned_to, reviewer, project_id, description?, status?, parent_task_id? }' },
@@ -5938,6 +5938,10 @@ app.get('/api/tasks', (c) => {
 
   let query = 'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE 1=1';
   const params: any[] = [];
+
+  // T#759: exclude soft-deleted tasks by default; ?include_deleted=true for audit/admin
+  const includeDeleted = c.req.query('include_deleted') === 'true';
+  if (!includeDeleted) { query += " AND t.status != 'deleted'"; }
 
   if (projectId) { query += ' AND t.project_id = ?'; params.push(parseInt(projectId, 10)); }
   if (status) {


### PR DESCRIPTION
## Summary
- GET /api/tasks now excludes soft-deleted tasks by default
- New ?include_deleted=true param for audit/admin access
- 4 integration tests added

## Changes
- src/server.ts: add WHERE status != 'deleted' to GET /api/tasks query (3 lines)
- src/integration/tasks.test.ts: 4 new T#759 tests (deleted excluded from list, include_deleted returns them, board excludes, subtree excludes)

## Test plan
- [x] Pre-existing board + subtree already filter deleted (verified)
- [x] 4 new tests cover the list endpoint gap + include_deleted param
- [ ] Tests pass post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)