### PR TITLE
Spec #57 Phase 2 — GET version endpoints (T#755)

### DIFF
--- a/src/integration/specs.test.ts
+++ b/src/integration/specs.test.ts
@@ -428,6 +428,49 @@ describe("Specs API Integration", () => {
       expect(res.status).toBe(403);
     });
 
+    // T#755 / Spec #57 Phase 2 — version endpoints
+    test("GET /api/specs/:id/versions returns version list", async () => {
+      const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
+      const approvedData = await approvedRes.json();
+      if (!approvedData.specs || approvedData.specs.length === 0) return;
+      const specId = approvedData.specs[0].id;
+      const res = await fetch(`${BASE_URL}/api/specs/${specId}/versions`);
+      expect(res.ok).toBe(true);
+      const data = await res.json();
+      expect(data.spec_id).toBe(specId);
+      expect(data.versions).toBeInstanceOf(Array);
+      expect(data.current_version).toBeTruthy();
+    });
+
+    test("GET /api/specs/:id/content?version=v1 returns v1 snapshot", async () => {
+      const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
+      const approvedData = await approvedRes.json();
+      if (!approvedData.specs || approvedData.specs.length === 0) return;
+      const specId = approvedData.specs[0].id;
+      const versionsRes = await fetch(`${BASE_URL}/api/specs/${specId}/versions`);
+      const versionsData = await versionsRes.json();
+      if (!versionsData.versions || versionsData.versions.length === 0) return;
+      const res = await fetch(`${BASE_URL}/api/specs/${specId}/content?version=v1`);
+      expect(res.ok).toBe(true);
+      const data = await res.json();
+      expect(data.version).toBe("v1");
+      expect(data.content).toBeTruthy();
+    });
+
+    test("GET /api/specs/:id/content?version=v999 returns 404", async () => {
+      const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
+      const approvedData = await approvedRes.json();
+      if (!approvedData.specs || approvedData.specs.length === 0) return;
+      const specId = approvedData.specs[0].id;
+      const res = await fetch(`${BASE_URL}/api/specs/${specId}/content?version=v999`);
+      expect(res.status).toBe(404);
+    });
+
+    test("GET /api/specs/99999/versions returns 404", async () => {
+      const res = await fetch(`${BASE_URL}/api/specs/99999/versions`);
+      expect(res.status).toBe(404);
+    });
+
     test("POST /api/specs/:id/resubmit on approved spec points at reopen", async () => {
       const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
       const approvedData = await approvedRes.json();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1638,7 +1638,8 @@ const HELP_ENDPOINTS = [
     // Specs (SDD)
     { method: 'GET', path: '/api/specs', desc: 'List all specs', params: '?status=&author=' },
     { method: 'GET', path: '/api/specs/:id', desc: 'Get spec by ID', params: null },
-    { method: 'GET', path: '/api/specs/:id/content', desc: 'Get spec markdown content', params: null },
+    { method: 'GET', path: '/api/specs/:id/content', desc: 'Get spec markdown content (Spec #57: ?version=vN for historical)', params: '?version=v1' },
+    { method: 'GET', path: '/api/specs/:id/versions', desc: 'List spec version snapshots (Spec #57)', params: null },
     { method: 'GET', path: '/api/specs/:id/history', desc: 'Get spec review history', params: null },
     { method: 'GET', path: '/api/specs/:id/diff', desc: 'Get spec version diff', params: '?v1=&v2=' },
     { method: 'POST', path: '/api/specs', desc: 'Submit new spec', params: 'body: { title, content, author, task_ids?, thread_ids? }' },
@@ -8286,19 +8287,40 @@ app.get('/api/specs/:id', (c) => {
   return c.json(spec);
 });
 
-// GET /api/specs/:id/content — raw markdown content from repo
+// GET /api/specs/:id/content — raw markdown content from repo (or historical version via ?version=vN)
 app.get('/api/specs/:id/content', (c) => {
   const id = parseInt(c.req.param('id'), 10);
-  const spec = sqlite.prepare('SELECT repo, file_path FROM spec_reviews WHERE id = ?').get(id) as any;
+  const spec = sqlite.prepare('SELECT repo, file_path, current_version FROM spec_reviews WHERE id = ?').get(id) as any;
   if (!spec) return c.json({ error: 'Spec not found' }, 404);
+
+  // T#755 / Spec #57 Phase 2: serve historical version if ?version=vN specified
+  const versionParam = c.req.query('version');
+  if (versionParam) {
+    const row = sqlite.prepare('SELECT * FROM spec_versions WHERE spec_id = ? AND version = ?').get(id, versionParam) as any;
+    if (!row) return c.json({ error: `Version ${versionParam} not found for spec #${id}` }, 404);
+    return c.json({ content: row.content, version: row.version, stamped_at: row.stamped_at, stamped_by: row.stamped_by, change_summary: row.change_summary, file_path: spec.file_path, repo: spec.repo });
+  }
+
+  // Default: serve current on-disk content
   const resolved = resolveSpecPath(spec.repo, spec.file_path);
   if (!resolved) return c.json({ error: 'Invalid spec path' }, 400);
   try {
     const content = fs.readFileSync(resolved, 'utf-8');
-    return c.json({ content, file_path: spec.file_path, repo: spec.repo });
+    return c.json({ content, file_path: spec.file_path, repo: spec.repo, current_version: spec.current_version || 'v1' });
   } catch {
     return c.json({ error: 'Spec file not found on disk' }, 404);
   }
+});
+
+// T#755 / Spec #57 Phase 2: GET /api/specs/:id/versions — list all version snapshots
+app.get('/api/specs/:id/versions', (c) => {
+  const id = parseInt(c.req.param('id'), 10);
+  const spec = sqlite.prepare('SELECT id, current_version FROM spec_reviews WHERE id = ?').get(id) as any;
+  if (!spec) return c.json({ error: 'Spec not found' }, 404);
+  const versions = sqlite.prepare(
+    'SELECT version, stamped_at, stamped_by, change_summary, created_at FROM spec_versions WHERE spec_id = ? ORDER BY created_at ASC'
+  ).all(id) as any[];
+  return c.json({ spec_id: id, current_version: spec.current_version || 'v1', versions });
 });
 
 // GET /api/specs/:id/history — git log for spec file


### PR DESCRIPTION
## Summary
Read endpoints for spec version chain. Serves historical version snapshots + version list.

## Changes
- GET /api/specs/:id/content?version=vN — historical version from spec_versions table
- GET /api/specs/:id/versions — list all version snapshots with metadata
- 4 integration tests

## Test plan
- [ ] Pip QA review
- [ ] Tests pass post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)