### PR TITLE
Spec #54 Phase 5 Window 2 — server-drain fallback warning (T#738)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7389,6 +7389,11 @@ function runDrainCycle() {
       // that defeats the offline-resilience guarantee.
       if (perBeastDrainAlive(pidPath)) continue;
 
+      // T#738 / Spec #54 Phase 5 Window 2: log-only-warning when server-drain
+      // falls back to handling a queue that should be per-Beast-drained.
+      // After 7 days of zero warnings → Window 3 removes runDrainCycle entirely.
+      console.warn(`[Notify] WINDOW-2-WARNING: server-drain fallback for ${beast} — per-Beast drain NOT alive (pid: ${pidPath})`);
+
       // Check spacing — don't send to same Beast within DRAIN_SPACING
       const lastSent = drainLastSent.get(beast) || 0;
       if (Date.now() - lastSent < DRAIN_SPACING) continue;


### PR DESCRIPTION
## Summary
Log-only-warning on server runDrainCycle fallback. Window 2 of the 3-window observation.

## Changes
- 5-line addition: console.warn when server-drain processes a queue that per-Beast drain should own
- After 7 days of zero warnings → Window 3 removes runDrainCycle entirely

## Test plan
- [ ] Monitor server logs for WINDOW-2-WARNING entries
- [ ] 7 days zero warnings = Phase 5 complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)