### PR TITLE
T#763: Show creation time on Prowl task cards

### DIFF
--- a/frontend/src/pages/Prowl.module.css
+++ b/frontend/src/pages/Prowl.module.css
@@ -289,6 +289,12 @@
   color: var(--text-muted);
 }
 
+.createdAt {
+  font-size: 0.7em;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
 /* Expanded Task */
 .taskExpanded {
   margin-top: 12px;

--- a/frontend/src/pages/Prowl.tsx
+++ b/frontend/src/pages/Prowl.tsx
@@ -217,6 +217,20 @@ export function Prowl() {
     return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   }
 
+  function formatCreatedAt(iso: string): string {
+    const d = new Date(iso);
+    const now = new Date();
+    const diff = now.getTime() - d.getTime();
+    const mins = Math.round(diff / 60000);
+    const hours = Math.round(diff / 3600000);
+    const days = Math.round(diff / 86400000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    if (hours < 24) return `${hours}h ago`;
+    if (days < 7) return `${days}d ago`;
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  }
+
   const filterTabs: { key: FilterTab; label: string; count?: number }[] = [
     { key: 'all', label: 'All', count: counts.pending },
     { key: 'high', label: 'High', count: counts.high },
@@ -351,6 +365,7 @@ export function Prowl() {
                     {task.source && task.source !== 'manual' && (
                       <span className={styles.source}>{task.source}{task.source_id ? ` #${task.source_id}` : ''}</span>
                     )}
+                    <span className={styles.createdAt}>{formatCreatedAt(task.created_at)}</span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Add relative timestamp (e.g. "3d ago") to Prowl task meta row
- Right-aligned via margin-left: auto
- formatCreatedAt helper for human-readable output

## Test plan
- [ ] Verify timestamp shows on all Prowl tasks
- [ ] Verify relative time updates (just now → Xm → Xh → Xd → date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)