### PR TITLE
T#769: Extract risk routes to src/risk/routes.ts

### DIFF
--- a/src/risk/routes.ts
+++ b/src/risk/routes.ts
@@ -1,0 +1,277 @@
+import type { Context } from 'hono';
+import type { OpenAPIHono } from '@hono/zod-openapi';
+import type { Database } from 'bun:sqlite';
+
+const ALLOWED_RISK_CREATORS = ['gorn', 'bertus', 'talon'];
+
+interface RiskHelpers {
+  hasSessionAuth: (c: Context) => boolean;
+  wsBroadcast: (event: string, data: any) => void;
+}
+
+export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: RiskHelpers) {
+  const { hasSessionAuth, wsBroadcast } = helpers;
+
+  // GET /api/risks — list risks
+  app.get('/api/risks', (c) => {
+    const status = c.req.query('status');
+    const category = c.req.query('category');
+    const severity = c.req.query('severity');
+    const likelihood = c.req.query('likelihood');
+    const owner = c.req.query('owner');
+    const risk_type = c.req.query('risk_type');
+    const includeDeleted = c.req.query('deleted') === 'true';
+
+    let query = 'SELECT * FROM risks WHERE 1=1';
+    const params: any[] = [];
+
+    if (!includeDeleted) {
+      query += ' AND deleted_at IS NULL';
+    }
+    if (status) { query += ' AND status = ?'; params.push(status); }
+    if (category) { query += ' AND category = ?'; params.push(category); }
+    if (severity) { query += ' AND severity = ?'; params.push(severity); }
+    if (likelihood) { query += ' AND likelihood = ?'; params.push(likelihood); }
+    if (owner) { query += ' AND owner = ?'; params.push(owner); }
+    if (risk_type) { query += ' AND risk_type = ?'; params.push(risk_type); }
+
+    query += ' ORDER BY risk_score DESC, updated_at DESC';
+
+    const risks = sqlite.prepare(query).all(...params);
+    return c.json({ risks });
+  });
+
+  // GET /api/risks/summary — dashboard summary
+  app.get('/api/risks/summary', (c) => {
+    const base = 'FROM risks WHERE deleted_at IS NULL';
+    const total = (sqlite.prepare(`SELECT COUNT(*) as c ${base}`).get() as any).c;
+
+    const bySeverity: any = {};
+    for (const s of ['critical', 'high', 'medium', 'low', 'info']) {
+      bySeverity[s] = (sqlite.prepare(`SELECT COUNT(*) as c ${base} AND severity = ?`).get(s) as any).c;
+    }
+
+    const byStatus: any = {};
+    for (const s of ['open', 'mitigating', 'accepted', 'mitigated', 'closed']) {
+      byStatus[s] = (sqlite.prepare(`SELECT COUNT(*) as c ${base} AND status = ?`).get(s) as any).c;
+    }
+
+    const byCategory: any = {};
+    const catRows = sqlite.prepare(`SELECT category, COUNT(*) as c ${base} GROUP BY category`).all() as any[];
+    for (const r of catRows) byCategory[r.category] = r.c;
+
+    const staleCount = (sqlite.prepare(
+      `SELECT COUNT(*) as c ${base} AND status IN ('open','mitigating') AND (reviewed_at IS NULL OR reviewed_at < datetime('now', '-7 days'))`
+    ).get() as any).c;
+
+    // Matrix data: count of risks per severity × likelihood
+    const matrixRows = sqlite.prepare(
+      `SELECT severity, likelihood, COUNT(*) as count ${base} AND status NOT IN ('closed','mitigated') GROUP BY severity, likelihood`
+    ).all() as any[];
+
+    return c.json({ total, by_severity: bySeverity, by_status: byStatus, by_category: byCategory, stale_count: staleCount, matrix: matrixRows });
+  });
+
+  // GET /api/risks/stale — risks not reviewed in >7 days
+  app.get('/api/risks/stale', (c) => {
+    const risks = sqlite.prepare(
+      "SELECT * FROM risks WHERE deleted_at IS NULL AND status IN ('open','mitigating') AND (reviewed_at IS NULL OR reviewed_at < datetime('now', '-7 days')) ORDER BY risk_score DESC"
+    ).all();
+    return c.json({ risks });
+  });
+
+  // GET /api/risks/:id — single risk
+  app.get('/api/risks/:id', (c) => {
+    const id = parseInt(c.req.param('id'), 10);
+    if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
+    const risk = sqlite.prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL').get(id);
+    if (!risk) return c.json({ error: 'Risk not found' }, 404);
+    return c.json(risk);
+  });
+
+  // POST /api/risks — create risk (Gorn, Bertus, Talon)
+  app.post('/api/risks', async (c) => {
+    try {
+      const data = await c.req.json();
+      if (!data.title?.trim()) return c.json({ error: 'title required' }, 400);
+
+      const requester = (c.req.query('as') || data.created_by || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
+      if (!requester || !ALLOWED_RISK_CREATORS.includes(requester)) {
+        return c.json({ error: `Only ${ALLOWED_RISK_CREATORS.join(', ')} can create risks` }, 403);
+      }
+
+      const validSeverity = ['critical', 'high', 'medium', 'low', 'info'];
+      const validLikelihood = ['almost_certain', 'likely', 'possible', 'unlikely', 'rare'];
+      const validStatus = ['open', 'mitigating', 'accepted', 'mitigated', 'closed'];
+      const validSourceType = ['scan', 'audit', 'thread', 'directive', 'external'];
+      const validRiskType = ['vulnerability', 'threat', 'operational', 'compliance', 'project'];
+
+      const now = new Date().toISOString();
+      const result = sqlite.prepare(
+        `INSERT INTO risks (title, description, category, severity, likelihood, impact_notes, status, mitigation, owner, source, source_type, risk_type, thread_id, created_by, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        data.title.trim(),
+        data.description || null,
+        data.category || 'security',
+        validSeverity.includes(data.severity) ? data.severity : 'medium',
+        validLikelihood.includes(data.likelihood) ? data.likelihood : 'possible',
+        data.impact_notes || null,
+        validStatus.includes(data.status) ? data.status : 'open',
+        data.mitigation || null,
+        data.owner || null,
+        data.source || null,
+        validSourceType.includes(data.source_type) ? data.source_type : 'scan',
+        validRiskType.includes(data.risk_type) ? data.risk_type : 'threat',
+        data.thread_id ?? null,
+        requester,
+        now, now
+      );
+
+      const risk = sqlite.prepare('SELECT * FROM risks WHERE id = ?').get((result as any).lastInsertRowid) as any;
+      wsBroadcast('risk_update', { action: 'create', id: risk.id });
+      return c.json(risk, 201);
+    } catch (e: any) {
+      return c.json({ error: e?.message || 'Invalid request' }, 400);
+    }
+  });
+
+  // PATCH /api/risks/:id — update risk
+  app.patch('/api/risks/:id', async (c) => {
+    const id = parseInt(c.req.param('id'), 10);
+    if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
+    const existing = sqlite.prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL').get(id) as any;
+    if (!existing) return c.json({ error: 'Risk not found' }, 404);
+
+    const requester = (c.req.query('as') || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
+    if (!requester) return c.json({ error: 'Identity required' }, 400);
+
+    try {
+      const data = await c.req.json();
+
+      // Gorn-only fields
+      const gornOnly = ['status', 'severity', 'likelihood'];
+      for (const field of gornOnly) {
+        if (field in data && requester !== 'gorn') {
+          return c.json({ error: `Only Gorn can change ${field}` }, 403);
+        }
+      }
+
+      const allowed = ['title', 'description', 'category', 'severity', 'likelihood', 'impact_notes', 'status', 'mitigation', 'owner', 'source', 'source_type', 'risk_type', 'thread_id', 'reviewed_at'];
+      const updates: string[] = [];
+      const values: any[] = [];
+
+      for (const field of allowed) {
+        if (field in data) {
+          updates.push(`${field} = ?`);
+          values.push(data[field]);
+        }
+      }
+      if (updates.length === 0) return c.json({ error: 'No valid fields to update' }, 400);
+
+      // Auto-set closed_at when status changes to closed
+      if (data.status === 'closed' && existing.status !== 'closed') {
+        updates.push('closed_at = ?');
+        values.push(new Date().toISOString());
+      } else if (data.status && data.status !== 'closed' && existing.closed_at) {
+        updates.push('closed_at = ?');
+        values.push(null);
+      }
+
+      updates.push('updated_at = ?');
+      values.push(new Date().toISOString());
+      values.push(id);
+
+      sqlite.prepare(`UPDATE risks SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+      const risk = sqlite.prepare('SELECT * FROM risks WHERE id = ?').get(id) as any;
+      wsBroadcast('risk_update', { action: 'update', id: risk?.id });
+      return c.json(risk);
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
+  });
+
+  // DELETE /api/risks/:id — soft delete (Gorn only)
+  app.delete('/api/risks/:id', async (c) => {
+    if (!hasSessionAuth(c)) return c.json({ error: 'Gorn-only' }, 403);
+    const id = parseInt(c.req.param('id'), 10);
+    if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
+    const existing = sqlite.prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL').get(id) as any;
+    if (!existing) return c.json({ error: 'Risk not found' }, 404);
+
+    const now = new Date().toISOString();
+    sqlite.prepare('UPDATE risks SET deleted_at = ?, updated_at = ? WHERE id = ?').run(now, now, id);
+    wsBroadcast('risk_update', { action: 'delete', id: (existing as any).id });
+    return c.json({ deleted: true, id });
+  });
+
+  // --- Risk Comments (T#323) ---
+
+  // GET /api/risks/:id/comments — list comments for a risk
+  app.get('/api/risks/:id/comments', (c) => {
+    const id = parseInt(c.req.param('id'), 10);
+    if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
+    const risk = sqlite.prepare('SELECT id FROM risks WHERE id = ? AND deleted_at IS NULL').get(id);
+    if (!risk) return c.json({ error: 'Risk not found' }, 404);
+    const comments = sqlite.prepare('SELECT * FROM risk_comments WHERE risk_id = ? ORDER BY created_at ASC').all(id);
+    return c.json({ comments });
+  });
+
+  // POST /api/risks/:id/comments — add comment
+  app.post('/api/risks/:id/comments', async (c) => {
+    const id = parseInt(c.req.param('id'), 10);
+    if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
+    const risk = sqlite.prepare('SELECT id FROM risks WHERE id = ? AND deleted_at IS NULL').get(id);
+    if (!risk) return c.json({ error: 'Risk not found' }, 404);
+
+    try {
+      const data = await c.req.json();
+      const author = (c.req.query('as') || data.author || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
+      if (!author) return c.json({ error: 'Identity required: pass ?as=beast or author in body' }, 400);
+      if (!data.content?.trim()) return c.json({ error: 'content required' }, 400);
+
+      const contentText = data.content.trim();
+      const result = sqlite.prepare(
+        'INSERT INTO risk_comments (risk_id, author, content) VALUES (?, ?, ?)'
+      ).run(id, author, contentText);
+
+      const comment = sqlite.prepare('SELECT * FROM risk_comments WHERE id = ?').get((result as any).lastInsertRowid);
+      wsBroadcast('risk_update', { action: 'comment', risk_id: id });
+
+      // Notify risk owner + previous commenters
+      try {
+        const riskData = sqlite.prepare('SELECT title, owner FROM risks WHERE id = ?').get(id) as any;
+        if (riskData) {
+          const { parseMentions, notifyMentioned } = await import('../forum/mentions.ts');
+          const toNotify = new Set<string>();
+          // Risk owner
+          if (riskData.owner && riskData.owner.toLowerCase() !== author) toNotify.add(riskData.owner.toLowerCase());
+          // Previous commenters
+          const prevCommenters = sqlite.prepare(
+            'SELECT DISTINCT author FROM risk_comments WHERE risk_id = ? AND author != ?'
+          ).all(id, author) as any[];
+          for (const pc of prevCommenters) toNotify.add(pc.author.toLowerCase());
+          // @mentions in comment content
+          const mentions = parseMentions(contentText, 0);
+          for (const m of mentions) toNotify.add(m.toLowerCase());
+          toNotify.delete(author);
+          toNotify.delete('gorn'); toNotify.delete('human'); toNotify.delete('user');
+          if (toNotify.size > 0) {
+            notifyMentioned(
+              [...toNotify],
+              0,
+              `Risk #${id}: ${riskData.title || 'Untitled'}`,
+              author,
+              `New comment on risk #${id}: ${contentText.slice(0, 100)}`,
+              { type: 'Risk comment', label: `risk #${id}`, hint: `View at /risk and expand risk #${id} to see comments.` }
+            );
+          }
+        }
+      } catch { /* notification failure is non-critical */ }
+
+      return c.json(comment, 201);
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -94,6 +94,7 @@ import type { Role } from './server/rbac.ts';
 import { registerGovernanceRoutes } from './governance/routes.ts';
 import { registerProwlRoutes } from './prowl/routes.ts';
 import { registerLibraryRoutes } from './library/routes.ts';
+import { registerRiskRoutes } from './risk/routes.ts';
 import {
   initGuestTables,
   createGuest,
@@ -8448,8 +8449,6 @@ app.post('/api/specs/:id/comments', async (c) => {
 // Risk Register (T#316)
 // ============================================================================
 
-const ALLOWED_RISK_CREATORS = ['gorn', 'bertus', 'talon'];
-
 try { sqlite.prepare(`
   CREATE TABLE IF NOT EXISTS risks (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -8485,204 +8484,7 @@ try { sqlite.prepare(`
   )
 `).run(); } catch { /* exists */ }
 
-// GET /api/risks — list risks
-app.get('/api/risks', (c) => {
-  const status = c.req.query('status');
-  const category = c.req.query('category');
-  const severity = c.req.query('severity');
-  const likelihood = c.req.query('likelihood');
-  const owner = c.req.query('owner');
-  const risk_type = c.req.query('risk_type');
-  const includeDeleted = c.req.query('deleted') === 'true';
-
-  let query = 'SELECT * FROM risks WHERE 1=1';
-  const params: any[] = [];
-
-  if (!includeDeleted) {
-    query += ' AND deleted_at IS NULL';
-  }
-  if (status) { query += ' AND status = ?'; params.push(status); }
-  if (category) { query += ' AND category = ?'; params.push(category); }
-  if (severity) { query += ' AND severity = ?'; params.push(severity); }
-  if (likelihood) { query += ' AND likelihood = ?'; params.push(likelihood); }
-  if (owner) { query += ' AND owner = ?'; params.push(owner); }
-  if (risk_type) { query += ' AND risk_type = ?'; params.push(risk_type); }
-
-  query += ' ORDER BY risk_score DESC, updated_at DESC';
-
-  const risks = sqlite.prepare(query).all(...params);
-  return c.json({ risks });
-});
-
-// GET /api/risks/summary — dashboard summary
-app.get('/api/risks/summary', (c) => {
-  const base = 'FROM risks WHERE deleted_at IS NULL';
-  const total = (sqlite.prepare(`SELECT COUNT(*) as c ${base}`).get() as any).c;
-
-  const bySeverity: any = {};
-  for (const s of ['critical', 'high', 'medium', 'low', 'info']) {
-    bySeverity[s] = (sqlite.prepare(`SELECT COUNT(*) as c ${base} AND severity = ?`).get(s) as any).c;
-  }
-
-  const byStatus: any = {};
-  for (const s of ['open', 'mitigating', 'accepted', 'mitigated', 'closed']) {
-    byStatus[s] = (sqlite.prepare(`SELECT COUNT(*) as c ${base} AND status = ?`).get(s) as any).c;
-  }
-
-  const byCategory: any = {};
-  const catRows = sqlite.prepare(`SELECT category, COUNT(*) as c ${base} GROUP BY category`).all() as any[];
-  for (const r of catRows) byCategory[r.category] = r.c;
-
-  const staleCount = (sqlite.prepare(
-    `SELECT COUNT(*) as c ${base} AND status IN ('open','mitigating') AND (reviewed_at IS NULL OR reviewed_at < datetime('now', '-7 days'))`
-  ).get() as any).c;
-
-  // Matrix data: count of risks per severity × likelihood
-  const matrixRows = sqlite.prepare(
-    `SELECT severity, likelihood, COUNT(*) as count ${base} AND status NOT IN ('closed','mitigated') GROUP BY severity, likelihood`
-  ).all() as any[];
-
-  return c.json({ total, by_severity: bySeverity, by_status: byStatus, by_category: byCategory, stale_count: staleCount, matrix: matrixRows });
-});
-
-// GET /api/risks/stale — risks not reviewed in >7 days
-app.get('/api/risks/stale', (c) => {
-  const risks = sqlite.prepare(
-    "SELECT * FROM risks WHERE deleted_at IS NULL AND status IN ('open','mitigating') AND (reviewed_at IS NULL OR reviewed_at < datetime('now', '-7 days')) ORDER BY risk_score DESC"
-  ).all();
-  return c.json({ risks });
-});
-
-// GET /api/risks/:id — single risk
-app.get('/api/risks/:id', (c) => {
-  const id = parseInt(c.req.param('id'), 10);
-  if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
-  const risk = sqlite.prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL').get(id);
-  if (!risk) return c.json({ error: 'Risk not found' }, 404);
-  return c.json(risk);
-});
-
-// POST /api/risks — create risk (Gorn, Bertus, Talon)
-app.post('/api/risks', async (c) => {
-  try {
-    const data = await c.req.json();
-    if (!data.title?.trim()) return c.json({ error: 'title required' }, 400);
-
-    const requester = (c.req.query('as') || data.created_by || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-    if (!requester || !ALLOWED_RISK_CREATORS.includes(requester)) {
-      return c.json({ error: `Only ${ALLOWED_RISK_CREATORS.join(', ')} can create risks` }, 403);
-    }
-
-    const validSeverity = ['critical', 'high', 'medium', 'low', 'info'];
-    const validLikelihood = ['almost_certain', 'likely', 'possible', 'unlikely', 'rare'];
-    const validStatus = ['open', 'mitigating', 'accepted', 'mitigated', 'closed'];
-    const validSourceType = ['scan', 'audit', 'thread', 'directive', 'external'];
-    const validRiskType = ['vulnerability', 'threat', 'operational', 'compliance', 'project'];
-
-    const now = new Date().toISOString();
-    const result = sqlite.prepare(
-      `INSERT INTO risks (title, description, category, severity, likelihood, impact_notes, status, mitigation, owner, source, source_type, risk_type, thread_id, created_by, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      data.title.trim(),
-      data.description || null,
-      data.category || 'security',
-      validSeverity.includes(data.severity) ? data.severity : 'medium',
-      validLikelihood.includes(data.likelihood) ? data.likelihood : 'possible',
-      data.impact_notes || null,
-      validStatus.includes(data.status) ? data.status : 'open',
-      data.mitigation || null,
-      data.owner || null,
-      data.source || null,
-      validSourceType.includes(data.source_type) ? data.source_type : 'scan',
-      validRiskType.includes(data.risk_type) ? data.risk_type : 'threat',
-      data.thread_id ?? null,
-      requester,
-      now, now
-    );
-
-    const risk = sqlite.prepare('SELECT * FROM risks WHERE id = ?').get((result as any).lastInsertRowid) as any;
-    // Risk excluded from search index per Gorn
-    wsBroadcast('risk_update', { action: 'create', id: risk.id });
-    return c.json(risk, 201);
-  } catch (e: any) {
-    return c.json({ error: e?.message || 'Invalid request' }, 400);
-  }
-});
-
-// PATCH /api/risks/:id — update risk
-app.patch('/api/risks/:id', async (c) => {
-  const id = parseInt(c.req.param('id'), 10);
-  if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
-  const existing = sqlite.prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL').get(id) as any;
-  if (!existing) return c.json({ error: 'Risk not found' }, 404);
-
-  const requester = (c.req.query('as') || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-  if (!requester) return c.json({ error: 'Identity required' }, 400);
-
-  try {
-    const data = await c.req.json();
-
-    // Gorn-only fields
-    const gornOnly = ['status', 'severity', 'likelihood'];
-    for (const field of gornOnly) {
-      if (field in data && requester !== 'gorn') {
-        return c.json({ error: `Only Gorn can change ${field}` }, 403);
-      }
-    }
-
-    const allowed = ['title', 'description', 'category', 'severity', 'likelihood', 'impact_notes', 'status', 'mitigation', 'owner', 'source', 'source_type', 'risk_type', 'thread_id', 'reviewed_at'];
-    const updates: string[] = [];
-    const values: any[] = [];
-
-    for (const field of allowed) {
-      if (field in data) {
-        updates.push(`${field} = ?`);
-        values.push(data[field]);
-      }
-    }
-    if (updates.length === 0) return c.json({ error: 'No valid fields to update' }, 400);
-
-    // Auto-set closed_at when status changes to closed
-    if (data.status === 'closed' && existing.status !== 'closed') {
-      updates.push('closed_at = ?');
-      values.push(new Date().toISOString());
-    } else if (data.status && data.status !== 'closed' && existing.closed_at) {
-      updates.push('closed_at = ?');
-      values.push(null);
-    }
-
-    updates.push('updated_at = ?');
-    values.push(new Date().toISOString());
-    values.push(id);
-
-    sqlite.prepare(`UPDATE risks SET ${updates.join(', ')} WHERE id = ?`).run(...values);
-    const risk = sqlite.prepare('SELECT * FROM risks WHERE id = ?').get(id) as any;
-    // Risk excluded from search index per Gorn
-    wsBroadcast('risk_update', { action: 'update', id: risk?.id });
-    return c.json(risk);
-  } catch {
-    return c.json({ error: 'Invalid request' }, 400);
-  }
-});
-
-// DELETE /api/risks/:id — soft delete (Gorn only)
-app.delete('/api/risks/:id', async (c) => {
-  if (!hasSessionAuth(c)) return c.json({ error: 'Gorn-only' }, 403);
-  const id = parseInt(c.req.param('id'), 10);
-  if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
-  const existing = sqlite.prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL').get(id) as any;
-  if (!existing) return c.json({ error: 'Risk not found' }, 404);
-
-  const now = new Date().toISOString();
-  sqlite.prepare('UPDATE risks SET deleted_at = ?, updated_at = ? WHERE id = ?').run(now, now, id);
-  wsBroadcast('risk_update', { action: 'delete', id: (existing as any).id });
-  return c.json({ deleted: true, id });
-});
-
-// ============================================================================
-// Risk Comments (T#323)
-// ============================================================================
+// Risk + risk comment routes — extracted to src/risk/routes.ts
 
 try { sqlite.prepare(`
   CREATE TABLE IF NOT EXISTS risk_comments (
@@ -8693,74 +8495,6 @@ try { sqlite.prepare(`
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
   )
 `).run(); } catch { /* exists */ }
-
-// GET /api/risks/:id/comments — list comments for a risk
-app.get('/api/risks/:id/comments', (c) => {
-  const id = parseInt(c.req.param('id'), 10);
-  if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
-  const risk = sqlite.prepare('SELECT id FROM risks WHERE id = ? AND deleted_at IS NULL').get(id);
-  if (!risk) return c.json({ error: 'Risk not found' }, 404);
-  const comments = sqlite.prepare('SELECT * FROM risk_comments WHERE risk_id = ? ORDER BY created_at ASC').all(id);
-  return c.json({ comments });
-});
-
-// POST /api/risks/:id/comments — add comment
-app.post('/api/risks/:id/comments', async (c) => {
-  const id = parseInt(c.req.param('id'), 10);
-  if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
-  const risk = sqlite.prepare('SELECT id FROM risks WHERE id = ? AND deleted_at IS NULL').get(id);
-  if (!risk) return c.json({ error: 'Risk not found' }, 404);
-
-  try {
-    const data = await c.req.json();
-    const author = (c.req.query('as') || data.author || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-    if (!author) return c.json({ error: 'Identity required: pass ?as=beast or author in body' }, 400);
-    if (!data.content?.trim()) return c.json({ error: 'content required' }, 400);
-
-    const contentText = data.content.trim();
-    const result = sqlite.prepare(
-      'INSERT INTO risk_comments (risk_id, author, content) VALUES (?, ?, ?)'
-    ).run(id, author, contentText);
-
-    const comment = sqlite.prepare('SELECT * FROM risk_comments WHERE id = ?').get((result as any).lastInsertRowid);
-    wsBroadcast('risk_update', { action: 'comment', risk_id: id });
-
-    // Notify risk owner + previous commenters
-    try {
-      const riskData = sqlite.prepare('SELECT title, owner FROM risks WHERE id = ?').get(id) as any;
-      if (riskData) {
-        const { parseMentions, notifyMentioned } = await import('./forum/mentions.ts');
-        const toNotify = new Set<string>();
-        // Risk owner
-        if (riskData.owner && riskData.owner.toLowerCase() !== author) toNotify.add(riskData.owner.toLowerCase());
-        // Previous commenters
-        const prevCommenters = sqlite.prepare(
-          'SELECT DISTINCT author FROM risk_comments WHERE risk_id = ? AND author != ?'
-        ).all(id, author) as any[];
-        for (const pc of prevCommenters) toNotify.add(pc.author.toLowerCase());
-        // @mentions in comment content
-        const mentions = parseMentions(contentText, 0);
-        for (const m of mentions) toNotify.add(m.toLowerCase());
-        toNotify.delete(author);
-        toNotify.delete('gorn'); toNotify.delete('human'); toNotify.delete('user');
-        if (toNotify.size > 0) {
-          notifyMentioned(
-            [...toNotify],
-            0,
-            `Risk #${id}: ${riskData.title || 'Untitled'}`,
-            author,
-            `New comment on risk #${id}: ${contentText.slice(0, 100)}`,
-            { type: 'Risk comment', label: `risk #${id}`, hint: `View at /risk and expand risk #${id} to see comments.` }
-          );
-        }
-      }
-    } catch { /* notification failure is non-critical */ }
-
-    return c.json(comment, 201);
-  } catch {
-    return c.json({ error: 'Invalid request' }, 400);
-  }
-});
 
 // ============================================================================
 // Withings OAuth Integration (T#414, Spec #23)
@@ -11553,6 +11287,9 @@ registerProwlRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, wsBroadcast
 
 // Library routes extracted to src/library/routes.ts (T#768)
 registerLibraryRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, searchIndexUpsert, searchIndexDelete, wsBroadcast });
+
+// Risk routes extracted to src/risk/routes.ts (T#769)
+registerRiskRoutes(app, sqlite, { hasSessionAuth, wsBroadcast });
 // ============================================================================
 // Global Search — Meilisearch + FTS5 (T#347 + T#350)
 // ============================================================================


### PR DESCRIPTION
## Summary
- Extracts 9 risk route handlers (CRUD + summary + stale + risk comments) from `server.ts` to `src/risk/routes.ts`
- Uses `registerRiskRoutes(app, sqlite, helpers)` DI pattern matching governance, prowl, and library modules
- DDL for `risks` and `risk_comments` tables stays in server.ts per Phase 3 convention
- server.ts: 12,598 → 12,335 lines (-263 lines)
- No logic changes — pure extraction

## Helpers injected
`hasSessionAuth`, `wsBroadcast`

## Test plan
- [ ] TypeScript compilation clean (no new errors)
- [ ] Risk endpoints return same responses after extraction
- [ ] Deploy and verify `/api/risks` + `/api/risks/summary` serve clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)