### PR TITLE
Hotfix T#783: relocate pack-route registration before SPA fallback wildcard

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4731,6 +4731,13 @@ registerSearchRoutes(app, sqlite, { hasSessionAuth, isLocalNetwork, isTrustedReq
 // Telegram routes + polling — extracted to src/telegram/routes.ts (T#770)
 registerTelegramRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, uploadsDir: UPLOADS_DIR });
 
+// Pack routes — must register BEFORE the SPA fallback catch-all below, else /api/pack* gets 404'd by `app.get('*', ...)`
+// Web presence tracking — in-memory, ephemeral (T#595)
+// Keyed by identity (e.g. 'gorn', 'gorn_guest'). Rebuilt on server restart.
+const webPresence = new Map<string, { identity: string; role: string; lastSeen: number }>();
+const WEB_PRESENCE_TIMEOUT_MS = 90_000; // 90s — 3 missed heartbeats
+registerPackRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast, getTmuxStatus, normalizeAvatarUrl, webPresence, WEB_PRESENCE_TIMEOUT_MS });
+
 // ============================================================================
 // OpenAPI Schema + Swagger UI (Spec #55 Phase 1)
 // ============================================================================
@@ -4796,12 +4803,6 @@ if (fs.existsSync(FRONTEND_DIST)) {
 // ============================================================================
 
 const wsClients = new Set<any>();
-
-// Web presence tracking — in-memory, ephemeral (T#595)
-// Keyed by identity (e.g. 'gorn', 'gorn_guest'). Rebuilt on server restart.
-const webPresence = new Map<string, { identity: string; role: string; lastSeen: number }>();
-const WEB_PRESENCE_TIMEOUT_MS = 90_000; // 90s — 3 missed heartbeats
-registerPackRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast, getTmuxStatus, normalizeAvatarUrl, webPresence, WEB_PRESENCE_TIMEOUT_MS });
 
 // Allowed origins for WebSocket connections
 const WS_ALLOWED_ORIGINS = new Set([


### PR DESCRIPTION
## Summary

- Pure 3-statement relocation fix for the live `/api/pack 404` regression in production after T#783 modularization deploy (14:58 BKK)
- Root cause: `registerPackRoutes` was placed AFTER `app.get('*', ...)` SPA fallback — Hono first-match-wins meant the catch-all returned `c.notFound()` for `/api/pack*` before the pack handlers were reached
- Moves `webPresence` const + `WEB_PRESENCE_TIMEOUT_MS` const + `registerPackRoutes` call from line ~4800-4804 to right after `registerTelegramRoutes` at line 4732
- No logic change, no signature change, no helper change — pure ordering

## Live incident timeline (BKK)

- 14:58 — deploy `a95ad3a → b00aafc` (12 PRs, T#771-T#784)
- 15:11 — Zaghnal escalates `/api/pack` 404 + frontend dashboard black
- 15:11-13 — Karo / Pip / Bertus / Zaghnal independently triangulate same root cause + same 3-line fix
- 15:14 — Bertus smoke-verifies pack is ONLY regression (forum/dm/board/specs/trace/dashboard/search all 200)
- 15:24 — Gorn GREEN on hotfix + deploy via TG → Zaghnal DM
- 15:26 — this PR

## Test plan

- [x] `bun build` clean
- [ ] Merge + deploy via `scripts/deploy.sh` from `/home/gorn/workspace/denbook/`
- [ ] Pip smoke-verifies all 13 pack routes post-deploy:
  - `/api/pack`, `/api/pack/spinner-verbs`, `/api/beasts`, `/api/beast/:name`
  - `/api/beast/:name/terminal`, `/api/beast/:name/terminal/input`, `/api/beast/:name/terminal/key`
  - `/api/beast/:name/avatar.svg`, `/api/beast/:name/avatar`, `/api/beasts/seed-avatars`
  - `/api/beast/:name` (PUT, PATCH), `/api/beast/:name/wake`
- [ ] Bertus re-confirms no other regressions

## Class banked for Phase 3 (T#781, T#786)

`module-registration-must-precede-spa-catch-all` — registration site relative to wildcards is an orthogonal surface from auth-gate-preservation. Pip's QA-lane note: per-PR domain-route smoke (post-deploy curl of each new domain endpoint) would have caught this in under a minute. This is exactly what the new per-PR deploy cadence (Gorn 14:56) enables.

Decree #71 live-incident exception surgical-fix lane authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)