### PR TITLE
Hotfix T#781: add missing isLocalNetwork import in src/server/routes.ts

### DIFF
--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -6,7 +6,7 @@ import {
   SESSION_COOKIE_NAME, SESSION_DURATION_MS, GUEST_SESSION_DURATION_MS,
   LOGIN_RATE_LIMIT, LOGIN_RATE_WINDOW_MS, WEB_PRESENCE_TIMEOUT_MS,
   getRateLimit, clearRateLimit,
-  generateSessionToken, isAuthenticated,
+  generateSessionToken, isAuthenticated, isLocalNetwork,
 } from '../server.ts';
 import {
   createGuest, listGuests, getGuest, getGuestByUsername,


### PR DESCRIPTION
## Summary

- Pure 1-line import fix for the live `/api/auth/status` 500 regression in production after T#781 deploy
- Root cause: `isLocalNetwork` was T#792-exported but not added to the new module's import block. `/api/auth/status` handler references it; runtime `ReferenceError`
- Bertus pen-class missed it (diff-shape was 1:1 body preservation, not import-completeness)
- Pip per-PR smoke caught it within 90 sec of deploy

## Class banked

`extraction-import-completeness-check` — for every `register*Routes` extraction, ensure every NAME used inside any handler body is present in the new module's import block. T#792-exported names must MATCH the new module's `from '../server.ts'` list, not be a subset.

Recommend folding into Bertus + Pip pen-review checklists for remaining Phase 3 work.

## Test plan

- [x] `bun build` clean
- [ ] Merge + deploy via `scripts/deploy.sh`
- [ ] `/api/auth/status` returns 200 with full body
- [ ] All other module routes still 200

Decree #71 live-incident exception authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)