### PR TITLE
Hotfix T#781 (second): add missing parseSessionToken import

### DIFF
--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -6,7 +6,7 @@ import {
   SESSION_COOKIE_NAME, SESSION_DURATION_MS, GUEST_SESSION_DURATION_MS,
   LOGIN_RATE_LIMIT, LOGIN_RATE_WINDOW_MS, WEB_PRESENCE_TIMEOUT_MS,
   getRateLimit, clearRateLimit,
-  generateSessionToken, isAuthenticated, isLocalNetwork,
+  generateSessionToken, parseSessionToken, isAuthenticated, isLocalNetwork,
 } from '../server.ts';
 import {
   createGuest, listGuests, getGuest, getGuestByUsername,


### PR DESCRIPTION
## Summary

- Second 1-line hotfix for `/api/auth/status` 500 regression
- First hotfix added `isLocalNetwork`; THIS one adds `parseSessionToken`
- Same import-completeness class as first hotfix
- Cross-verified via `grep -oE` that ALL 12 T#792 exports now match the new module's import block

## Class learning

The Bertus pen-review pattern caught 1:1 handler-body preservation but did NOT cross-check identifier-completeness against the IMPORT-block. Both hotfixes today (isLocalNetwork + parseSessionToken) were T#792-exported symbols MISSED from the import block.

For Phase 3 + future register*Routes PRs:
- `grep -oE` every helper identifier used inside the new module
- Cross-check against the import block
- This pen-step must be MANDATORY pre-merge, not optional

Worth banking as the `extraction-import-completeness-check` class (filed via T#788 backlog or new norm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)