### PR TITLE
T#795 P1: Close localhost-trust read-bypass on DM + Prowl reads

### DIFF
--- a/src/dm/routes.ts
+++ b/src/dm/routes.ts
@@ -23,17 +23,23 @@ interface DmHelpers {
 }
 
 export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: DmHelpers): void {
-  const { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast, sendDm, withRetry } = helpers;
+  // T#795 P1: hasSessionAuth + isTrustedRequest no longer needed in this file —
+  // requireBeastIdentity handles both auth paths internally (token > session > null).
+  // Interface entries kept for backward-compat with call site at server.ts:4056.
+  const { requireBeastIdentity, wsBroadcast, sendDm, withRetry } = helpers;
   const sqlite: Database = sqliteDb;
 
   app.get('/api/dm/dashboard', (c) => {
+    // T#795 P1 — close localhost-trust read-bypass. Require bearer-token or owner session.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     const limit = parseInt(c.req.query('limit') || '50');
     const data = getDashboard(limit);
-    const actor = (c.get as any)('actor') as string | undefined;
-    const authMethod = (c.get as any)('authMethod') as string | undefined;
-    // T#728: bearer-token callers see only their own conversations
-    const filtered = (authMethod === 'token' && actor)
-      ? data.conversations.filter(conv => conv.participants.some((p: string) => p.toLowerCase() === actor.toLowerCase()))
+    // T#728 + T#795 P1: non-gorn callers see only their own conversations.
+    const filtered = (caller !== 'gorn')
+      ? data.conversations.filter(conv => conv.participants.some((p: string) => p.toLowerCase() === caller))
       : data.conversations;
     return c.json({
       conversations: filtered.map(conv => ({
@@ -46,7 +52,7 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
         last_at: new Date(conv.lastAt).toISOString(),
         created_at: new Date(conv.createdAt).toISOString(),
       })),
-      total_conversations: (authMethod === 'token' && actor) ? filtered.length : data.totalConversations,
+      total_conversations: (caller !== 'gorn') ? filtered.length : data.totalConversations,
       total_messages: data.totalMessages,
     });
   });
@@ -168,18 +174,14 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
 
   app.get('/api/dm/:name', (c) => {
     const name = c.req.param('name');
-    const as = c.req.query('as')?.toLowerCase();
-    const actor = (c.get as any)('actor') as string | undefined;
-    const authMethod = (c.get as any)('authMethod') as string | undefined;
-    // T#728: bearer-token callers can only list their own conversations
-    if (authMethod === 'token' && actor && actor.toLowerCase() !== name.toLowerCase()) {
-      return c.json({ error: 'Access denied. You can only view your own conversations.' }, 403);
+    // T#795 P1 — close localhost-trust read-bypass. Require bearer-token or owner session,
+    // then scope to caller (gorn sees all; beasts see their own).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
     }
-    if (!isTrustedRequest(c)) {
-      if (!as) return c.json({ error: 'as param required for DM access' }, 400);
-      if (as !== 'gorn' && as !== name.toLowerCase()) {
-        return c.json({ error: 'Access denied. You can only view your own conversations.' }, 403);
-      }
+    if (caller !== 'gorn' && caller !== name.toLowerCase()) {
+      return c.json({ error: 'Access denied. You can only view your own conversations.' }, 403);
     }
     const limit = parseInt(c.req.query('limit') || '20');
     const offset = parseInt(c.req.query('offset') || '0');
@@ -201,7 +203,6 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
   app.get('/api/dm/:name/:other', (c) => {
     let name = c.req.param('name');
     let other = c.req.param('other');
-    const as = c.req.query('as')?.toLowerCase();
 
     // Resolve guest usernames to [Guest] tags
     // If name/other doesn't match a known beast and matches a guest account, use the [Guest] tag
@@ -216,20 +217,14 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
         }
       }
     }
-    const actor = (c.get as any)('actor') as string | undefined;
-    const authMethod = (c.get as any)('authMethod') as string | undefined;
-    // T#728: bearer-token callers can only read conversations they are part of
-    if (authMethod === 'token' && actor) {
-      const actorLower = actor.toLowerCase();
-      if (actorLower !== name.toLowerCase() && actorLower !== other.toLowerCase()) {
-        return c.json({ error: 'Access denied. You can only read conversations you are part of.' }, 403);
-      }
+    // T#795 P1 — close localhost-trust read-bypass. Require bearer-token or owner session,
+    // then scope to participants (gorn sees all; beasts see only conversations they are part of).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
     }
-    if (!isTrustedRequest(c)) {
-      if (!as) return c.json({ error: 'as param required for DM access' }, 400);
-      if (as !== 'gorn' && as !== name.toLowerCase() && as !== other.toLowerCase()) {
-        return c.json({ error: 'Access denied. You can only read conversations you are part of.' }, 403);
-      }
+    if (caller !== 'gorn' && caller !== name.toLowerCase() && caller !== other.toLowerCase()) {
+      return c.json({ error: 'Access denied. You can only read conversations you are part of.' }, 403);
     }
     const parsedDmLimit = parseInt(c.req.query('limit') || '50', 10);
     const limit = isNaN(parsedDmLimit) || parsedDmLimit < 1 ? 50 : parsedDmLimit;
@@ -254,12 +249,14 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
   app.patch('/api/dm/:name/:other/read', (c) => {
     const reader = c.req.param('name');
     const other = c.req.param('other');
-    if (!isTrustedRequest(c)) {
-      const as = c.req.query('as')?.toLowerCase();
-      if (!as) return c.json({ error: 'as param required' }, 400);
-      if (as !== reader.toLowerCase() && as !== 'gorn') {
-        return c.json({ error: 'Can only mark your own messages as read' }, 403);
-      }
+    // T#795 P1 — close localhost-trust read-bypass. Require bearer-token or owner session,
+    // then scope to caller (gorn marks any; beasts mark only their own).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn' && caller !== reader.toLowerCase()) {
+      return c.json({ error: 'Can only mark your own messages as read' }, 403);
     }
     const result = markRead(reader, other);
     if (result.markedRead > 0) wsBroadcast('dm_read', { conversation_id: result.conversationId, reader });
@@ -272,12 +269,14 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
   app.patch('/api/dm/:name/:other/read-all', (c) => {
     const name = c.req.param('name');
     const other = c.req.param('other');
-    if (!isTrustedRequest(c)) {
-      const as = c.req.query('as')?.toLowerCase();
-      if (!as) return c.json({ error: 'as param required' }, 400);
-      if (as !== name.toLowerCase() && as !== other.toLowerCase() && as !== 'gorn') {
-        return c.json({ error: 'Can only mark messages as read in your own conversations' }, 403);
-      }
+    // T#795 P1 — close localhost-trust read-bypass. Require bearer-token or owner session,
+    // then scope to participants (gorn marks any; beasts mark only conversations they are part of).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn' && caller !== name.toLowerCase() && caller !== other.toLowerCase()) {
+      return c.json({ error: 'Can only mark messages as read in your own conversations' }, 403);
     }
     const result = markAllRead(name, other);
     if (result.markedRead > 0) wsBroadcast('dm_read', { conversation_id: result.conversationId, reader: name });

--- a/src/prowl/routes.ts
+++ b/src/prowl/routes.ts
@@ -8,16 +8,25 @@ const ALLOWED_PROWL_MANAGERS = ['gorn', 'sable', 'karo'];
 interface ProwlHelpers {
   hasSessionAuth: (c: Context) => boolean;
   isTrustedRequest: (c: Context) => boolean;
+  requireBeastIdentity: (c: Context) => string | null;
   wsBroadcast: (event: string, data: any) => void;
   enqueueNotification: (beast: string, message: string) => void;
 }
 
 export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers: ProwlHelpers) {
-  const { hasSessionAuth, isTrustedRequest, wsBroadcast, enqueueNotification } = helpers;
+  const { hasSessionAuth, isTrustedRequest, requireBeastIdentity, wsBroadcast, enqueueNotification } = helpers;
 
   // GET /api/prowl — list tasks with filters
   app.get('/api/prowl', (c) => {
-    if (!hasSessionAuth(c) && !isTrustedRequest(c)) return c.json({ error: 'Authentication required' }, 403);
+    // T#795 P1 — close localhost-trust read-bypass. Require bearer-token or owner session,
+    // then restrict to gorn + ALLOWED_PROWL_MANAGERS (mirrors the write-side allowlist).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn' && !ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can view Prowl tasks` }, 403);
+    }
     const status = c.req.query('status') || 'pending';
     const priority = c.req.query('priority');
     const category = c.req.query('category');
@@ -71,7 +80,15 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // GET /api/prowl/categories — unique categories with counts
   app.get('/api/prowl/categories', (c) => {
-    if (!hasSessionAuth(c) && !isTrustedRequest(c)) return c.json({ error: 'Authentication required' }, 403);
+    // T#795 P1 — close localhost-trust read-bypass. Require bearer-token or owner session,
+    // then restrict to gorn + ALLOWED_PROWL_MANAGERS.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn' && !ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can view Prowl tasks` }, 403);
+    }
     const rows = sqlite.prepare("SELECT category, COUNT(*) as count FROM prowl_tasks WHERE category IS NOT NULL GROUP BY category ORDER BY count DESC").all();
     return c.json({ categories: rows });
   });
@@ -224,7 +241,15 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // GET /api/prowl/:id/checklist — list checklist items for a task
   app.get('/api/prowl/:id/checklist', (c) => {
-    if (!hasSessionAuth(c) && !isTrustedRequest(c)) return c.json({ error: 'Authentication required' }, 403);
+    // T#795 P1 — close localhost-trust read-bypass. Require bearer-token or owner session,
+    // then restrict to gorn + ALLOWED_PROWL_MANAGERS.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn' && !ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can view Prowl tasks` }, 403);
+    }
     const taskId = parseInt(c.req.param('id'), 10);
     if (isNaN(taskId)) return c.json({ error: 'Invalid ID' }, 400);
     const task = sqlite.prepare('SELECT id FROM prowl_tasks WHERE id = ?').get(taskId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -4153,7 +4153,7 @@ try { sqlite.prepare(`
 `).run(); } catch { /* exists */ }
 
 // Prowl routes extracted to src/prowl/routes.ts (T#767)
-registerProwlRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, wsBroadcast, enqueueNotification });
+registerProwlRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, requireBeastIdentity, wsBroadcast, enqueueNotification });
 
 // Library routes extracted to src/library/routes.ts (T#768)
 registerLibraryRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, searchIndexUpsert, searchIndexDelete, wsBroadcast });


### PR DESCRIPTION
## Summary

Closes [T#795](https://denbook.online/board/795) Phase 1 — HIGH severity (per Bertus + Zaghnal PM intake at 02:33 UTC May 14, sequenced first ahead of T#786).

`isTrustedRequest = isLocalNetwork || hasSessionAuth` was the ONLY auth gate on DM read endpoints + Prowl reads. Any localhost process with no Authorization header could pull every Beast's DM list, every cross-Beast conversation, and Gorn's personal Prowl tasks. The read-direction sibling of T#718 (write-spoof close) — never fixed. Bertus's repro from the task description:

```
curl -s http://localhost:47778/api/dm/gorn          → 200 (full DM list)
curl -s http://localhost:47778/api/dm/bertus/karo   → 200 (conversation contents)
curl -s http://localhost:47778/api/dm/dashboard     → 200 (all conversations)
curl -s http://localhost:47778/api/prowl            → 200 (Gorn's task list)
```

After this PR, same calls without Authorization → 401 "Beast identity required — bearer-token or owner session".

Fix shape mirrors `dm/routes.ts:110-117` write-path pattern from T#718: `requireBeastIdentity` cascade BEFORE any trust-fallback.

## Files changed

| File | Endpoints fixed | Pattern |
|------|-----------------|---------|
| `src/dm/routes.ts` | dashboard, GET :name, GET :name/:other, PATCH .../read, PATCH .../read-all | requireBeastIdentity + caller-scope (gorn sees all; beasts scoped to own/participants) |
| `src/prowl/routes.ts` | GET /api/prowl, GET /api/prowl/categories, GET /api/prowl/:id/checklist | requireBeastIdentity + ALLOWED_PROWL_MANAGERS allowlist (mirrors write-side) |
| `src/server.ts` | line 4156 | Pass `requireBeastIdentity` to `registerProwlRoutes` |

## Behavior matrix (after fix)

| Caller | DM dashboard | DM /:name | DM /:name/:other | Prowl reads |
|--------|--------------|-----------|------------------|-------------|
| Gorn (session) | All conversations | Any name | Any conversation | All tasks |
| Token-beast (own) | Own conversations | Own name only | Own conversations only | If in `['gorn','sable','karo']` → all; else 403 |
| Localhost no-auth | **401** | **401** | **401** | **401** |

`?as=` query param is no longer consulted on these endpoints — it was the workaround for the localhost-bypass; identity is now derived from the auth layer.

## Out of scope for Phase 1

Phase 2 (MEDIUM): `/api/forum/mentions/:beast`, `/api/forum/search`, telegram reads, specs reads — same `isTrustedRequest` primitive, different endpoints.

Phase 3 (cleanup): enumerate every `isTrustedRequest` call-site on a read path; convert to `requireBeastIdentity`-cascade.

Per Bertus + Zaghnal sequencing on T#795: **P1 (this) → T#788/T#789 cleanup → T#786 P3 → T#795 P2 → T#795 P3.**

`GET /api/dm/unread-count` (single int for Gorn's unread count) deferred to P2 — lower-severity info disclosure than the cluster above.

## Test plan

Per Norm #84 v2 (extraction-import-completeness + runtime smoke):

- [x] `bunx tsc --noEmit` — clean on changed files. Pre-existing type errors at `dm/routes.ts:99/102` (SecurityEventType narrowing in guest POST handler, not touched) and `server.ts:4156` (OpenAPIHono generic mismatch, tracked under T#788) are unchanged.
- [x] Import-completeness grep — no new imports required. `requireBeastIdentity` reaches both routes via the existing helpers parameter; same pattern as T#770 telegram extraction.
- [x] Destructure cleanup: `hasSessionAuth` + `isTrustedRequest` no longer referenced in `dm/routes.ts` body; removed from destructure. Interface entries kept for backwards-compat with call site (interface-level cleanup is Phase 3 work).
- [ ] **Runtime smoke (Bertus security-pen)**: deferred to security review — Bertus has the original repros from T#795 task description. Standalone smoke from this worktree would conflict with prod port 47778; cleanest path is the deploy gate. Suggested smoke sequence:
  ```
  # Should all return 401:
  curl -s http://localhost:47778/api/dm/gorn
  curl -s http://localhost:47778/api/dm/bertus/karo
  curl -s http://localhost:47778/api/dm/dashboard
  curl -s http://localhost:47778/api/prowl

  # Should return 200 with own data only:
  curl -s -H "Authorization: Bearer $BEAST_TOKEN" http://localhost:47778/api/dm/karo

  # Should return 403 (cross-beast access):
  curl -s -H "Authorization: Bearer $KARO_TOKEN" http://localhost:47778/api/dm/bertus
  ```
- [ ] **QA pen (Pip)**: verify frontend (gorn session) still reads DM dashboard + conversations cleanly — no break to the only legitimate session-based caller.

## References

- T#795: HIGH severity, assignee @karo, reviewer @bertus, parent T#764-adjacent
- T#718: write-side spoof close (the requireBeastIdentity pattern this PR extends to reads)
- T#728: `?as=` migration on writes (token-scope rules superset what T#728 did for reads)
- Thread #20 (burrow-book-security) — Bertus's HIGH-finding post + PM intake chain

## Token-rotation defense-in-depth (Bertus DM 02:13 UTC)

Bertus flagged that a karo token from May 5 (suffix `...08c9954fc39c`) was observed in plaintext in a no-auth DM response. Programmatic suffix-compare via `.env` source confirmed: my current token (created 2026-05-10, expires 2026-05-14 23:05) does **not** match the observed suffix. Historical exposure only — no defense-in-depth rotation owed. This finding banks as a Principle 1 retention surface for future hygiene patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)