### PR TITLE
T#788: Migrate risk + prowl write handlers to requireBeastIdentity()

### DIFF
--- a/src/prowl/routes.ts
+++ b/src/prowl/routes.ts
@@ -95,13 +95,20 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // POST /api/prowl — create task
   app.post('/api/prowl', async (c) => {
-    if (!hasSessionAuth(c) && !isTrustedRequest(c)) return c.json({ error: 'Authentication required' }, 403);
+    // T#788 — derive requester from auth-layer (T#718 pattern), reject body-asserted mismatch.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     try {
       const data = await c.req.json();
       if (!data.title?.trim()) return c.json({ error: 'title required' }, 400);
 
-      const requester = (c.req.query('as') || data.created_by || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-      if (!requester || !ALLOWED_PROWL_CREATORS.includes(requester)) {
+      if (data.created_by && data.created_by.toLowerCase() !== caller) {
+        return c.json({ error: 'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.' }, 403);
+      }
+      const requester = caller;
+      if (!ALLOWED_PROWL_CREATORS.includes(requester)) {
         return c.json({ error: `Only ${ALLOWED_PROWL_CREATORS.join(', ')} can create Prowl tasks` }, 403);
       }
 
@@ -138,8 +145,14 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // PATCH /api/prowl/:id — update task fields (T#619: Gorn, Sable, or Karo)
   app.patch('/api/prowl/:id', async (c) => {
-    const requester = c.req.query('as')?.toLowerCase();
-    if (!hasSessionAuth(c) && !(isTrustedRequest(c) && requester && ALLOWED_PROWL_MANAGERS.includes(requester))) return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can update Prowl tasks` }, 403);
+    // T#788 — derive caller from auth-layer.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can update Prowl tasks` }, 403);
+    }
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
     const existing = sqlite.prepare('SELECT * FROM prowl_tasks WHERE id = ?').get(id) as any;
@@ -175,8 +188,14 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // PATCH /api/prowl/:id/status — change status (T#619: Gorn, Sable, or Karo)
   app.patch('/api/prowl/:id/status', async (c) => {
-    const requester = c.req.query('as')?.toLowerCase();
-    if (!hasSessionAuth(c) && !(isTrustedRequest(c) && requester && ALLOWED_PROWL_MANAGERS.includes(requester))) return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can change Prowl task status` }, 403);
+    // T#788 — derive caller from auth-layer.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can change Prowl task status` }, 403);
+    }
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
     const existing = sqlite.prepare('SELECT * FROM prowl_tasks WHERE id = ?').get(id) as any;
@@ -202,8 +221,14 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // POST /api/prowl/:id/toggle — quick toggle pending ↔ done (T#619: Gorn, Sable, or Karo)
   app.post('/api/prowl/:id/toggle', async (c) => {
-    const requester = c.req.query('as')?.toLowerCase();
-    if (!hasSessionAuth(c) && !(isTrustedRequest(c) && requester && ALLOWED_PROWL_MANAGERS.includes(requester))) return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can toggle Prowl tasks` }, 403);
+    // T#788 — derive caller from auth-layer.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can toggle Prowl tasks` }, 403);
+    }
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
     const existing = sqlite.prepare('SELECT * FROM prowl_tasks WHERE id = ?').get(id) as any;
@@ -222,8 +247,12 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // DELETE /api/prowl/:id — delete task (T#619: Gorn, Sable, or Karo)
   app.delete('/api/prowl/:id', async (c) => {
-    const requester = (c.req.query('as') || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-    if (!hasSessionAuth(c) && !(isTrustedRequest(c) && requester && ALLOWED_PROWL_MANAGERS.includes(requester))) {
+    // T#788 — derive caller from auth-layer.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
       return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can delete Prowl tasks` }, 403);
     }
     const id = parseInt(c.req.param('id'), 10);
@@ -260,8 +289,14 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // POST /api/prowl/:id/checklist — add checklist item
   app.post('/api/prowl/:id/checklist', async (c) => {
-    const requester = c.req.query('as')?.toLowerCase();
-    if (!hasSessionAuth(c) && !(isTrustedRequest(c) && requester && ALLOWED_PROWL_MANAGERS.includes(requester))) return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+    // T#788 — derive caller from auth-layer.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+    }
     const taskId = parseInt(c.req.param('id'), 10);
     if (isNaN(taskId)) return c.json({ error: 'Invalid ID' }, 400);
     const task = sqlite.prepare('SELECT id FROM prowl_tasks WHERE id = ?').get(taskId);
@@ -284,8 +319,14 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // PATCH /api/prowl/:id/checklist/:itemId — update checklist item (text, checked, sort_order)
   app.patch('/api/prowl/:id/checklist/:itemId', async (c) => {
-    const requester = c.req.query('as')?.toLowerCase();
-    if (!hasSessionAuth(c) && !(isTrustedRequest(c) && requester && ALLOWED_PROWL_MANAGERS.includes(requester))) return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+    // T#788 — derive caller from auth-layer.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+    }
     const taskId = parseInt(c.req.param('id'), 10);
     const itemId = parseInt(c.req.param('itemId'), 10);
     if (isNaN(taskId) || isNaN(itemId)) return c.json({ error: 'Invalid ID' }, 400);
@@ -317,8 +358,14 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // POST /api/prowl/:id/checklist/:itemId/toggle — quick toggle checked
   app.post('/api/prowl/:id/checklist/:itemId/toggle', (c) => {
-    const requester = c.req.query('as')?.toLowerCase();
-    if (!hasSessionAuth(c) && !(isTrustedRequest(c) && requester && ALLOWED_PROWL_MANAGERS.includes(requester))) return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+    // T#788 — derive caller from auth-layer.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+    }
     const taskId = parseInt(c.req.param('id'), 10);
     const itemId = parseInt(c.req.param('itemId'), 10);
     if (isNaN(taskId) || isNaN(itemId)) return c.json({ error: 'Invalid ID' }, 400);
@@ -334,8 +381,14 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // DELETE /api/prowl/:id/checklist/:itemId — delete checklist item
   app.delete('/api/prowl/:id/checklist/:itemId', (c) => {
-    const requester = (c.req.query('as') || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-    if (!hasSessionAuth(c) && !(isTrustedRequest(c) && requester && ALLOWED_PROWL_MANAGERS.includes(requester))) return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+    // T#788 — derive caller from auth-layer.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
+      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+    }
     const taskId = parseInt(c.req.param('id'), 10);
     const itemId = parseInt(c.req.param('itemId'), 10);
     if (isNaN(taskId) || isNaN(itemId)) return c.json({ error: 'Invalid ID' }, 400);

--- a/src/risk/routes.ts
+++ b/src/risk/routes.ts
@@ -6,11 +6,12 @@ const ALLOWED_RISK_CREATORS = ['gorn', 'bertus', 'talon'];
 
 interface RiskHelpers {
   hasSessionAuth: (c: Context) => boolean;
+  requireBeastIdentity: (c: Context) => string | null;
   wsBroadcast: (event: string, data: any) => void;
 }
 
 export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: RiskHelpers) {
-  const { hasSessionAuth, wsBroadcast } = helpers;
+  const { hasSessionAuth, requireBeastIdentity, wsBroadcast } = helpers;
 
   // GET /api/risks — list risks
   app.get('/api/risks', (c) => {
@@ -95,8 +96,16 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
       const data = await c.req.json();
       if (!data.title?.trim()) return c.json({ error: 'title required' }, 400);
 
-      const requester = (c.req.query('as') || data.created_by || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-      if (!requester || !ALLOWED_RISK_CREATORS.includes(requester)) {
+      // T#788 — derive requester from auth-layer (T#718 pattern), reject body-asserted mismatch.
+      const caller = requireBeastIdentity(c);
+      if (!caller) {
+        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      }
+      if (data.created_by && data.created_by.toLowerCase() !== caller) {
+        return c.json({ error: 'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.' }, 403);
+      }
+      const requester = caller;
+      if (!ALLOWED_RISK_CREATORS.includes(requester)) {
         return c.json({ error: `Only ${ALLOWED_RISK_CREATORS.join(', ')} can create risks` }, 403);
       }
 
@@ -143,8 +152,12 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
     const existing = sqlite.prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL').get(id) as any;
     if (!existing) return c.json({ error: 'Risk not found' }, 404);
 
-    const requester = (c.req.query('as') || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-    if (!requester) return c.json({ error: 'Identity required' }, 400);
+    // T#788 — derive requester from auth-layer.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    const requester = caller;
 
     try {
       const data = await c.req.json();
@@ -226,8 +239,15 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
 
     try {
       const data = await c.req.json();
-      const author = (c.req.query('as') || data.author || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-      if (!author) return c.json({ error: 'Identity required: pass ?as=beast or author in body' }, 400);
+      // T#788 — derive author from auth-layer, reject body-asserted mismatch.
+      const caller = requireBeastIdentity(c);
+      if (!caller) {
+        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      }
+      if (data.author && data.author.toLowerCase() !== caller) {
+        return c.json({ error: 'Sender impersonation blocked. body.author must match authenticated caller or be omitted.' }, 403);
+      }
+      const author = caller;
       if (!data.content?.trim()) return c.json({ error: 'content required' }, 400);
 
       const contentText = data.content.trim();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1642,7 +1642,7 @@ registerProwlRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, requireBeas
 registerLibraryRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, searchIndexUpsert, searchIndexDelete, wsBroadcast });
 
 // Risk routes extracted to src/risk/routes.ts (T#769)
-registerRiskRoutes(app, sqlite, { hasSessionAuth, wsBroadcast });
+registerRiskRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, wsBroadcast });
 // Search routes + Meilisearch + FTS5 — extracted to src/search/routes.ts (T#771)
 initSearch(sqlite);
 registerSearchRoutes(app, sqlite, { hasSessionAuth, isLocalNetwork, isTrustedRequest, handleSearch });


### PR DESCRIPTION
## Summary

Closes [T#788](https://denbook.online/board/788) — risk + prowl write handlers use the spoofable `c.req.query('as') || data.created_by || hasSessionAuth(c)` pattern flagged by Bertus in #20 PR-71-75 review (May 13). Same class as T#718 write-spoof close for DM/forum/spec — risk + prowl missed the migration.

Fix: replace requester derivation with `requireBeastIdentity(c)`, 401 on no identity, 403 on body-asserted mismatch (`Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.`).

## Files changed

| File | Handlers migrated | Pattern |
|------|-------------------|---------|
| `src/risk/routes.ts` | POST /api/risks, PATCH /api/risks/:id, POST /api/risks/:id/comments | requireBeastIdentity + ALLOWED_RISK_CREATORS allowlist + body.created_by/author mismatch rejection |
| `src/prowl/routes.ts` | POST /api/prowl + 8 PATCH/POST/DELETE (incl. checklist) | requireBeastIdentity + ALLOWED_PROWL_CREATORS / ALLOWED_PROWL_MANAGERS allowlist + mismatch rejection |
| `src/server.ts` | line 4162 | pass `requireBeastIdentity` to `registerRiskRoutes` (already passed to `registerProwlRoutes` from T#795 P1) |

12 total handler migrations + 1 helper-interface update + 1 server.ts wire-up.

## Behavior matrix (after fix)

| Caller | Pre-fix | Post-fix |
|--------|---------|----------|
| Gorn session | works | works (`requireBeastIdentity → 'gorn'`) |
| Beast bearer in allowlist | works via `?as=` | works (bearer-derived caller) |
| Beast bearer NOT in allowlist | could pass via local-net + spoofed `?as=` | 403 (caller-vs-allowlist check) |
| Localhost no-auth | could pass via `isTrustedRequest` + `?as=` | 401 `requiresAuth:true` |
| Spoofed `body.created_by` mismatch | accepted | 403 `Sender impersonation blocked` |

## Test plan

- [x] `bunx tsc --noEmit` clean on changed files (no new type errors; pre-existing `server.ts:4162` OpenAPIHono generic mismatch unchanged, tracked separately).
- [x] Import-completeness: `requireBeastIdentity` reaches both routes via helpers parameter; same pattern as T#795 P1.
- [ ] **Runtime smoke (Bertus security-pen)**: deferred to deploy gate.
  ```
  # Expect 401:
  curl -X POST http://localhost:47778/api/risks -d '{"title":"test"}'
  
  # Expect 401:
  curl -X POST http://localhost:47778/api/prowl -d '{"title":"test"}'
  
  # Expect 403 (karo not in ALLOWED_RISK_CREATORS):
  curl -X POST -H "Authorization: Bearer $KARO_TOKEN" http://localhost:47778/api/risks -d '{"title":"test"}'
  
  # Expect 200 (karo IS in ALLOWED_PROWL_CREATORS):
  curl -X POST -H "Authorization: Bearer $KARO_TOKEN" http://localhost:47778/api/prowl -d '{"title":"test"}'
  
  # Expect 403 Sender impersonation blocked:
  curl -X POST -H "Authorization: Bearer $KARO_TOKEN" http://localhost:47778/api/prowl -d '{"title":"test","created_by":"gorn"}'
  ```
- [ ] **QA pen (Pip)**: frontend (gorn session) regression check — risk/prowl create + update + delete flows via UI still functional.

## References

- T#788: medium-priority follow-up to extraction cleanup wave
- T#718: write-side spoof close for DM/forum/spec — established the pattern
- T#795 P1: introduced `requireBeastIdentity` into `ProwlHelpers` for reads — this PR uses it for writes too
- Bertus #20 review of PRs #71-75 — original flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)