### PR TITLE
T#798 P3-A: Extract settings module from server.ts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -92,6 +92,7 @@ import { rbacMiddleware, getGuestAllowlist } from './server/rbac.ts';
 import type { Role } from './server/rbac.ts';
 import { registerGovernanceRoutes } from './governance/routes.ts';
 import { registerProwlRoutes } from './prowl/routes.ts';
+import { registerSettingsRoutes } from './settings/routes.ts';
 import { registerLibraryRoutes } from './library/routes.ts';
 import { registerRiskRoutes } from './risk/routes.ts';
 import { registerTelegramRoutes } from './telegram/routes.ts';
@@ -733,117 +734,8 @@ export function clearRateLimit(ip: string): void {
 // Settings Routes
 // ============================================================================
 
-// Get settings (no password hash exposed)
-app.get('/api/settings', (c) => {
-  const authEnabled = getSetting('auth_enabled') === 'true';
-  const localBypass = getSetting('auth_local_bypass') !== 'false';
-  const hasPassword = !!getSetting('auth_password_hash');
-  const vaultRepo = getSetting('vault_repo');
-
-  return c.json({
-    authEnabled,
-    localBypass,
-    hasPassword,
-    vaultRepo
-  });
-});
-
-// Update settings (Gorn only — reject beast API calls)
-app.post('/api/settings', async (c) => {
-  // Only allow from browser sessions (Gorn) or local requests, not beast API calls
-  const asParam = c.req.query('as');
-  if (asParam) {
-    const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
-    logSecurityEvent({
-      eventType: 'impersonation_blocked',
-      severity: 'warning',
-      actor: asParam,
-      actorType: 'beast',
-      target: '/api/settings',
-      details: { method: 'POST', blocked_reason: 'beast_api_call' },
-      ipSource: ip,
-      requestId: (c.get as any)('requestId'),
-    });
-    return c.json({ error: 'Settings can only be changed by Gorn via the UI' }, 403);
-  }
-  const body = await c.req.json();
-  if (body.as) {
-    return c.json({ error: 'Settings can only be changed by Gorn via the UI' }, 403);
-  }
-
-  // Handle password change
-  if (body.newPassword) {
-    // If password exists, require current password
-    const existingHash = getSetting('auth_password_hash');
-    if (existingHash) {
-      if (!body.currentPassword) {
-        return c.json({ error: 'Current password required' }, 400);
-      }
-      const valid = await Bun.password.verify(body.currentPassword, existingHash);
-      if (!valid) {
-        return c.json({ error: 'Current password is incorrect' }, 401);
-      }
-    }
-
-    // Hash and store new password
-    const hash = await Bun.password.hash(body.newPassword);
-    setSetting('auth_password_hash', hash);
-  }
-
-  // Handle removing password
-  if (body.removePassword === true) {
-    const existingHash = getSetting('auth_password_hash');
-    if (existingHash && body.currentPassword) {
-      const valid = await Bun.password.verify(body.currentPassword, existingHash);
-      if (!valid) {
-        return c.json({ error: 'Current password is incorrect' }, 401);
-      }
-    }
-    setSetting('auth_password_hash', null);
-    setSetting('auth_enabled', 'false');
-  }
-
-  // Handle auth enabled toggle
-  if (typeof body.authEnabled === 'boolean') {
-    // Can only enable auth if password is set
-    if (body.authEnabled && !getSetting('auth_password_hash')) {
-      return c.json({ error: 'Cannot enable auth without password' }, 400);
-    }
-    setSetting('auth_enabled', body.authEnabled ? 'true' : 'false');
-  }
-
-  // Handle local bypass toggle
-  if (typeof body.localBypass === 'boolean') {
-    setSetting('auth_local_bypass', body.localBypass ? 'true' : 'false');
-  }
-
-  // Log security settings changes
-  const changes: string[] = [];
-  if (body.newPassword) changes.push('password_changed');
-  if (body.removePassword) changes.push('password_removed');
-  if (typeof body.authEnabled === 'boolean') changes.push(`auth_${body.authEnabled ? 'enabled' : 'disabled'}`);
-  if (typeof body.localBypass === 'boolean') changes.push(`local_bypass_${body.localBypass ? 'enabled' : 'disabled'}`);
-  if (changes.length > 0) {
-    const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
-    logSecurityEvent({
-      eventType: 'settings_changed',
-      severity: 'warning',
-      actor: 'gorn',
-      actorType: 'human',
-      target: '/api/settings',
-      details: { changes },
-      ipSource: ip,
-      requestId: (c.get as any)('requestId'),
-    });
-  }
-
-  return c.json({
-    success: true,
-    authEnabled: getSetting('auth_enabled') === 'true',
-    localBypass: getSetting('auth_local_bypass') !== 'false',
-    hasPassword: !!getSetting('auth_password_hash')
-  });
-});
+// Settings routes extracted to src/settings/routes.ts (T#798 P3-A)
+registerSettingsRoutes(app, { getSetting, setSetting, logSecurityEvent });
 
 // ============================================================================
 // API Routes

--- a/src/settings/routes.ts
+++ b/src/settings/routes.ts
@@ -1,0 +1,124 @@
+import type { Context } from 'hono';
+import type { OpenAPIHono } from '@hono/zod-openapi';
+
+interface SettingsHelpers {
+  getSetting: (key: string) => string | null;
+  setSetting: (key: string, value: string | null) => void;
+  logSecurityEvent: (event: any) => void;
+}
+
+export function registerSettingsRoutes(app: OpenAPIHono, helpers: SettingsHelpers) {
+  const { getSetting, setSetting, logSecurityEvent } = helpers;
+
+  // Get settings (no password hash exposed)
+  app.get('/api/settings', (c) => {
+    const authEnabled = getSetting('auth_enabled') === 'true';
+    const localBypass = getSetting('auth_local_bypass') !== 'false';
+    const hasPassword = !!getSetting('auth_password_hash');
+    const vaultRepo = getSetting('vault_repo');
+
+    return c.json({
+      authEnabled,
+      localBypass,
+      hasPassword,
+      vaultRepo
+    });
+  });
+
+  // Update settings (Gorn only — reject beast API calls)
+  app.post('/api/settings', async (c) => {
+    // Only allow from browser sessions (Gorn) or local requests, not beast API calls
+    const asParam = c.req.query('as');
+    if (asParam) {
+      const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+      logSecurityEvent({
+        eventType: 'impersonation_blocked',
+        severity: 'warning',
+        actor: asParam,
+        actorType: 'beast',
+        target: '/api/settings',
+        details: { method: 'POST', blocked_reason: 'beast_api_call' },
+        ipSource: ip,
+        requestId: (c.get as any)('requestId'),
+      });
+      return c.json({ error: 'Settings can only be changed by Gorn via the UI' }, 403);
+    }
+    const body = await c.req.json();
+    if (body.as) {
+      return c.json({ error: 'Settings can only be changed by Gorn via the UI' }, 403);
+    }
+
+    // Handle password change
+    if (body.newPassword) {
+      // If password exists, require current password
+      const existingHash = getSetting('auth_password_hash');
+      if (existingHash) {
+        if (!body.currentPassword) {
+          return c.json({ error: 'Current password required' }, 400);
+        }
+        const valid = await Bun.password.verify(body.currentPassword, existingHash);
+        if (!valid) {
+          return c.json({ error: 'Current password is incorrect' }, 401);
+        }
+      }
+
+      // Hash and store new password
+      const hash = await Bun.password.hash(body.newPassword);
+      setSetting('auth_password_hash', hash);
+    }
+
+    // Handle removing password
+    if (body.removePassword === true) {
+      const existingHash = getSetting('auth_password_hash');
+      if (existingHash && body.currentPassword) {
+        const valid = await Bun.password.verify(body.currentPassword, existingHash);
+        if (!valid) {
+          return c.json({ error: 'Current password is incorrect' }, 401);
+        }
+      }
+      setSetting('auth_password_hash', null);
+      setSetting('auth_enabled', 'false');
+    }
+
+    // Handle auth enabled toggle
+    if (typeof body.authEnabled === 'boolean') {
+      // Can only enable auth if password is set
+      if (body.authEnabled && !getSetting('auth_password_hash')) {
+        return c.json({ error: 'Cannot enable auth without password' }, 400);
+      }
+      setSetting('auth_enabled', body.authEnabled ? 'true' : 'false');
+    }
+
+    // Handle local bypass toggle
+    if (typeof body.localBypass === 'boolean') {
+      setSetting('auth_local_bypass', body.localBypass ? 'true' : 'false');
+    }
+
+    // Log security settings changes
+    const changes: string[] = [];
+    if (body.newPassword) changes.push('password_changed');
+    if (body.removePassword) changes.push('password_removed');
+    if (typeof body.authEnabled === 'boolean') changes.push(`auth_${body.authEnabled ? 'enabled' : 'disabled'}`);
+    if (typeof body.localBypass === 'boolean') changes.push(`local_bypass_${body.localBypass ? 'enabled' : 'disabled'}`);
+    if (changes.length > 0) {
+      const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+      logSecurityEvent({
+        eventType: 'settings_changed',
+        severity: 'warning',
+        actor: 'gorn',
+        actorType: 'human',
+        target: '/api/settings',
+        details: { changes },
+        ipSource: ip,
+        requestId: (c.get as any)('requestId'),
+      });
+    }
+
+    return c.json({
+      success: true,
+      authEnabled: getSetting('auth_enabled') === 'true',
+      localBypass: getSetting('auth_local_bypass') !== 'false',
+      hasPassword: !!getSetting('auth_password_hash')
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes [T#798](https://denbook.online/board/798) — first sub-task of [T#786](https://denbook.online/board/786) Phase 3 of [T#764](https://denbook.online/board/764) Library #102 modularization.

Extracts the 2 settings handlers (~110 LoC) from `server.ts` into `src/settings/routes.ts` following the Phase 1 module pattern (T#769-T#784). Behavior preserved exactly.

- `server.ts`: 4428L → 4320L (-108L)
- New: `src/settings/routes.ts` (124L)

## Files changed

| File | Change |
|------|--------|
| `src/settings/routes.ts` | **new** — `registerSettingsRoutes(app, helpers)` registrar with SettingsHelpers DI (getSetting, setSetting, logSecurityEvent) + 2 handlers (GET + POST /api/settings) extracted verbatim |
| `src/server.ts` | Add import; replace 110-line inline handler block at lines 736-846 with single `registerSettingsRoutes(app, { getSetting, setSetting, logSecurityEvent })` call |

Registration call placed at the same approximate location as the prior inline handlers, well before the SPA fallback catch-all (line 4227). Bug-class avoided: `module-registration-must-precede-spa-catch-all` (T#783 hotfix lesson).

## Test plan

- [x] `bunx tsc --noEmit` clean on changed files. Zero new type errors introduced; pre-existing errors at `src/server.ts:2531/2608/2614` (FormData upload handler) and `4081/4085` (OpenAPIHono AppEnv/Env mismatch) are unchanged and tracked separately.
- [x] Import-completeness: `registerSettingsRoutes` is the only new symbol reaching server.ts; the helpers (`getSetting`, `setSetting`, `logSecurityEvent`) are already imported in server.ts and just passed through DI.
- [ ] **Runtime smoke** at deploy gate:
  ```
  # Expect 200 with shape {authEnabled, localBypass, hasPassword, vaultRepo}:
  curl http://localhost:47778/api/settings

  # Expect 403 + impersonation_blocked security event:
  curl -X POST 'http://localhost:47778/api/settings?as=karo' -H 'Content-Type: application/json' -d '{}'

  # Expect 200 + settings_changed security event (gorn session):
  curl -X POST 'http://localhost:47778/api/settings' --cookie 'oracle_session=...' -H 'Content-Type: application/json' -d '{"localBypass":true}'
  ```

Reviewer: @zaghnal per task assignment.

## References

- T#798: sub-task of T#786 P3 (sibling under T#764 per Spec #56 v1 2-level constraint)
- T#786: parent phase task (Library #102 final cleanup, server.ts ~500L target)
- T#783: established the module-registration-must-precede-SPA-catch-all rule
- T#769-T#784: Phase 1 modularization pattern this PR follows

## Next in lane

T#799 (P3-D remote, 3 handlers, ~90 LoC) per the proposed order: A → D → F → I → G → H → E → J → B → C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)