### PR TITLE
T#799 P3-D: Extract remote module from server.ts

### DIFF
--- a/src/remote/routes.ts
+++ b/src/remote/routes.ts
@@ -1,0 +1,111 @@
+import type { Context } from 'hono';
+import type { OpenAPIHono } from '@hono/zod-openapi';
+import { execSync } from 'child_process';
+
+const REMOTE_SESSION = 'Mindlink';
+
+interface RemoteHelpers {
+  isLocalNetwork: (c: Context) => boolean;
+  hasSessionAuth: (c: Context) => boolean;
+}
+
+export function registerRemoteRoutes(app: OpenAPIHono, helpers: RemoteHelpers) {
+  const { isLocalNetwork, hasSessionAuth } = helpers;
+
+  // Module-local attached-beast state. Reset on server restart (intentional —
+  // tmux session is the source of truth, this is a fast-path cache).
+  let attachedBeastName: string | null = null;
+
+  // GET /api/remote/status — which beast is currently attached
+  app.get('/api/remote/status', (c) => {
+    // Verify the Remote session still exists and has a linked window
+    if (attachedBeastName) {
+      try {
+        execSync(`tmux has-session -t ${JSON.stringify(REMOTE_SESSION)}`, { timeout: 2000 });
+        // Check if window 1 still exists (beast is still linked)
+        const windows = execSync(
+          `tmux list-windows -t ${JSON.stringify(REMOTE_SESSION)} -F "#{window_index}"`,
+          { timeout: 2000 }
+        ).toString().trim().split('\n');
+        if (!windows.includes('1')) {
+          attachedBeastName = null; // Window was unlinked externally
+        }
+      } catch {
+        attachedBeastName = null; // Session gone
+      }
+    }
+
+    return c.json({ session_exists: !!attachedBeastName, attached_beast: attachedBeastName });
+  });
+
+  // POST /api/remote/attach — attach a beast's claude window (local only — requires tmux)
+  app.post('/api/remote/attach', async (c) => {
+    // Remote attach requires local tmux access — reject non-local requests cleanly
+    if (!isLocalNetwork(c) && !hasSessionAuth(c)) {
+      return c.json({ error: 'forbidden' }, 403);
+    }
+    try {
+      const data = await c.req.json();
+      const beastName = data.beast?.toLowerCase();
+      if (!beastName) return c.json({ error: 'beast name required' }, 400);
+
+      // Sanitize: only allow alphanumeric beast names
+      if (!/^[a-z]+$/.test(beastName)) return c.json({ error: 'Invalid beast name' }, 400);
+
+      const sessionName = beastName.charAt(0).toUpperCase() + beastName.slice(1);
+
+      // Verify beast session exists
+      try {
+        execSync(`tmux has-session -t ${JSON.stringify(sessionName)}`, { timeout: 2000 });
+      } catch {
+        return c.json({ error: `No tmux session for ${beastName}` }, 404);
+      }
+
+      // Find the claude window index in the beast's session
+      let claudeWindow = '1';
+      try {
+        const windows = execSync(
+          `tmux list-windows -t ${JSON.stringify(sessionName)} -F "#{window_index}:#{pane_current_command}"`,
+          { timeout: 2000 }
+        ).toString().trim().split('\n');
+        const claudeWin = windows.find(w => w.includes(':claude'));
+        if (claudeWin) claudeWindow = claudeWin.split(':')[0];
+      } catch { /* default to 1 */ }
+
+      // Ensure Remote session exists
+      try {
+        execSync(`tmux has-session -t ${JSON.stringify(REMOTE_SESSION)}`, { timeout: 2000 });
+      } catch {
+        execSync(`tmux new-session -d -s ${JSON.stringify(REMOTE_SESSION)}`, { timeout: 2000 });
+      }
+
+      // Unlink any existing beast window (window index 1)
+      try {
+        execSync(`tmux unlink-window -k -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
+      } catch { /* no window to unlink */ }
+
+      // Link the beast's claude window
+      execSync(
+        `tmux link-window -s ${JSON.stringify(sessionName)}:${claudeWindow} -t ${JSON.stringify(REMOTE_SESSION)}:1`,
+        { timeout: 2000 }
+      );
+
+      // Switch to the linked window
+      execSync(`tmux select-window -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
+
+      attachedBeastName = beastName;
+      return c.json({ attached: beastName, session: REMOTE_SESSION });
+    } catch (e) {
+      return c.json({ error: e instanceof Error ? e.message : 'Attach failed' }, 500);
+    }
+  });
+
+  // POST /api/remote/detach — detach current beast (local only — requires tmux)
+  app.post('/api/remote/detach', (_c) => {
+    try {
+      execSync(`tmux unlink-window -k -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
+    } catch { /* already detached */ }
+    attachedBeastName = null;
+    return _c.json({ detached: true });
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -93,6 +93,7 @@ import type { Role } from './server/rbac.ts';
 import { registerGovernanceRoutes } from './governance/routes.ts';
 import { registerProwlRoutes } from './prowl/routes.ts';
 import { registerSettingsRoutes } from './settings/routes.ts';
+import { registerRemoteRoutes } from './remote/routes.ts';
 import { registerLibraryRoutes } from './library/routes.ts';
 import { registerRiskRoutes } from './risk/routes.ts';
 import { registerTelegramRoutes } from './telegram/routes.ts';
@@ -2336,101 +2337,8 @@ function getTmuxStatus(): { tmuxStatus: Map<string, 'processing' | 'idle' | 'wai
 // Remote Control — tmux Beast switcher
 // ============================================================================
 
-const REMOTE_SESSION = 'Mindlink';
-let attachedBeastName: string | null = null;
-
-// GET /api/remote/status — which beast is currently attached
-app.get('/api/remote/status', (c) => {
-  // Verify the Remote session still exists and has a linked window
-  if (attachedBeastName) {
-    try {
-      execSync(`tmux has-session -t ${JSON.stringify(REMOTE_SESSION)}`, { timeout: 2000 });
-      // Check if window 1 still exists (beast is still linked)
-      const windows = execSync(
-        `tmux list-windows -t ${JSON.stringify(REMOTE_SESSION)} -F "#{window_index}"`,
-        { timeout: 2000 }
-      ).toString().trim().split('\n');
-      if (!windows.includes('1')) {
-        attachedBeastName = null; // Window was unlinked externally
-      }
-    } catch {
-      attachedBeastName = null; // Session gone
-    }
-  }
-
-  return c.json({ session_exists: !!attachedBeastName, attached_beast: attachedBeastName });
-});
-
-// POST /api/remote/attach — attach a beast's claude window (local only — requires tmux)
-app.post('/api/remote/attach', async (c) => {
-  // Remote attach requires local tmux access — reject non-local requests cleanly
-  if (!isLocalNetwork(c) && !hasSessionAuth(c)) {
-    return c.json({ error: 'forbidden' }, 403);
-  }
-  try {
-    const data = await c.req.json();
-    const beastName = data.beast?.toLowerCase();
-    if (!beastName) return c.json({ error: 'beast name required' }, 400);
-
-    // Sanitize: only allow alphanumeric beast names
-    if (!/^[a-z]+$/.test(beastName)) return c.json({ error: 'Invalid beast name' }, 400);
-
-    const sessionName = beastName.charAt(0).toUpperCase() + beastName.slice(1);
-
-    // Verify beast session exists
-    try {
-      execSync(`tmux has-session -t ${JSON.stringify(sessionName)}`, { timeout: 2000 });
-    } catch {
-      return c.json({ error: `No tmux session for ${beastName}` }, 404);
-    }
-
-    // Find the claude window index in the beast's session
-    let claudeWindow = '1';
-    try {
-      const windows = execSync(
-        `tmux list-windows -t ${JSON.stringify(sessionName)} -F "#{window_index}:#{pane_current_command}"`,
-        { timeout: 2000 }
-      ).toString().trim().split('\n');
-      const claudeWin = windows.find(w => w.includes(':claude'));
-      if (claudeWin) claudeWindow = claudeWin.split(':')[0];
-    } catch { /* default to 1 */ }
-
-    // Ensure Remote session exists
-    try {
-      execSync(`tmux has-session -t ${JSON.stringify(REMOTE_SESSION)}`, { timeout: 2000 });
-    } catch {
-      execSync(`tmux new-session -d -s ${JSON.stringify(REMOTE_SESSION)}`, { timeout: 2000 });
-    }
-
-    // Unlink any existing beast window (window index 1)
-    try {
-      execSync(`tmux unlink-window -k -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
-    } catch { /* no window to unlink */ }
-
-    // Link the beast's claude window
-    execSync(
-      `tmux link-window -s ${JSON.stringify(sessionName)}:${claudeWindow} -t ${JSON.stringify(REMOTE_SESSION)}:1`,
-      { timeout: 2000 }
-    );
-
-    // Switch to the linked window
-    execSync(`tmux select-window -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
-
-    attachedBeastName = beastName;
-    return c.json({ attached: beastName, session: REMOTE_SESSION });
-  } catch (e) {
-    return c.json({ error: e instanceof Error ? e.message : 'Attach failed' }, 500);
-  }
-});
-
-// POST /api/remote/detach — detach current beast (local only — requires tmux)
-app.post('/api/remote/detach', (_c) => {
-  try {
-    execSync(`tmux unlink-window -k -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
-  } catch { /* already detached */ }
-  attachedBeastName = null;
-  return _c.json({ detached: true });
-});
+// Remote routes extracted to src/remote/routes.ts (T#799 P3-D)
+registerRemoteRoutes(app, { isLocalNetwork, hasSessionAuth });
 
 // ============================================================================
 // Beast Profile Routes


### PR DESCRIPTION
## Summary

Closes [T#799](https://denbook.online/board/799) — sub-task D of T#786 P3 (Library #102 modularization).

Extracts 3 remote tmux-window-attach handlers (~90 LoC) + `REMOTE_SESSION` constant + `attachedBeastName` state from `server.ts` into `src/remote/routes.ts`.

- `server.ts`: 4320L → 4228L (-92L)
- New: `src/remote/routes.ts` (111L)

## Files changed

| File | Change |
|------|--------|
| `src/remote/routes.ts` | **new** — `registerRemoteRoutes(app, helpers)` with RemoteHelpers DI (`isLocalNetwork`, `hasSessionAuth`); module-local `REMOTE_SESSION` constant + `attachedBeastName` state (closure-scoped, resets on server restart); 3 handlers extracted verbatim |
| `src/server.ts` | Add import; remove `REMOTE_SESSION` constant + `attachedBeastName`; replace 3 inline handler blocks (~92L) with single `registerRemoteRoutes(app, { isLocalNetwork, hasSessionAuth })` call |

`execSync` import in `server.ts` preserved — still used by beast-terminal endpoints (lines 2217/2225/2240), separate concern.

## Test plan

- [x] `bun build src/server.ts --target=bun --outdir=/tmp/t799-build` clean — all imports resolve at bundle-time (per Norm #84 refinement pattern Zaghnal acked at T#798 #1135).
- [x] DI captures all closure deps explicitly.
- [x] `REMOTE_SESSION` moved into the module that uses it — no orphaned constant in server.ts.
- [x] Module registration at line 2340 < SPA fallback at 4119 (T#783 lesson respected).
- [ ] Post-deploy smoke:
  ```
  # Expect 200 + {session_exists, attached_beast}:
  curl http://localhost:47778/api/remote/status

  # Expect 400 Invalid beast name:
  curl -X POST http://localhost:47778/api/remote/attach -H 'Content-Type: application/json' -d '{"beast":"123"}'

  # Expect 403 forbidden (non-local, no session):
  curl -X POST http://example.com/api/remote/attach -d '{"beast":"karo"}'  # remote test, optional
  ```

Reviewer: @zaghnal per task assignment.

## References

- T#799: sub-task of T#786 P3
- T#798: established bundle-build + post-deploy smoke pattern (Zaghnal CLEAR + merge at #1135)

## Next in lane

T#800 P3-F queue + gorn (3 handlers, ~50 LoC) per A → D → F → I → G → H → E → J → B → C order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)