### PR TITLE
T#801 P3-I: Extract supersede module from server.ts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -95,6 +95,7 @@ import { registerProwlRoutes } from './prowl/routes.ts';
 import { registerSettingsRoutes } from './settings/routes.ts';
 import { registerRemoteRoutes } from './remote/routes.ts';
 import { registerQueueRoutes } from './queue/routes.ts';
+import { registerSupersedeRoutes } from './supersede/routes.ts';
 import { registerLibraryRoutes } from './library/routes.ts';
 import { registerRiskRoutes } from './risk/routes.ts';
 import { registerTelegramRoutes } from './telegram/routes.ts';
@@ -3368,115 +3369,8 @@ registerDaemonRoutes(app, sqlite);
 // Withings auto-sync daemon — moved to src/integrations/routes.ts initIntegrations() (T#775)
 
 
-// List supersessions with optional filters
-app.get('/api/supersede', (c) => {
-  const project = c.req.query('project');
-  const limit = parseInt(c.req.query('limit') || '50');
-  const offset = parseInt(c.req.query('offset') || '0');
-
-  // Build where clause using Drizzle
-  const whereClause = project ? eq(supersedeLog.project, project) : undefined;
-
-  // Get total count using Drizzle
-  const countResult = db.select({ total: sql<number>`count(*)` })
-    .from(supersedeLog)
-    .where(whereClause)
-    .get();
-  const total = countResult?.total || 0;
-
-  // Get logs using Drizzle
-  const logs = db.select()
-    .from(supersedeLog)
-    .where(whereClause)
-    .orderBy(desc(supersedeLog.supersededAt))
-    .limit(limit)
-    .offset(offset)
-    .all();
-
-  return c.json({
-    supersessions: logs.map(log => ({
-      id: log.id,
-      old_path: log.oldPath,
-      old_id: log.oldId,
-      old_title: log.oldTitle,
-      old_type: log.oldType,
-      new_path: log.newPath,
-      new_id: log.newId,
-      new_title: log.newTitle,
-      reason: log.reason,
-      superseded_at: new Date(log.supersededAt).toISOString(),
-      superseded_by: log.supersededBy,
-      project: log.project
-    })),
-    total,
-    limit,
-    offset
-  });
-});
-
-// Get supersede chain for a document (what superseded what)
-app.get('/api/supersede/chain/:path', (c) => {
-  const docPath = decodeURIComponent(c.req.param('path'));
-
-  // Find all supersessions where this doc was old or new using Drizzle
-  const asOld = db.select()
-    .from(supersedeLog)
-    .where(eq(supersedeLog.oldPath, docPath))
-    .orderBy(supersedeLog.supersededAt)
-    .all();
-
-  const asNew = db.select()
-    .from(supersedeLog)
-    .where(eq(supersedeLog.newPath, docPath))
-    .orderBy(supersedeLog.supersededAt)
-    .all();
-
-  return c.json({
-    superseded_by: asOld.map(log => ({
-      new_path: log.newPath,
-      reason: log.reason,
-      superseded_at: new Date(log.supersededAt).toISOString()
-    })),
-    supersedes: asNew.map(log => ({
-      old_path: log.oldPath,
-      reason: log.reason,
-      superseded_at: new Date(log.supersededAt).toISOString()
-    }))
-  });
-});
-
-// Log a new supersession
-app.post('/api/supersede', async (c) => {
-  try {
-    const data = await c.req.json();
-    if (!data.old_path) {
-      return c.json({ error: 'Missing required field: old_path' }, 400);
-    }
-
-    const result = db.insert(supersedeLog).values({
-      oldPath: data.old_path,
-      oldId: data.old_id || null,
-      oldTitle: data.old_title || null,
-      oldType: data.old_type || null,
-      newPath: data.new_path || null,
-      newId: data.new_id || null,
-      newTitle: data.new_title || null,
-      reason: data.reason || null,
-      supersededAt: Date.now(),
-      supersededBy: data.superseded_by || 'user',
-      project: data.project || null
-    }).returning({ id: supersedeLog.id }).get();
-
-    return c.json({
-      id: result.id,
-      message: 'Supersession logged'
-    }, 201);
-  } catch (error) {
-    return c.json({
-      error: error instanceof Error ? error.message : 'Unknown error'
-    }, 500);
-  }
-});
+// Supersede routes extracted to src/supersede/routes.ts (T#801 P3-I)
+registerSupersedeRoutes(app);
 
 // ============================================================================
 // Trace Routes - Discovery journey visualization

--- a/src/supersede/routes.ts
+++ b/src/supersede/routes.ts
@@ -1,0 +1,115 @@
+import type { OpenAPIHono } from '@hono/zod-openapi';
+import { eq, desc, sql } from 'drizzle-orm';
+import { db, supersedeLog } from '../db/index.ts';
+
+export function registerSupersedeRoutes(app: OpenAPIHono) {
+  // List supersessions with optional filters
+  app.get('/api/supersede', (c) => {
+    const project = c.req.query('project');
+    const limit = parseInt(c.req.query('limit') || '50');
+    const offset = parseInt(c.req.query('offset') || '0');
+
+    // Build where clause using Drizzle
+    const whereClause = project ? eq(supersedeLog.project, project) : undefined;
+
+    // Get total count using Drizzle
+    const countResult = db.select({ total: sql<number>`count(*)` })
+      .from(supersedeLog)
+      .where(whereClause)
+      .get();
+    const total = countResult?.total || 0;
+
+    // Get logs using Drizzle
+    const logs = db.select()
+      .from(supersedeLog)
+      .where(whereClause)
+      .orderBy(desc(supersedeLog.supersededAt))
+      .limit(limit)
+      .offset(offset)
+      .all();
+
+    return c.json({
+      supersessions: logs.map(log => ({
+        id: log.id,
+        old_path: log.oldPath,
+        old_id: log.oldId,
+        old_title: log.oldTitle,
+        old_type: log.oldType,
+        new_path: log.newPath,
+        new_id: log.newId,
+        new_title: log.newTitle,
+        reason: log.reason,
+        superseded_at: new Date(log.supersededAt).toISOString(),
+        superseded_by: log.supersededBy,
+        project: log.project
+      })),
+      total,
+      limit,
+      offset
+    });
+  });
+
+  // Get supersede chain for a document (what superseded what)
+  app.get('/api/supersede/chain/:path', (c) => {
+    const docPath = decodeURIComponent(c.req.param('path'));
+
+    // Find all supersessions where this doc was old or new using Drizzle
+    const asOld = db.select()
+      .from(supersedeLog)
+      .where(eq(supersedeLog.oldPath, docPath))
+      .orderBy(supersedeLog.supersededAt)
+      .all();
+
+    const asNew = db.select()
+      .from(supersedeLog)
+      .where(eq(supersedeLog.newPath, docPath))
+      .orderBy(supersedeLog.supersededAt)
+      .all();
+
+    return c.json({
+      superseded_by: asOld.map(log => ({
+        new_path: log.newPath,
+        reason: log.reason,
+        superseded_at: new Date(log.supersededAt).toISOString()
+      })),
+      supersedes: asNew.map(log => ({
+        old_path: log.oldPath,
+        reason: log.reason,
+        superseded_at: new Date(log.supersededAt).toISOString()
+      }))
+    });
+  });
+
+  // Log a new supersession
+  app.post('/api/supersede', async (c) => {
+    try {
+      const data = await c.req.json();
+      if (!data.old_path) {
+        return c.json({ error: 'Missing required field: old_path' }, 400);
+      }
+
+      const result = db.insert(supersedeLog).values({
+        oldPath: data.old_path,
+        oldId: data.old_id || null,
+        oldTitle: data.old_title || null,
+        oldType: data.old_type || null,
+        newPath: data.new_path || null,
+        newId: data.new_id || null,
+        newTitle: data.new_title || null,
+        reason: data.reason || null,
+        supersededAt: Date.now(),
+        supersededBy: data.superseded_by || 'user',
+        project: data.project || null
+      }).returning({ id: supersedeLog.id }).get();
+
+      return c.json({
+        id: result.id,
+        message: 'Supersession logged'
+      }, 201);
+    } catch (error) {
+      return c.json({
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }, 500);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Closes [T#801](https://denbook.online/board/801) — sub-task I of T#786 P3.

Extracts 3 supersede handlers (~106 LoC) from `server.ts` into `src/supersede/routes.ts`. Module imports drizzle (`db`, `supersedeLog`, `eq`, `desc`, `sql`) directly — no DI helpers needed (cleaner shape than DI-required modules).

- `server.ts`: 4160L → 4054L (-106L)
- New: `src/supersede/routes.ts` (115L)

## Test plan
- [x] bun build clean (Norm #84 Layer 1)
- [x] Module registration before SPA fallback (T#783 lesson)
- [ ] Post-deploy smoke: GET /api/supersede → 200 + {supersessions, total, limit, offset} shape

Reviewer: @zaghnal.

## Next in lane
T#802 P3-G audit + security/events (4 handlers, ~140 LoC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)