### PR TITLE
Hotfix T#811: export HELP_ENDPOINTS for 404 handler

### DIFF
--- a/src/knowledge/routes.ts
+++ b/src/knowledge/routes.ts
@@ -14,7 +14,7 @@ import { getVaultPsiRoot } from '../vault/handler.ts';
 import type { ToolContext } from '../tools/types.ts';
 
 // Endpoint catalog — shared by /api/help and 404 handler
-const HELP_ENDPOINTS = [
+export const HELP_ENDPOINTS = [
     // Auth
     { method: 'GET', path: '/api/auth/status', desc: 'Check if session is authenticated', params: null },
     { method: 'POST', path: '/api/auth/login', desc: 'Login with password', params: 'body: { password }' },

--- a/src/server.ts
+++ b/src/server.ts
@@ -100,7 +100,7 @@ import { registerAuditRoutes } from './audit/routes.ts';
 import { registerTeamsRoutes } from './teams/routes.ts';
 import { registerFilesRoutes } from './files/routes.ts';
 import { registerInboxRoutes } from './inbox/routes.ts';
-import { registerKnowledgeRoutes } from './knowledge/routes.ts';
+import { registerKnowledgeRoutes, HELP_ENDPOINTS } from './knowledge/routes.ts';
 import { registerGuestRoutes } from './guest/routes.ts';
 import { registerLibraryRoutes } from './library/routes.ts';
 import { registerRiskRoutes } from './risk/routes.ts';
@@ -227,7 +227,7 @@ const UPLOADS_DIR = path.join(ORACLE_DATA_DIR, 'uploads');
 const ARCHIVE_DIR = path.join(ORACLE_DATA_DIR, 'uploads', 'archive');
 
 // Custom 404 with did-you-mean hints for API routes
-// Uses HELP_ENDPOINTS (defined below with /api/help) for path matching
+// HELP_ENDPOINTS imported from ./knowledge/routes.ts (T#806 extraction; T#811 hotfix)
 function findSimilarPaths(requested: string): string[] {
   const reqParts = requested.toLowerCase().split('/').filter(Boolean);
   const paths = HELP_ENDPOINTS.map(e => e.path);


### PR DESCRIPTION
## Summary

- T#806 P3-B (`b4481cd`) extracted `HELP_ENDPOINTS` into `src/knowledge/routes.ts` but left the reference in `server.ts:findSimilarPaths` stale. Any `/api/*` 404 hit `ReferenceError` → 500 instead of the did-you-mean 404 handler.
- Fix: `export const HELP_ENDPOINTS` from knowledge module + import in server.ts. Single-symbol re-export, minimum-diff shape.
- Class: extraction-import-completeness-check (banked for /denbook v1.0.X). Sister to T#807 TDZ hotfix.

## Repro (pre-fix)

```
curl http://localhost:47778/api/this-route-definitely-does-not-exist → 500
ReferenceError: HELP_ENDPOINTS is not defined at findSimilarPaths (server.ts:233)
```

## Expected (post-fix)

```
HTTP 404 + JSON body with did-you-mean hints
```

## Reviewers

- Code-side: @zaghnal
- Security-pen: @bertus (already confirmed no security impact in task #811)
- QA: @pip (filer)

## Test plan

- [ ] `bun build src/server.ts --target=bun --outdir=/tmp` succeeds
- [ ] Deploy → `curl /api/foo-does-not-exist` returns 404 + suggestions
- [ ] `curl /api/help` still returns full catalog (knowledge module intact)
- [ ] Other 404 paths (`/api/forge`, `/api/integrations`) return 404 not 500

Tracks: T#811

🤖 Generated with [Claude Code](https://claude.com/claude-code)