### PR TITLE
T#814: auth-first ordering on POST /api/risks

### DIFF
--- a/src/risk/routes.ts
+++ b/src/risk/routes.ts
@@ -92,15 +92,16 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
 
   // POST /api/risks — create risk (Gorn, Bertus, Talon)
   app.post('/api/risks', async (c) => {
+    // T#814 — auth-first ordering: 401 fires before body-validation leaks endpoint shape.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     try {
       const data = await c.req.json();
       if (!data.title?.trim()) return c.json({ error: 'title required' }, 400);
 
-      // T#788 — derive requester from auth-layer (T#718 pattern), reject body-asserted mismatch.
-      const caller = requireBeastIdentity(c);
-      if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
-      }
+      // T#788 — reject body-asserted mismatch.
       if (data.created_by && data.created_by.toLowerCase() !== caller) {
         return c.json({ error: 'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.' }, 403);
       }


### PR DESCRIPTION
## Summary

Fix handler step-order inconsistency on `POST /api/risks` — `requireBeastIdentity()` was running AFTER `c.req.json()` + title-validation, so empty-body no-auth probes returned `400 title required` instead of `401 Beast identity required`. Leaks endpoint-shape to unauthed callers as defense-in-depth gap.

Pre-existing — T#788 preserved the existing order. This is the orthogonal step-order class Pip QA-self-banked (#12523) and Zaghnal filed as T#814 follow-up.

## Diff

`src/risk/routes.ts`: 6/-5 lines. Move `requireBeastIdentity()` + 401 return above the `try { c.req.json() }` block. Other handlers in the file (`PATCH /api/risks/:id`, `POST /api/risks/:id/comments`) were already auth-first (per Bertus correction #12525).

## Test plan

Post-deploy smoke:
- `POST /api/risks {}` no-auth → expect **401** (was 400 title-required)
- `POST /api/risks {"title":"x"}` no-auth → expect **401** (was 401, unchanged)
- `POST /api/risks` with bearer=bertus → expect **201** legit create (unchanged)
- `POST /api/risks` with bearer=karo → expect **403** allowlist-block (unchanged)

## Risk

LOW. No behavior change for authenticated callers. Single-handler scope. No new auth surface — pure ordering. Same class as the T#788 cascade pattern, applied to one handler's internal step-order.

## Refs

- Bertus security cycle #12519 (2026-05-15 09:15 BKK)
- Pip QA-pen-miss self-bank #12523
- Zaghnal scope-resolved #1186 narrowed to single handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)