### PR TITLE
T#819: requireBeastIdentity cascade on board/routes.ts (8 endpoints, T#788 sister-class)

### DIFF
--- a/src/board/routes.ts
+++ b/src/board/routes.ts
@@ -137,9 +137,18 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // POST /api/projects — create project
   app.post('/api/projects', async (c) => {
+    // T#819 — auth-derive (T#788 pattern), reject body-asserted mismatch.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     const data = await c.req.json();
-    const { name, description, created_by } = data;
-    if (!name || !created_by) return c.json({ error: 'name and created_by required' }, 400);
+    const { name, description } = data;
+    if (!name) return c.json({ error: 'name required' }, 400);
+    if (data.created_by && data.created_by.toLowerCase() !== caller) {
+      return c.json({ error: 'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.' }, 403);
+    }
+    const created_by = caller;
     const now = new Date().toISOString();
     const result = sqlite.prepare(
       'INSERT INTO projects (name, description, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
@@ -162,6 +171,11 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // PATCH /api/projects/:id — update project
   app.patch('/api/projects/:id', async (c) => {
+    // T#819 — auth-first.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     const id = parseInt(c.req.param('id'), 10);
     const data = await c.req.json();
     const updates: string[] = [];
@@ -179,7 +193,11 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // DELETE /api/projects/:id — delete project (Gorn or Pip)
   app.delete('/api/projects/:id', (c) => {
-    const requester = (c.req.query('as') || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
+    // T#819 — auth-derive (T#795 P1 pattern), close localhost-trust ?as= bypass class.
+    const requester = requireBeastIdentity(c);
+    if (!requester) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     if (requester !== 'gorn' && requester !== 'pip') {
       return c.json({ error: 'Only Gorn or Pip can delete projects' }, 403);
     }
@@ -251,9 +269,18 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // POST /api/tasks — create task
   app.post('/api/tasks', async (c) => {
+    // T#819 — auth-derive (T#788 pattern), reject body-asserted mismatch.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     const data = await c.req.json();
-    const { title, description, project_id, status, priority, assigned_to, created_by, thread_id, due_date, type, reviewer, risk_level, parent_task_id } = data;
-    if (!title || !created_by) return c.json({ error: 'title and created_by required' }, 400);
+    const { title, description, project_id, status, priority, assigned_to, thread_id, due_date, type, reviewer, risk_level, parent_task_id } = data;
+    if (!title) return c.json({ error: 'title required' }, 400);
+    if (data.created_by && data.created_by.toLowerCase() !== caller) {
+      return c.json({ error: 'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.' }, 403);
+    }
+    const created_by = caller;
     if (!project_id) return c.json({ error: 'project_id required — every task must belong to a project' }, 400);
     if (!assigned_to) return c.json({ error: 'assigned_to required — every task must have an assignee' }, 400);
     if (!reviewer) return c.json({ error: 'reviewer required — every task must have a reviewer for the in_review workflow' }, 400);
@@ -329,6 +356,11 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // PATCH /api/tasks/:id — update task
   app.patch('/api/tasks/:id', async (c) => {
+    // T#819 — auth-first.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     const id = parseInt(c.req.param('id'), 10);
     const existing = sqlite.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as any;
     if (!existing) return c.json({ error: 'Task not found' }, 404);
@@ -409,6 +441,11 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // DELETE /api/tasks/:id — soft delete (set status to 'deleted') + orphan subtasks (Bertus C4)
   app.delete('/api/tasks/:id', async (c) => {
+    // T#819 — auth-first. Closes anonymous soft-delete-any-task class (Bertus #12602 sharpest edge).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     const id = parseInt(c.req.param('id'), 10);
     const now = new Date().toISOString();
     sqlite.transaction(() => {
@@ -435,6 +472,11 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // POST /api/tasks/bulk-status — bulk status update (for PM)
   app.post('/api/tasks/bulk-status', async (c) => {
+    // T#819 — auth-first. Closes anonymous mass-mutate class.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     const data = await c.req.json();
     const { task_ids, status } = data;
     if (!Array.isArray(task_ids) || !status) return c.json({ error: 'task_ids and status required' }, 400);
@@ -475,10 +517,19 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // POST /api/tasks/:id/comments
   app.post('/api/tasks/:id/comments', async (c) => {
+    // T#819 — auth-derive (T#788 pattern), reject body-asserted mismatch.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
     const taskId = parseInt(c.req.param('id'), 10);
     const data = await c.req.json();
-    const { author, content } = data;
-    if (!author || !content) return c.json({ error: 'author and content required' }, 400);
+    const { content } = data;
+    if (!content) return c.json({ error: 'content required' }, 400);
+    if (data.author && data.author.toLowerCase() !== caller) {
+      return c.json({ error: 'Sender impersonation blocked. body.author must match authenticated caller or be omitted.' }, 403);
+    }
+    const author = caller;
 
     const now = new Date().toISOString();
     const result = sqlite.prepare(


### PR DESCRIPTION
## Summary

Closes T#788 sister-class miss on `src/board/routes.ts` surfaced by @bertus security cycle #12602. **No write endpoint in `board/routes.ts` was calling `requireBeastIdentity(c)`** — the helper was destructured at line 27 but never invoked across 8 handlers. This PR applies the auth-derive cascade pattern to all 8.

## Affected endpoints (8 total)

| Endpoint | Class | Body attribution |
|---|---|---|
| `POST /api/projects` | spoofable | `created_by` from body |
| `PATCH /api/projects/:id` | no-auth mutate | n/a |
| `DELETE /api/projects/:id` | no-auth delete + `?as=` query bypass | n/a |
| `POST /api/tasks` | spoofable + notify-channel | `created_by` from body |
| `PATCH /api/tasks/:id` | no-auth mutate | n/a |
| `DELETE /api/tasks/:id` | no-auth soft-delete-any-task (sharpest edge) | n/a |
| `POST /api/tasks/bulk-status` | no-auth mass-mutate | n/a |
| `POST /api/tasks/:id/comments` | spoofable | `author` from body |

## Pattern applied

Mirrors `dm/routes.ts:110-117` post-T#718. Each handler now:
1. Derives `caller` from auth-layer first (401 on missing identity)
2. POST handlers with body-asserted identity (`created_by` / `author`) reject mismatch with 403 ("Sender impersonation blocked")
3. `DELETE /projects/:id` additionally closes the localhost-trust `?as=` query bypass class (T#795 P1 pattern — was deriving requester from `c.req.query('as')` fallback)

## Test plan

Pre-merge probe matrix (verifies on each of 8 endpoints):
- Empty-body no-auth → **401 Beast identity required** (was 400 on POST, 200 on DELETE, etc.)
- Valid-body no-auth → **401** (unchanged shape for POSTs that had it)
- Bearer-legit → **201/200** happy-path preserved
- Bearer + body-asserted-mismatch (POST `created_by`/`author`) → **403 Sender impersonation blocked**
- `DELETE /api/projects/:id?as=bertus` no-creds → **401** (was 403 allowlist-spoof-success)

## Risk

HIGH severity per @bertus + @zaghnal. Tier-1 write surface per Decree #66 Req 1. Same class as Bertus/Flint DM-spoof (#10002) that T#788 closed for risk + prowl. Soft-delete-any-task on `DELETE /api/tasks/:id` is the sharpest edge — anonymous caller could delete any task by ID.

## Diff

`src/board/routes.ts`: +58/-7 lines across 8 handlers. TSC clean for the touched file (pre-existing AppEnv-vs-Env drift unrelated).

## Refs

- Bertus security cycle finding #12602
- Pip QA-pen intake #12603
- Zaghnal PM-narrow #1198 (board-only scope, dm/thread/forum-read split to T#820)
- Pattern source: `dm/routes.ts:110-117` (T#718)
- Sister cascade: T#788 (risk + prowl), T#814 (auth-first ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)