### PR TITLE
T#789 DAEMON-1..4: owner-only gate cascade on daemons module (5 endpoints)

### DIFF
--- a/src/daemons/routes.ts
+++ b/src/daemons/routes.ts
@@ -309,23 +309,40 @@ export function initDaemons(sqliteDb: Database): void {
 // Routes — 5 daemon-management endpoints
 // ============================================================================
 
-export function registerDaemonRoutes(app: OpenAPIHono, sqliteDb: Database): void {
+interface DaemonHelpers {
+  hasSessionAuth: (c: Context) => boolean;
+  isTrustedRequest: (c: Context) => boolean;
+}
+
+export function registerDaemonRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: DaemonHelpers): void {
   // Shadow module-level sqlite (Database | null) with non-null local
   const sqlite: Database = sqliteDb;
+  const { hasSessionAuth, isTrustedRequest } = helpers;
+
+  // T#789 DAEMON-gate: shared owner-only guard for daemons-module mutations + reads.
+  // Closes DAEMON-1..4 — missing-auth or broken Gorn-only checks.
+  const requireOwner = (c: Context) => {
+    if (!hasSessionAuth(c) && !isTrustedRequest(c)) {
+      return c.json({ error: 'Gorn-only — session or trusted-request required', requiresAuth: true }, 403);
+    }
+    return null;
+  };
 
   // DB maintenance routes
   // POST /api/db/maintenance — manual trigger (Gorn-only)
   app.post('/api/db/maintenance', (c) => {
-    const requester = c.req.query('as');
-    if (requester) {
-      return c.json({ error: 'forbidden' }, 403);
-    }
+    // T#789 DAEMON-3 — replace broken ?as=-only check with proper session/trusted gate.
+    const gate = requireOwner(c);
+    if (gate) return gate;
     runDbMaintenance();
     return c.json({ status: 'ok', retention_days: DB_RETENTION_DAYS });
   });
 
   // GET /api/db/stats — table sizes and DB info
   app.get('/api/db/stats', (c) => {
+    // T#789 DAEMON-4 — owner-only read (table sizes are info-disclosure surface).
+    const gate = requireOwner(c);
+    if (gate) return gate;
     const tables = sqlite.prepare(
       `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`
     ).all() as { name: string }[];
@@ -354,6 +371,9 @@ export function registerDaemonRoutes(app: OpenAPIHono, sqliteDb: Database): void
   // File archive routes
   // GET /api/files/archive/stats — archive statistics
   app.get('/api/files/archive/stats', (c) => {
+    // T#789 DAEMON-4 — owner-only read (archive bundle filenames are info-disclosure surface).
+    const gate = requireOwner(c);
+    if (gate) return gate;
     const archived = sqlite.prepare(
       `SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as original_size FROM files WHERE archived_at IS NOT NULL`
     ).get() as any;
@@ -393,12 +413,18 @@ export function registerDaemonRoutes(app: OpenAPIHono, sqliteDb: Database): void
 
   // POST /api/files/archive/run — manual trigger
   app.post('/api/files/archive/run', (c) => {
+    // T#789 DAEMON-2 — owner-only trigger (idempotent but should not be public).
+    const gate = requireOwner(c);
+    if (gate) return gate;
     runFileArchive();
     return c.json({ status: 'ok', message: 'Archive cycle completed' });
   });
 
   // POST /api/files/:id/restore — restore an archived file
   app.post('/api/files/:id/restore', (c) => {
+    // T#789 DAEMON-1 — HIGH: file-restore is deletion-undo (Principle 1 gravity), owner-only.
+    const gate = requireOwner(c);
+    if (gate) return gate;
     const id = parseInt(c.req.param('id'), 10);
     const file = sqlite.prepare('SELECT * FROM files WHERE id = ?').get(id) as any;
     if (!file) return c.json({ error: 'File not found' }, 404);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1345,7 +1345,7 @@ registerSchedulerRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity });
 
 // Daemons (notification drain + DB maintenance + file archive) — extracted to src/daemons/routes.ts (T#773)
 initDaemons(sqlite);
-registerDaemonRoutes(app, sqlite);
+registerDaemonRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest });
 
 
 


### PR DESCRIPTION
## Summary

Closes 4 pre-existing missing-auth-gate findings (DAEMON-1..4) in `src/daemons/routes.ts` surfaced during T#773 (PR #78) security review. Per @zaghnal Sunday-push prioritization, fix shipped as one cleanup pass since findings are scoped together.

## Findings closed

| Severity | Endpoint | Class | Before | After |
|---|---|---|---|---|
| **HIGH** (DAEMON-1) | `POST /api/files/:id/restore` | no auth at all | anon file-restore-any | 403 owner-only |
| medium (DAEMON-2) | `POST /api/files/archive/run` | no auth at all | anon trigger | 403 owner-only |
| medium (DAEMON-3) | `POST /api/db/maintenance` | broken `?as=`-only check | bearer/local bypass | 403 owner-only |
| low (DAEMON-4) | `GET /api/db/stats` + `GET /api/files/archive/stats` | no auth at all | anon info-disclosure | 403 owner-only |

## Pattern

Shared `requireOwner(c)` helper at handler entry:

```ts
const requireOwner = (c: Context) => {
  if (!hasSessionAuth(c) && !isTrustedRequest(c)) {
    return c.json({ error: 'Gorn-only — session or trusted-request required', requiresAuth: true }, 403);
  }
  return null;
};
```

Each handler calls `const gate = requireOwner(c); if (gate) return gate;` at entry. Single helper across 5 endpoints, mirrors T#719 owner-only gate shape.

Updated `registerDaemonRoutes` signature to accept `hasSessionAuth + isTrustedRequest` helpers (mirror of dm/risk/prowl/board pattern). `server.ts:1348` call site extended to pass them in.

## Test plan

Pre-merge probe matrix (5 endpoints):
- `POST /api/files/:id/restore` no-auth → expect **403** (was no gate / 404 if file missing)
- `POST /api/files/archive/run` no-auth → expect **403** (was 200)
- `POST /api/db/maintenance` no-auth → expect **403** (was 200, broken check)
- `POST /api/db/maintenance?as=karo` no-auth → expect **403** (was 403 — pre-fix already blocked this specific shape)
- `GET /api/db/stats` no-auth → expect **403** (was 200)
- `GET /api/files/archive/stats` no-auth → expect **403** (was 200)
- All with session-cookie → expect **200** happy-path preserved

## Risk

HIGH severity per @zaghnal sharpest-edge ranking. DAEMON-1 file-restore was the canonical "Nothing is Deleted gravity violated" — anonymous caller could restore any soft-deleted file by ID. Closes that class.

## Diff

`src/daemons/routes.ts`: +32/-6. `src/server.ts`: +1/-1 (call site). TSC: pre-existing AppEnv-vs-Env drift on `1348` matches drift on all other `registerXxxRoutes` calls (lines 750, 763, 772, 985, 1026, 1144) — not introduced by this PR.

## Refs

- T#789 parent (DAEMON-1..4 scope)
- T#773 origin finding (Bertus security review during PR #78)
- Zaghnal Sunday push DM (Gorn TG-directed continue-by-priority)
- Sister cascade: T#788/T#814/T#811/T#819

🤖 Generated with [Claude Code](https://claude.com/claude-code)