### PR TITLE
T#793 PACK-1: owner-or-Gorn auth gate on 4 beast-profile handlers

### DIFF
--- a/src/pack/routes.ts
+++ b/src/pack/routes.ts
@@ -245,6 +245,14 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
   });
 
   app.post('/api/beasts/seed-avatars', (c) => {
+    // T#793 PACK-1 — Gorn-only (mass-mutate across all profiles).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn') {
+      return c.json({ error: 'Gorn-only — mass profile mutation' }, 403);
+    }
     const profiles = getAllBeastProfiles();
     let updated = 0;
     for (const p of profiles) {
@@ -272,7 +280,15 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
 
   app.put('/api/beast/:name', async (c) => {
     try {
+      // T#793 PACK-1 — owner-or-Gorn-only profile create/replace.
+      const caller = requireBeastIdentity(c);
+      if (!caller) {
+        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      }
       const name = c.req.param('name');
+      if (caller !== name.toLowerCase() && caller !== 'gorn') {
+        return c.json({ error: 'Only the beast themselves or Gorn can modify this profile' }, 403);
+      }
       const body = await c.req.json();
 
       if (!body.displayName || !body.animal) {
@@ -299,7 +315,15 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
 
   app.patch('/api/beast/:name', async (c) => {
     try {
+      // T#793 PACK-1 — owner-or-Gorn-only profile update.
+      const caller = requireBeastIdentity(c);
+      if (!caller) {
+        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      }
       const name = c.req.param('name');
+      if (caller !== name.toLowerCase() && caller !== 'gorn') {
+        return c.json({ error: 'Only the beast themselves or Gorn can modify this profile' }, 403);
+      }
       const profile = getBeastProfile(name);
       if (!profile) {
         return c.json({ error: 'Beast not found' }, 404);
@@ -331,7 +355,15 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
 
   app.patch('/api/beast/:name/avatar', async (c) => {
     try {
+      // T#793 PACK-1 — owner-or-Gorn-only avatar update.
+      const caller = requireBeastIdentity(c);
+      if (!caller) {
+        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      }
       const name = c.req.param('name');
+      if (caller !== name.toLowerCase() && caller !== 'gorn') {
+        return c.json({ error: 'Only the beast themselves or Gorn can modify this profile' }, 403);
+      }
       const profile = getBeastProfile(name);
       if (!profile) {
         return c.json({ error: 'Beast not found. Create profile first with PUT /api/beast/:name' }, 404);


### PR DESCRIPTION
## Summary

Closes T#793 PACK-1 — pre-existing finding from @bertus T#783 PR #86 security review. 4 beast-profile mutation handlers in `src/pack/routes.ts` relied entirely on global `/api/*` middleware (local-bypass passes through with no identity-bound check). Any localhost process could mutate any Beast's profile.

## Affected handlers (4)

| Endpoint | Class | Gate |
|---|---|---|
| `PUT /api/beast/:name` | profile create/replace | owner-or-Gorn |
| `PATCH /api/beast/:name` | profile update (bio/role/displayName/themeColor/avatarUrl/birthdate/sex) | owner-or-Gorn |
| `PATCH /api/beast/:name/avatar` | avatar URL | owner-or-Gorn |
| `POST /api/beasts/seed-avatars` | mass-mutate across all profiles | Gorn-only |

## Pattern

`requireBeastIdentity(c)` at handler entry (401 if missing) + ownership check (`caller !== name && caller !== 'gorn'` → 403). Same shape as T#789 owner gate / T#788 auth-derive cascade.

## Test plan

Pre-merge probe (4 endpoints):
- External no-auth → **401** Beast identity required (was 200 via local-bypass)
- Bearer=karo on `PUT /api/beast/bertus` → **403** "Only the beast themselves or Gorn can modify"
- Bearer=karo on `PUT /api/beast/karo` → **200** happy-path preserved (self-mutation OK)
- Session-Gorn on any → **200** preserved (owner-bypass)
- Bearer=karo on `POST /api/beasts/seed-avatars` → **403** "Gorn-only — mass profile mutation"

## Risk

Medium severity per task. Pre-existing class (not regression). Same module-class as T#789 daemons cascade. Closes UI impersonation (displayName swap), avatar/theme confusion, PII rewrite (birthdate/sex), role-display swap on other Beasts. Weaponizable if any Beast is compromised per Decree #66 trust model.

## Diff

`src/pack/routes.ts`: +32/-0 across 4 handlers. TSC clean. Helpers already passed in (line 26 destructure includes `requireBeastIdentity`).

## Refs

- T#793 parent (PACK-1 scope)
- T#783 origin finding (Bertus PR #86 security review)
- Sister cascades: T#788 (risk + prowl), T#814 (auth-first), T#811 (HELP_ENDPOINTS hotfix), T#819 (board), T#789 (daemons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)