### PR TITLE
T#808: requireBeastIdentity cascade on audit + security/events read endpoints (4 handlers)

### DIFF
--- a/src/audit/routes.ts
+++ b/src/audit/routes.ts
@@ -53,9 +53,12 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // GET /api/audit/stats — summary counts
   app.get('/api/audit/stats', (c) => {
-    // T#727: bearer-derive + legacy ?as= for security team check
-    const requester = ((c.get as any)('actor') || c.req.query('as') || '').toLowerCase();
-    if (!hasSessionAuth(c) && !AUDIT_READ_ALLOWLIST.includes(requester)) {
+    // T#808 — requireBeastIdentity cascade (replaces ?as= + isTrustedRequest read-bypass).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn' && !AUDIT_READ_ALLOWLIST.includes(caller)) {
       return c.json({ error: 'Audit stats are restricted to Gorn and security team' }, 403);
     }
 
@@ -70,10 +73,12 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // GET /api/security/events — query security events
   app.get('/api/security/events', (c) => {
-    // T#727: bearer-derive + legacy ?as= for security team check
-    const requester = ((c.get as any)('actor') || c.req.query('as') || '').toLowerCase();
-    const isSecurityTeam = (isTrustedRequest(c) || (c.get as any)('authMethod') === 'token') && SECURITY_READ_ALLOWLIST.includes(requester);
-    if (!hasSessionAuth(c) && !isSecurityTeam) {
+    // T#808 — requireBeastIdentity cascade (replaces ?as= + isTrustedRequest read-bypass).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn' && !SECURITY_READ_ALLOWLIST.includes(caller)) {
       return c.json({ error: 'Security events are restricted to Gorn and security team' }, 403);
     }
 
@@ -115,10 +120,12 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // GET /api/security/events/stats — summary counts
   app.get('/api/security/events/stats', (c) => {
-    // T#727: bearer-derive + legacy ?as= for security team check
-    const requester = ((c.get as any)('actor') || c.req.query('as') || '').toLowerCase();
-    const isSecurityTeam = (isTrustedRequest(c) || (c.get as any)('authMethod') === 'token') && SECURITY_READ_ALLOWLIST.includes(requester);
-    if (!hasSessionAuth(c) && !isSecurityTeam) {
+    // T#808 — requireBeastIdentity cascade (replaces ?as= + isTrustedRequest read-bypass).
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn' && !SECURITY_READ_ALLOWLIST.includes(caller)) {
       return c.json({ error: 'Security event stats are restricted to Gorn and security team' }, 403);
     }
 

--- a/src/audit/routes.ts
+++ b/src/audit/routes.ts
@@ -11,15 +11,20 @@ const SECURITY_READ_ALLOWLIST = ['bertus', 'talon'];
 interface AuditHelpers {
   hasSessionAuth: (c: Context) => boolean;
   isTrustedRequest: (c: Context) => boolean;
+  requireBeastIdentity: (c: Context) => string | null;
 }
 
 export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers: AuditHelpers) {
-  const { hasSessionAuth, isTrustedRequest } = helpers;
+  const { hasSessionAuth, isTrustedRequest, requireBeastIdentity } = helpers;
 
   app.get('/api/audit', (c) => {
-    // T#727: bearer-derive + legacy ?as= for security team check
-    const requester = ((c.get as any)('actor') || c.req.query('as') || '').toLowerCase();
-    if (!hasSessionAuth(c) && !AUDIT_READ_ALLOWLIST.includes(requester)) {
+    // T#808 — requireBeastIdentity cascade replaces ?as= + isTrustedRequest read-bypass.
+    // Closes localhost-host attacker pretending bertus/talon via ?as= query param.
+    const caller = requireBeastIdentity(c);
+    if (!caller) {
+      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+    }
+    if (caller !== 'gorn' && !AUDIT_READ_ALLOWLIST.includes(caller)) {
       return c.json({ error: 'Audit logs are restricted to Gorn and security team' }, 403);
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1327,7 +1327,7 @@ try {
 // ============================================================================
 
 // Audit + Security events routes extracted to src/audit/routes.ts (T#802 P3-G)
-registerAuditRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest });
+registerAuditRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, requireBeastIdentity });
 
 // ============================================================================
 // Teams API (Task #81 — Gnarl spec, thread #105)


### PR DESCRIPTION
## Summary

Closes T#795 Phase 3 — pre-existing latent gap surfaced by T#802 P3-G extraction (@bertus security-pen review, T#802 c#1148). NOT introduced by PR #99 — has lived since T#727 `?as=` migration. Now visible as isolated module surface in `src/audit/routes.ts`.

## Bypass shape closed

Localhost-host attacker could pretend to be bertus/talon via `?as=bertus` query param, since `isTrustedRequest(c)` is true on localhost and `?as=` was the only identity check. Bearer-token + session-auth paths preserved.

## Fixes (4 handlers in src/audit/routes.ts)

| Endpoint | Class | Allowlist |
|---|---|---|
| `GET /api/audit` | forensic audit-log read | gorn + AUDIT_READ_ALLOWLIST (bertus, talon) |
| `GET /api/audit/stats` | audit summary | same |
| `GET /api/security/events` | security events read | gorn + SECURITY_READ_ALLOWLIST (bertus, talon) |
| `GET /api/security/events/stats` | events summary | same |

## Pattern

```typescript
const caller = requireBeastIdentity(c);
if (!caller) return c.json({ error: ..., requiresAuth: true }, 401);
if (caller !== 'gorn' && !ALLOWLIST.includes(caller)) {
  return c.json({ error: ... }, 403);
}
```

Drops `?as=` query branch + `isTrustedRequest` reliance. Mirrors T#795 Phase 1 (DM + Prowl `isTrustedRequest` read-bypass close) — narrower scope, same shape.

## Test plan

Pre-merge probe (4 endpoints):
- External no-auth → **401** (was 403 — allowlist-protected, but exposed `?as=`-via-trusted attack on localhost)
- Localhost no-auth + `?as=bertus` query → **401** (was **200** — actual data leak)
- External bertus-bearer → **200** (preserved — bearer-allowlist works)
- Gorn session → **200** (preserved — short-circuit via auth-derive)

## Risk

Medium per Bertus #1148. Audit-trail integrity invariant (Principle 1) — forensic audit reads now require validated identity, not localhost-trust assumption.

## Diff

`src/audit/routes.ts`: +29/-19 (4 handlers + interface + destructure). `src/server.ts`: +1/-1 (call site). TSC: clean.

## Refs

- T#795 parent class (closed Phase 1, this is Phase 3 cleanup-sweep)
- T#802 origin task (extraction surfaced this gap)
- T#727 original `?as=` migration that left the gap
- Sister cascades: T#788/T#814/T#811/T#819/T#789/T#793

🤖 Generated with [Claude Code](https://claude.com/claude-code)