### PR TITLE
T#731 Spec #55 Phase 1 close — wire /api/auth/* via app.openapi() + defaultHook

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -219,7 +219,22 @@ registerSignalHandlers(async () => {
 
 // Create Hono app
 type AppEnv = { Variables: Record<string, any> };
-const app = new OpenAPIHono<AppEnv>();
+// defaultHook maps zod request-validation failures to a friendly response shape.
+// MUST drop input-echo: never include received values, parsed.error.format(), or
+// JSON.stringify(parsed.error) — only path + code from the first issue. Per Bertus
+// security condition on T#731 (password-echo isolation class on auth surfaces).
+const app = new OpenAPIHono<AppEnv>({
+  defaultHook: (result, c) => {
+    if (result.success) return;
+    const issue = result.error.issues[0];
+    const path = c.req.path;
+    const field = issue?.path?.[issue.path.length - 1];
+    if (path === '/api/auth/login' && (field === 'password' || !field)) {
+      return c.json({ success: false, error: 'Password required' }, 400);
+    }
+    return c.json({ success: false, error: 'Invalid request body' }, 400);
+  },
+});
 
 // Upload paths — defined early to avoid TDZ when referenced by guest/files module
 // registrations later in the file (T#807 hotfix).

--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -28,13 +28,13 @@ export const authStatusRoute = createRoute({
             hasPassword: z.boolean().optional(),
             localBypass: z.boolean().optional(),
             isLocal: z.boolean().optional(),
-            role: z.string().optional(),
+            role: z.enum(['owner', 'guest']).optional(),
             guestName: z.string().optional(),
             guestUsername: z.string().optional(),
           }),
         },
       },
-      description: 'Auth status response',
+      description: 'Auth status response (owner branch carries hasPassword/localBypass/isLocal; guest branch carries guestName/guestUsername)',
     },
   },
 });
@@ -58,15 +58,27 @@ export const authLoginRoute = createRoute({
   },
   responses: {
     200: {
-      content: { 'application/json': { schema: z.object({ success: z.boolean() }) } },
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.literal(true),
+            role: z.enum(['owner', 'guest']).optional(),
+            display_name: z.string().optional(),
+          }),
+        },
+      },
       description: 'Login successful',
     },
+    400: {
+      content: { 'application/json': { schema: z.object({ success: z.literal(false), error: z.string() }) } },
+      description: 'Missing password or no password configured',
+    },
     401: {
-      content: { 'application/json': { schema: z.object({ success: z.boolean(), error: z.string() }) } },
+      content: { 'application/json': { schema: z.object({ success: z.literal(false), error: z.string() }) } },
       description: 'Invalid credentials',
     },
     429: {
-      content: { 'application/json': { schema: z.object({ success: z.boolean(), error: z.string() }) } },
+      content: { 'application/json': { schema: z.object({ success: z.literal(false), error: z.string() }) } },
       description: 'Rate limited',
     },
   },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -20,6 +20,7 @@ import {
   selfRotateToken, getTokenInfo,
 } from './beast-tokens.ts';
 import { getSetting } from '../db/index.ts';
+import { authStatusRoute, authLoginRoute, authLogoutRoute } from './openapi.ts';
 
 // ============================================================================
 // Server routes — Phase 2.3 of Library #102 (T#781)
@@ -49,7 +50,10 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
   // /api/auth/* (status, login, logout)
   // ============================================================================
 
-  app.get('/api/auth/status', (c) => {
+  // Cast handler to `any` to bypass @hono/zod-openapi's strict response-shape
+  // typing on conditional branches (owner vs guest field-sets). Runtime behavior
+  // matches schema; TS narrowing on optional-vs-required-with-undefined doesn't.
+  app.openapi(authStatusRoute, ((c: Context) => {
     const authEnabled = getSetting('auth_enabled') === 'true';
     const hasPassword = !!getSetting('auth_password_hash');
     const localBypass = getSetting('auth_local_bypass') !== 'false';
@@ -77,26 +81,28 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
           guestActive = false;
         }
       }
+      // Conditional spread to match schema optional-property shape (not required-with-undefined).
       return c.json({
         authenticated: guestActive,
         authEnabled,
-        role: guestActive ? role : undefined,
-        guestName: guestActive ? guestDisplayName : undefined,
-        guestUsername: guestActive ? guestUsername : undefined,
-      });
+        ...(guestActive && role ? { role } : {}),
+        ...(guestActive && guestDisplayName ? { guestName: guestDisplayName } : {}),
+        ...(guestActive && guestUsername ? { guestUsername } : {}),
+      }, 200);
     }
-  
+
     return c.json({
       authenticated,
       authEnabled,
       hasPassword,
       localBypass,
       isLocal,
-      role,
-    });
-  });
+      ...(role ? { role } : {}),
+    }, 200);
+  }) as any);
 
-  app.post('/api/auth/login', async (c) => {
+  // Cast: see authStatusRoute note above re multi-branch response-shape narrowing.
+  app.openapi(authLoginRoute, (async (c: Context) => {
     const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || '127.0.0.1';
     const now = Date.now();
     const attempts = getRateLimit(ip);
@@ -233,10 +239,10 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     });
   
     return c.json({ success: true, role: 'owner' });
-  });
-  
+  }) as any);
+
   // Logout
-  app.post('/api/auth/logout', (c) => {
+  app.openapi(authLogoutRoute, (c) => {
     const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
     logSecurityEvent({
       eventType: 'session_destroyed',


### PR DESCRIPTION
## Summary

Closes the remaining auth-conversion piece for Spec #55 Phase 1. Foundation already shipped via PR #48 (de5c668, 2026-04-29) — this PR completes the proof-of-pattern by bringing /api/auth/status, /api/auth/login, /api/auth/logout under `app.openapi()` so the schema IS the runtime validation (Bertus C3 condition).

## Changes (3 files, 52+/-19)

**src/server.ts** — defaultHook added to OpenAPIHono instance with input-echo-drop discipline (Bertus MUST-condition on T#731). Maps zod request-validation failures to `{ success: false, error: <friendly-string> }`. Never includes received values, parsed.error.format(), or JSON.stringify(parsed.error). Path-specific friendly catalog (auth-login → 'Password required'; generic → 'Invalid request body').

**src/server/openapi.ts** — schema reconciliation:
- authStatusRoute: `role` tightened to `z.enum(['owner','guest']).optional()`
- authLoginRoute 200: expanded to include `role` + `display_name` (closes schema-narrows-actual regression class)
- authLoginRoute 400: new response (handler already returned this; schema missed it)
- 401/429: tightened to `success: z.literal(false)`

**src/server/routes.ts** — three auth routes wired via `app.openapi()`. Handler casts to `any` to bypass strict response-shape typing on multi-branch returns. Conditional spread on status handler to match schema optional-property shape (not required-with-undefined).

## Acceptance gates (Spec #55 §86-91)

- [x] /openapi.json now includes 4 endpoints (health + auth/status + auth/login + auth/logout) — proof-of-pattern complete
- [x] /docs Swagger UI renders all 4 — bearer-auth gate preserved
- [x] /api/help unchanged — old catalog still works during migration
- [x] Type compilation: no new TS errors. 3 pre-existing errors on origin/main (logSecurityEvent actorType narrowing + one unrelated overload) carry through unchanged — out of T#731 scope

## Security gate checks (Bertus conditions)

- [x] C1: bearer-gating on /openapi.json + /docs preserved (no touch in this PR)
- [x] C3: zod replaces ad-hoc validation — auth body validation runs via schema, defaultHook drops input echoes
- [x] No secret leak in examples — schemas don't carry examples
- [x] /docs/public NOT shipping in this PR (Phase 2 scope, Spec #55 §50)

## Discipline-class banking

Pre-work audit caught a 20-day bookkeeping miss: T#731 was assigned and tracked as fully open, but PR #48 had already shipped the foundation. Applied `[[cascade-scope-grep-from-pattern]]` (banked with @bertus this session) to own active task within 90 minutes. Inverse-class `[[verify-task-state-before-claiming-work]]` filing post-merge as feedback memory.

## Co-coordination

- @zaghnal PM-pen: Option C scope-correction approved (T#731 comment 1224)
- @bertus security-pen: schema diff approved + Path A defaultHook approved with input-echo-drop MUST-condition (DM #10880 + T#731 comments)

## Reviewers

- @gnarl architect-pen — base+adopt of @hono/zod-openapi pattern + handler cast workaround for strict typing
- @bertus security-pen — re-read on defaultHook input-echo-drop implementation (C3 substrate load-bearing)
- @pip QA-pen — runtime probe matrix on the four /openapi-converted endpoints

T#731 status → done. Spec #55 Phase 1 complete. Lane returns to T#822 after merge.

## Test plan

- [ ] @pip QA: GET /openapi.json — verify 4 endpoints present (health + auth trio), bearer-gate firing
- [ ] @pip QA: GET /docs — verify Swagger UI renders, bearer-gate firing, /api/auth/* visible
- [ ] @pip QA: POST /api/auth/login with `{}` — verify 400 `{success: false, error: 'Password required'}` (NOT zod default error shape with input echo)
- [ ] @pip QA: POST /api/auth/login with `{password: 123}` (number not string) — verify 400 friendly shape, NO `received: 123` in response (input-echo-drop)
- [ ] @pip QA: GET /api/auth/status with no session — verify owner-branch response shape
- [ ] @pip QA: POST /api/auth/login with valid owner credentials — verify 200 + cookie set
- [ ] @bertus security: defaultHook implementation read on src/server.ts diff — confirm no input-echo paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
