### PR TITLE
Spec #55 Phase 2 — emoji domain conversion (GET/POST/DELETE /api/forum/emojis)

### DIFF
--- a/src/forum/routes.ts
+++ b/src/forum/routes.ts
@@ -6,6 +6,7 @@ import { checkGuestPostRate, checkGuestContentLength, scanForInjection } from '.
 import { logSecurityEvent } from '../server/security-logger.ts';
 import { searchIndexUpsert } from '../search/routes.ts';
 import { handleThreadMessage, getFullThread, updateThreadStatus } from './handler.ts';
+import { emojiListRoute, emojiAddRoute, emojiRemoveRoute } from '../server/openapi.ts';
 
 // ============================================================================
 // Forum routes — Phase 2.1 of Library #102 (T#779)
@@ -686,12 +687,15 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     });
   });
 
-  app.get('/api/forum/emojis', (c) => {
+  app.openapi(emojiListRoute, (c) => {
     const rows = sqlite.prepare('SELECT emoji, added_by, created_at FROM emoji_whitelist ORDER BY created_at').all() as any[];
-    return c.json({ emoji: rows, total: rows.length });
+    return c.json({ emoji: rows, total: rows.length }, 200);
   });
 
-  app.post('/api/forum/emojis', async (c) => {
+  // Cast handler: schema-validated body shape conflicts with the legacy
+  // optional-beast-fallback derivation pattern. Runtime preserves current
+  // behavior; auth-derivation migration scoped to Spec #60 cat-PR.
+  app.openapi(emojiAddRoute, (async (c: Context) => {
     const data = await c.req.json();
     if (!data.emoji) return c.json({ error: 'emoji required' }, 400);
     const beast = data.beast || data.added_by || (hasSessionAuth(c) ? 'gorn' : '');
@@ -699,16 +703,16 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const now = Date.now();
     sqlite.prepare('INSERT OR IGNORE INTO emoji_whitelist (emoji, added_by, created_at) VALUES (?, ?, ?)').run(data.emoji, beast, now);
     SUPPORTED_EMOJI = getSupportedEmoji();
-    return c.json({ added: data.emoji, by: beast, total: SUPPORTED_EMOJI.size });
-  });
+    return c.json({ added: data.emoji, by: beast, total: SUPPORTED_EMOJI.size }, 200);
+  }) as any);
 
-  app.delete('/api/forum/emojis/:emoji', (c) => {
+  app.openapi(emojiRemoveRoute, ((c: Context) => {
     if (!hasSessionAuth(c) && !isTrustedRequest(c)) return c.json({ error: 'Gorn-only' }, 403);
-    const emoji = decodeURIComponent(c.req.param('emoji'));
+    const emoji = decodeURIComponent(c.req.param('emoji') ?? '');
     sqlite.prepare('DELETE FROM emoji_whitelist WHERE emoji = ?').run(emoji);
     SUPPORTED_EMOJI = getSupportedEmoji();
-    return c.json({ removed: emoji, total: SUPPORTED_EMOJI.size });
-  });
+    return c.json({ removed: emoji, total: SUPPORTED_EMOJI.size }, 200);
+  }) as any);
 
   app.get('/api/reactions/supported', (c) => {
     return c.json({ emoji: [...SUPPORTED_EMOJI] });

--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -97,6 +97,101 @@ export const authLogoutRoute = createRoute({
   },
 });
 
+// ============================================================================
+// /api/forum/emojis — emoji whitelist CRUD (Spec #55 Phase 2 emoji domain)
+// ============================================================================
+
+export const emojiListRoute = createRoute({
+  method: 'get',
+  path: '/api/forum/emojis',
+  tags: ['emoji'],
+  summary: 'List whitelisted forum emojis',
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            emoji: z.array(z.object({
+              emoji: z.string(),
+              added_by: z.string().nullable(),
+              created_at: z.number(),
+            })),
+            total: z.number(),
+          }),
+        },
+      },
+      description: 'Whitelisted emoji list',
+    },
+  },
+});
+
+export const emojiAddRoute = createRoute({
+  method: 'post',
+  path: '/api/forum/emojis',
+  tags: ['emoji'],
+  summary: 'Add emoji to whitelist',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            emoji: z.string(),
+            beast: z.string().optional(),
+            added_by: z.string().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            added: z.string(),
+            by: z.string(),
+            total: z.number(),
+          }),
+        },
+      },
+      description: 'Emoji added',
+    },
+    400: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Missing emoji or beast field',
+    },
+  },
+});
+
+export const emojiRemoveRoute = createRoute({
+  method: 'delete',
+  path: '/api/forum/emojis/{emoji}',
+  tags: ['emoji'],
+  summary: 'Remove emoji from whitelist (owner-only)',
+  request: {
+    params: z.object({
+      emoji: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            removed: z.string(),
+            total: z.number(),
+          }),
+        },
+      },
+      description: 'Emoji removed',
+    },
+    403: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Owner-only — bearer or session required',
+    },
+  },
+});
+
 export const OPENAPI_INFO = {
   openapi: '3.0.0' as const,
   info: {


### PR DESCRIPTION
## Summary

Spec #55 Phase 2 first domain — converts 3 emoji whitelist CRUD endpoints (`/api/forum/emojis`) to `app.openapi()` pattern. Refines the Phase 1 template before parallel-dispatch of remaining domains.

## Changes (2 files, +108/-9)

**src/server/openapi.ts**:
- `emojiListRoute`: GET /api/forum/emojis → `{emoji: array, total}`
- `emojiAddRoute`: POST /api/forum/emojis → `{added, by, total}` | 400 `{error}`
- `emojiRemoveRoute`: DELETE /api/forum/emojis/{emoji} → `{removed, total}` | 403

Tags: `['emoji']`. Path params modeled via `z.object` on remove route per zod-openapi convention.

**src/forum/routes.ts**:
- All three routes migrated from `app.get/post/delete` to `app.openapi(<route>, handler)`
- Handler casts to `any` on POST + DELETE per Phase 1 pattern (multi-branch response shape vs strict zod-openapi handler typing)
- `c.req.param('emoji') ?? ''` fallback added for URL-encoded param decode (was `string | undefined` under the typed context cast)

## Scope-preserve discipline

Current handler auth pattern retained:
- POST uses legacy `data.beast || data.added_by || (hasSessionAuth(c) ? 'gorn' : '')` derivation
- DELETE uses `hasSessionAuth + isTrustedRequest` gate (no requireBeastIdentity yet)

**Auth-derivation migration to `requireBeastIdentity()` is Spec #60 cat-PR scope** (T#816 Phase 1) — explicitly NOT bundled here to keep Spec #55 Phase 2 lane clean. The Spec #60 cascade enumerates all 296 routes; emoji POST will be in that body-driven-auth class enumeration.

## Acceptance gates (Spec #55 §92-98)

- [x] All emoji endpoints converted to zod schemas
- [x] Body validation enforced via schema (POST emoji + beast/added_by optional)
- [x] OpenAPI spec includes domain endpoints with full request/response shapes
- [x] Test coverage maintained (handler bodies preserved verbatim modulo the param-undefined-safety fix)

## Security gates (Bertus C-conditions carry from Phase 1)

- [x] C1: bearer-gating on /openapi.json + /docs preserved (no touch in this PR)
- [x] C3: zod replaces ad-hoc validation — POST body validation runs via schema, defaultHook handles validation failures
- [x] No secret leak in examples — schemas don't carry examples
- [x] No new defaultHook special-cases — generic 'Invalid request body' handles emoji POST validation failures

## Type compilation

No new TS errors. 4 pre-existing errors on origin/main (logSecurityEvent narrowing issues at forum/routes.ts:440, 443, 660, 663) carry through unchanged — out of this PR scope.

## Reviewers

- @gnarl architect-pen — domain conversion pattern adherence
- @bertus security-pen — auth-pattern preservation (intentional scope-split with Spec #60 cat-PR)
- @pip QA-pen — runtime probe matrix on the 3 emoji endpoints post-deploy

## Out of scope (deferred)

- `/api/help` array entry for emoji not yet retired (Spec #55 §97 — visibility-only)
- SKILL.md /denbook emoji section update — same-PR atomicity rule per PR #40 applies; deferring to follow-up commit if reviewers want it bundled here

## Test plan

- [ ] @pip GET /openapi.json — verify 3 new emoji endpoints present (now 7 total: health + 3 auth + 3 emoji)
- [ ] @pip GET /docs — Swagger UI renders /api/forum/emojis* group
- [ ] @pip POST /api/forum/emojis with `{emoji: ":test:", beast: "karo"}` — 200 `{added, by, total}`, body validation passes
- [ ] @pip POST /api/forum/emojis with `{}` — 400 friendly via defaultHook (`Invalid request body`), no input echo
- [ ] @pip POST /api/forum/emojis with `{emoji: 123}` (number) — 400 friendly, no `received:123` echo (input-echo-drop holds)
- [ ] @pip GET /api/forum/emojis — list returns array shape
- [ ] @pip DELETE /api/forum/emojis/:emoji with bearer — 200 `{removed, total}`
- [ ] @pip DELETE /api/forum/emojis/:emoji without auth — 403 `{error: "Gorn-only"}`
- [ ] @bertus C3 spot-check on POST/DELETE handler returns

## PM-lane

@zaghnal — please file T# for this work + flip to in_review. This is the first Phase 2 domain, refining template before subagent dispatch on domains 2-3 per Karo+Gorn directive 18:44 BKK.

Spec #55 Phase 1 closed earlier today (T#731 / PR #112). Phase 2 cadence: ~2-3 domains per session, subagent dispatch after this PR ships clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
