### PR TITLE
Spec #55 Phase 2 — settings domain conversion (GET/POST /api/settings)

### DIFF
--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -192,6 +192,83 @@ export const emojiRemoveRoute = createRoute({
   },
 });
 
+// ============================================================================
+// /api/settings — auth + vault settings (Spec #55 Phase 2 settings domain)
+// ============================================================================
+
+export const settingsGetRoute = createRoute({
+  method: 'get',
+  path: '/api/settings',
+  tags: ['settings'],
+  summary: 'Get current auth + vault settings (no password hash exposed)',
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            authEnabled: z.boolean(),
+            localBypass: z.boolean(),
+            hasPassword: z.boolean(),
+            vaultRepo: z.string().nullable(),
+          }),
+        },
+      },
+      description: 'Current settings snapshot',
+    },
+  },
+});
+
+export const settingsUpdateRoute = createRoute({
+  method: 'post',
+  path: '/api/settings',
+  tags: ['settings'],
+  summary: 'Update auth settings (Gorn-only via UI — beast API calls rejected)',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            newPassword: z.string().optional(),
+            currentPassword: z.string().optional(),
+            removePassword: z.boolean().optional(),
+            authEnabled: z.boolean().optional(),
+            localBypass: z.boolean().optional(),
+            as: z.string().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.literal(true),
+            authEnabled: z.boolean(),
+            localBypass: z.boolean(),
+            hasPassword: z.boolean(),
+          }),
+        },
+      },
+      description: 'Settings updated',
+    },
+    400: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Missing current password or cannot enable auth without password',
+    },
+    401: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Current password is incorrect',
+    },
+    403: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Beast API call blocked — settings can only be changed by Gorn via the UI',
+    },
+  },
+});
+
+
 export const OPENAPI_INFO = {
   openapi: '3.0.0' as const,
   info: {

--- a/src/settings/routes.ts
+++ b/src/settings/routes.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono';
 import type { OpenAPIHono } from '@hono/zod-openapi';
+import { settingsGetRoute, settingsUpdateRoute } from '../server/openapi.ts';
 
 interface SettingsHelpers {
   getSetting: (key: string) => string | null;
@@ -11,7 +12,7 @@ export function registerSettingsRoutes(app: OpenAPIHono, helpers: SettingsHelper
   const { getSetting, setSetting, logSecurityEvent } = helpers;
 
   // Get settings (no password hash exposed)
-  app.get('/api/settings', (c) => {
+  app.openapi(settingsGetRoute, (c) => {
     const authEnabled = getSetting('auth_enabled') === 'true';
     const localBypass = getSetting('auth_local_bypass') !== 'false';
     const hasPassword = !!getSetting('auth_password_hash');
@@ -22,11 +23,14 @@ export function registerSettingsRoutes(app: OpenAPIHono, helpers: SettingsHelper
       localBypass,
       hasPassword,
       vaultRepo
-    });
+    }, 200);
   });
 
   // Update settings (Gorn only — reject beast API calls)
-  app.post('/api/settings', async (c) => {
+  // Cast handler: multi-branch response-shape (200/400/401/403) vs strict
+  // zod-openapi handler typing. Runtime preserves current behavior; auth
+  // semantics retained verbatim (Spec #60 cat-PR scope).
+  app.openapi(settingsUpdateRoute, (async (c: Context) => {
     // Only allow from browser sessions (Gorn) or local requests, not beast API calls
     const asParam = c.req.query('as');
     if (asParam) {
@@ -119,6 +123,6 @@ export function registerSettingsRoutes(app: OpenAPIHono, helpers: SettingsHelper
       authEnabled: getSetting('auth_enabled') === 'true',
       localBypass: getSetting('auth_local_bypass') !== 'false',
       hasPassword: !!getSetting('auth_password_hash')
-    });
-  });
+    }, 200);
+  }) as any);
 }


### PR DESCRIPTION
## Summary

Spec #55 Phase 2 settings domain — converts 2 settings endpoints (`/api/settings`) to `app.openapi()` pattern. Per-domain conversion #4 in the Phase 2 lane (after auth Phase 1 close + emoji PR #114; queue + supersede dispatching in parallel).

## Changes (2 files, +85/-5)

**src/server/openapi.ts**:
- `settingsGetRoute`: GET /api/settings → `{authEnabled, localBypass, hasPassword, vaultRepo (nullable)}`
- `settingsUpdateRoute`: POST /api/settings →
  - 200 `{success: true, authEnabled, localBypass, hasPassword}`
  - 400 `{error}` — missing current password / cannot enable auth without password
  - 401 `{error}` — current password incorrect
  - 403 `{error}` — beast API call blocked (Gorn-only via UI)

Tags: `['settings']`. Request body schema models the union of accepted update fields (`newPassword`, `currentPassword`, `removePassword`, `authEnabled`, `localBypass`, `as`) — all optional, server branches on which arrived.

**src/settings/routes.ts**:
- Both routes migrated from `app.get/app.post` to `app.openapi(<route>, handler)`
- GET handler runs without a cast (single response shape — clean typing)
- POST handler cast to `any` per Phase 1/emoji-PR precedent (multi-branch 200/400/401/403 response shape vs strict zod-openapi handler typing)
- Explicit status codes added to `c.json` calls so the response shape matches the schema branch correctly
- Handler bodies preserved verbatim — no auth-derivation changes

## Schema-narrows-actual reconciliation

- GET response: `vaultRepo` is `string | null` (from `getSetting()` which returns `string | null`). Schema models as `z.string().nullable()` — matches handler return verbatim.
- POST 200 response: handler returns `success: true` (literal, not just boolean). Schema models as `z.literal(true)` to match.
- POST 400/401/403: all branches return `{error: string}` shape — modeled uniformly.

No fields-the-handler-returns-but-schema-doesn't-model gaps detected.

## Scope-preserve discipline

Current handler auth pattern retained:
- POST gates on `c.req.query('as')` presence + `body.as` presence — both routed to 403 with security-event log (`impersonation_blocked` for query-param branch)
- No requireBeastIdentity migration; password verification via `Bun.password.verify` retained verbatim

**Auth-derivation migration to `requireBeastIdentity()` is Spec #60 cat-PR scope** (T#816 Phase 1) — explicitly NOT bundled here to keep Spec #55 Phase 2 lane clean.

## Acceptance gates (Spec #55 §92-98)

- [x] Settings endpoints converted to zod schemas
- [x] Body validation enforced via schema (POST body shape modeled)
- [x] OpenAPI spec includes domain endpoints with full request/response shapes
- [x] Test coverage maintained (handler bodies preserved verbatim modulo explicit status codes on `c.json` calls)

## Security gates (Bertus C-conditions carry from Phase 1)

- [x] C1: bearer-gating on /openapi.json + /docs preserved (no touch in this PR)
- [x] C3: zod replaces ad-hoc validation — POST body validation runs via schema, defaultHook handles validation failures
- [x] No secret leak in examples — schemas don't carry examples
- [x] No new defaultHook special-cases — handler's own `Current password required` / `Cannot enable auth without password` 400 messages still fire from within the handler (legacy ad-hoc validation that depends on cross-field logic — kept as-is, documented as Phase 2+ follow-up below)

## Type compilation

No new TS errors. 56 pre-existing errors on origin/main carry through unchanged (verified via baseline-diff: `bun run build 2>&1 | grep '^src/' | grep 'error TS' | sort -u` matches byte-for-byte against origin/main baseline). The two touched files (`src/server/openapi.ts`, `src/settings/routes.ts`) do not appear in the error list.

## Reviewers

- @gnarl architect-pen — domain conversion pattern adherence
- @bertus security-pen — auth-pattern preservation (intentional scope-split with Spec #60 cat-PR); especially the `body.as` rejection branch
- @pip QA-pen — runtime probe matrix on the 2 settings endpoints post-deploy

## Out of scope (deferred)

- `/api/help` array entry for settings not yet retired (Spec #55 §97 — visibility-only)
- SKILL.md /denbook settings section update — same-PR atomicity rule per PR #40 applies; deferring to follow-up commit if reviewers want it bundled here
- defaultHook special-case for friendlier missing-field errors on POST (handler's cross-field validation — `currentPassword` required only when password already exists — stays inline since schema can't express conditional requirement cleanly)

## Test plan

- [ ] @pip GET /openapi.json — verify 2 new settings endpoints present
- [ ] @pip GET /docs — Swagger UI renders /api/settings group
- [ ] @pip GET /api/settings — returns `{authEnabled, localBypass, hasPassword, vaultRepo}` shape
- [ ] @pip POST /api/settings with `{newPassword: "test"}` from owner session — 200 `{success: true, ...}` if no existing password
- [ ] @pip POST /api/settings with `{newPassword: "test"}` when password exists, no `currentPassword` — 400 `{error: "Current password required"}`
- [ ] @pip POST /api/settings with `{newPassword: "test", currentPassword: "wrong"}` — 401 `{error: "Current password is incorrect"}`
- [ ] @pip POST /api/settings with `{authEnabled: true}` when no password set — 400 `{error: "Cannot enable auth without password"}`
- [ ] @pip POST /api/settings?as=karo (beast API call) — 403, `impersonation_blocked` security event logged
- [ ] @pip POST /api/settings with `{as: "karo"}` in body — 403
- [ ] @bertus C3 spot-check on POST handler return shapes match schema branches

## PM-lane

@zaghnal — please file T# for this work + flip to in_review. Domain 4 of Phase 2; queue + supersede dispatching in parallel.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>