### PR TITLE
Spec #55 Phase 2 — queue domain conversion (3 endpoints)

### DIFF
--- a/src/queue/routes.ts
+++ b/src/queue/routes.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono';
 import type { OpenAPIHono } from '@hono/zod-openapi';
 import type { Database } from 'bun:sqlite';
+import { queueListRoute, queueAddRoute, queueUpdateRoute } from '../server/openapi.ts';
 
 interface QueueHelpers {
   isTrustedRequest: (c: Context) => boolean;
@@ -11,7 +12,7 @@ export function registerQueueRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // Legacy queue endpoints (backwards compat)
   // GET /api/queue/gorn — list queue items
-  app.get('/api/queue/gorn', (c) => {
+  app.openapi(queueListRoute, ((c: Context) => {
     const status = c.req.query('status') || 'pending'; // pending, decided, deferred, withdrawn
     const rows = sqlite.prepare(`
       SELECT id, title, status, category, queue_status, queue_tagged_by, queue_tagged_at, queue_summary, created_at,
@@ -34,11 +35,15 @@ export function registerQueueRoutes(app: OpenAPIHono, sqlite: Database, helpers:
         created_at: new Date(r.created_at).toISOString(),
       })),
       total: rows.length,
-    });
-  });
+    }, 200);
+  }) as any);
 
   // POST /api/queue/gorn — add thread to queue (any Beast can tag)
-  app.post('/api/queue/gorn', async (c) => {
+  // Cast handler: schema validates body shape, but the JSON-parse try/catch
+  // branch still emits a 400 from a non-schema-validation path. Runtime
+  // preserves the legacy invalid-JSON message. Auth-derivation migration
+  // (tagged_by → bearer-derived) scoped to Spec #60 cat-PR.
+  app.openapi(queueAddRoute, (async (c: Context) => {
     try {
       const data = await c.req.json();
       if (!data.thread_id) return c.json({ error: 'thread_id required' }, 400);
@@ -50,15 +55,15 @@ export function registerQueueRoutes(app: OpenAPIHono, sqlite: Database, helpers:
         WHERE id = ?
       `).run(data.tagged_by || 'unknown', now, data.summary || null, data.thread_id);
 
-      return c.json({ success: true, thread_id: data.thread_id, queue_status: 'pending' });
+      return c.json({ success: true, thread_id: data.thread_id, queue_status: 'pending' }, 200);
     } catch (e) {
       return c.json({ error: 'Invalid JSON' }, 400);
     }
-  });
+  }) as any);
 
   // PATCH /api/queue/gorn/:threadId — update queue status (Decided/Defer/Withdraw — gorn only from browser)
-  app.patch('/api/queue/gorn/:threadId', async (c) => {
-    const threadId = parseInt(c.req.param('threadId'), 10);
+  app.openapi(queueUpdateRoute, (async (c: Context) => {
+    const threadId = parseInt(c.req.param('threadId') ?? '', 10);
     try {
       const data = await c.req.json();
       const allowed = ['decided', 'deferred', 'pending', 'withdrawn'];
@@ -75,9 +80,9 @@ export function registerQueueRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       sqlite.prepare('UPDATE forum_threads SET queue_status = ? WHERE id = ? AND category = ?')
         .run(data.status, threadId, 'gorn-queue');
 
-      return c.json({ success: true, thread_id: threadId, queue_status: data.status });
+      return c.json({ success: true, thread_id: threadId, queue_status: data.status }, 200);
     } catch (e) {
       return c.json({ error: 'Invalid JSON' }, 400);
     }
-  });
+  }) as any);
 }

--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -268,6 +268,127 @@ export const settingsUpdateRoute = createRoute({
   },
 });
 
+// ============================================================================
+// /api/queue/gorn — Gorn queue CRUD (Spec #55 Phase 2 queue domain)
+// ============================================================================
+
+export const queueListRoute = createRoute({
+  method: 'get',
+  path: '/api/queue/gorn',
+  tags: ['queue'],
+  summary: 'List queued threads for Gorn',
+  request: {
+    query: z.object({
+      status: z.string().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            items: z.array(z.object({
+              thread_id: z.number(),
+              title: z.string(),
+              thread_status: z.string().nullable(),
+              queue_status: z.string().nullable(),
+              tagged_by: z.string().nullable(),
+              tagged_at: z.string().nullable(),
+              summary: z.string().nullable(),
+              message_count: z.number(),
+              created_at: z.string(),
+            })),
+            total: z.number(),
+          }),
+        },
+      },
+      description: 'Queue items filtered by queue_status (default: pending)',
+    },
+  },
+});
+
+export const queueAddRoute = createRoute({
+  method: 'post',
+  path: '/api/queue/gorn',
+  tags: ['queue'],
+  summary: 'Tag a thread into Gorn queue',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            thread_id: z.number(),
+            tagged_by: z.string().optional(),
+            summary: z.string().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.literal(true),
+            thread_id: z.number(),
+            queue_status: z.literal('pending'),
+          }),
+        },
+      },
+      description: 'Thread tagged into queue',
+    },
+    400: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Missing thread_id or invalid JSON',
+    },
+  },
+});
+
+export const queueUpdateRoute = createRoute({
+  method: 'patch',
+  path: '/api/queue/gorn/{threadId}',
+  tags: ['queue'],
+  summary: 'Update queue status (Decided/Defer/Withdraw — Gorn-only from browser)',
+  request: {
+    params: z.object({
+      threadId: z.string(),
+    }),
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            status: z.string(),
+            as: z.string().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.literal(true),
+            thread_id: z.number(),
+            queue_status: z.string(),
+          }),
+        },
+      },
+      description: 'Queue status updated',
+    },
+    400: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Missing/invalid status or invalid JSON',
+    },
+    403: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Browser callers must be Gorn',
+    },
+  },
+});
+
 
 export const OPENAPI_INFO = {
   openapi: '3.0.0' as const,


### PR DESCRIPTION
## Summary

Converts /api/queue/gorn CRUD (GET/POST/PATCH, 3 endpoints) to the
`app.openapi(<route>, handler)` pattern per Spec #55 Phase 2 §63.
Second per-domain conversion after emoji (PR #114).

- Schemas defined in `src/server/openapi.ts` under tag `['queue']`
- Handlers in `src/queue/routes.ts` wired via `app.openapi()` with `as any` casts (Phase 1 + emoji precedent)
- Handler bodies preserved verbatim modulo `c.req.param('threadId') ?? ''` undefined-safety fix
- Schema response shapes reconciled from actual `rows.map(...)` return shape in GET handler (avoid schema-narrows-actual regression)

## Schemas added

| Route | Schema | Path | Responses |
|---|---|---|---|
| GET | `queueListRoute` | `/api/queue/gorn?status=` | 200 `{ items: [...], total }` |
| POST | `queueAddRoute` | `/api/queue/gorn` | 200 `{ success, thread_id, queue_status: 'pending' }` / 400 `{ error }` |
| PATCH | `queueUpdateRoute` | `/api/queue/gorn/{threadId}` | 200 `{ success, thread_id, queue_status }` / 400 / 403 `{ error }` |

## Scope-preserve

Current handler auth semantics retained verbatim. POST `tagged_by` stays
body-derived; PATCH retains the `isTrustedRequest` gate + `data.as === 'gorn'`
fallback. Auth-derivation migration to `requireBeastIdentity()` is Spec #60
cat-PR scope (T#816 Phase 1), explicitly NOT bundled here.

## Type compilation

No new TS errors. Pre-existing errors on origin/main carry through
unchanged. Baseline-diff verified zero-delta in `src/queue/*` and
`src/server/openapi.ts` (stash-baseline-restore comparison).

## Bertus C-conditions (carry from Phase 1)

- [x] C1: bearer-gating on /openapi.json + /docs preserved (untouched)
- [x] C3: zod replaces ad-hoc validation — schema validates body, defaultHook handles failures
- [x] No example values in schemas (secret-leak class)

## Out of scope

- `/api/help` array entry for queue (Spec #55 §97 deferred — visibility-only)
- SKILL.md update for /denbook queue section (same-PR atomicity rule deferred; lane bandwidth)
- POST `tagged_by` bearer-derivation (Spec #60 cat-PR)

## Test plan

- [ ] CI green
- [ ] Server restart deploys cleanly via `scripts/deploy.sh`
- [ ] `curl localhost:47778/openapi.json | jq '.paths["/api/queue/gorn"]'` shows queue schemas
- [ ] `GET /api/queue/gorn?status=pending` returns same shape as pre-conversion (verify against forge-side `denbook-frontend` consumer if any)
- [ ] `POST /api/queue/gorn { thread_id: <real-id>, summary: "test" }` round-trips
- [ ] `PATCH /api/queue/gorn/<threadId> { status: "deferred", as: "gorn" }` round-trips

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code