### PR TITLE
Spec #55 Phase 2 — supersede domain conversion (GET/GET-chain/POST /api/supersede)

### DIFF
--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -389,6 +389,133 @@ export const queueUpdateRoute = createRoute({
   },
 });
 
+// ============================================================================
+// /api/supersede — supersede chain log (Spec #55 Phase 2 supersede domain)
+// ============================================================================
+
+export const supersedeListRoute = createRoute({
+  method: 'get',
+  path: '/api/supersede',
+  tags: ['supersede'],
+  summary: 'List supersede log entries',
+  request: {
+    query: z.object({
+      project: z.string().optional(),
+      limit: z.string().optional(),
+      offset: z.string().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            supersessions: z.array(z.object({
+              id: z.number(),
+              old_path: z.string(),
+              old_id: z.string().nullable(),
+              old_title: z.string().nullable(),
+              old_type: z.string().nullable(),
+              new_path: z.string().nullable(),
+              new_id: z.string().nullable(),
+              new_title: z.string().nullable(),
+              reason: z.string().nullable(),
+              superseded_at: z.string(),
+              superseded_by: z.string().nullable(),
+              project: z.string().nullable(),
+            })),
+            total: z.number(),
+            limit: z.number(),
+            offset: z.number(),
+          }),
+        },
+      },
+      description: 'Supersede log entries with paging metadata',
+    },
+  },
+});
+
+export const supersedeChainRoute = createRoute({
+  method: 'get',
+  path: '/api/supersede/chain/{path}',
+  tags: ['supersede'],
+  summary: 'Get supersede chain for a document path',
+  request: {
+    params: z.object({
+      path: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            superseded_by: z.array(z.object({
+              new_path: z.string().nullable(),
+              reason: z.string().nullable(),
+              superseded_at: z.string(),
+            })),
+            supersedes: z.array(z.object({
+              old_path: z.string(),
+              reason: z.string().nullable(),
+              superseded_at: z.string(),
+            })),
+          }),
+        },
+      },
+      description: 'Chain of supersessions touching the given path',
+    },
+  },
+});
+
+export const supersedeCreateRoute = createRoute({
+  method: 'post',
+  path: '/api/supersede',
+  tags: ['supersede'],
+  summary: 'Log a new supersession',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            old_path: z.string(),
+            old_id: z.string().optional(),
+            old_title: z.string().optional(),
+            old_type: z.string().optional(),
+            new_path: z.string().optional(),
+            new_id: z.string().optional(),
+            new_title: z.string().optional(),
+            reason: z.string().optional(),
+            superseded_by: z.string().optional(),
+            project: z.string().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            id: z.number(),
+            message: z.string(),
+          }),
+        },
+      },
+      description: 'Supersession logged',
+    },
+    400: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Missing required field',
+    },
+    500: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Insert failed',
+    },
+  },
+});
+
 
 export const OPENAPI_INFO = {
   openapi: '3.0.0' as const,

--- a/src/supersede/routes.ts
+++ b/src/supersede/routes.ts
@@ -1,10 +1,19 @@
+import type { Context } from 'hono';
 import type { OpenAPIHono } from '@hono/zod-openapi';
 import { eq, desc, sql } from 'drizzle-orm';
 import { db, supersedeLog } from '../db/index.ts';
+import {
+  supersedeListRoute,
+  supersedeChainRoute,
+  supersedeCreateRoute,
+} from '../server/openapi.ts';
 
 export function registerSupersedeRoutes(app: OpenAPIHono) {
   // List supersessions with optional filters
-  app.get('/api/supersede', (c) => {
+  // Cast handler: response includes a union of nullable-string fields
+  // (Drizzle row -> JSON) that TS narrows differently from the schema's
+  // structural union. Runtime preserves prior behavior.
+  app.openapi(supersedeListRoute, ((c: Context) => {
     const project = c.req.query('project');
     const limit = parseInt(c.req.query('limit') || '50');
     const offset = parseInt(c.req.query('offset') || '0');
@@ -46,12 +55,12 @@ export function registerSupersedeRoutes(app: OpenAPIHono) {
       total,
       limit,
       offset
-    });
-  });
+    }, 200);
+  }) as any);
 
   // Get supersede chain for a document (what superseded what)
-  app.get('/api/supersede/chain/:path', (c) => {
-    const docPath = decodeURIComponent(c.req.param('path'));
+  app.openapi(supersedeChainRoute, ((c: Context) => {
+    const docPath = decodeURIComponent(c.req.param('path') ?? '');
 
     // Find all supersessions where this doc was old or new using Drizzle
     const asOld = db.select()
@@ -77,11 +86,14 @@ export function registerSupersedeRoutes(app: OpenAPIHono) {
         reason: log.reason,
         superseded_at: new Date(log.supersededAt).toISOString()
       }))
-    });
-  });
+    }, 200);
+  }) as any);
 
   // Log a new supersession
-  app.post('/api/supersede', async (c) => {
+  // Cast handler: body validation now runs via schema (defaultHook handles
+  // malformed JSON); the inner try/catch preserves the prior 500-on-DB-error
+  // shape rather than letting Hono's default error path take over.
+  app.openapi(supersedeCreateRoute, (async (c: Context) => {
     try {
       const data = await c.req.json();
       if (!data.old_path) {
@@ -111,5 +123,5 @@ export function registerSupersedeRoutes(app: OpenAPIHono) {
         error: error instanceof Error ? error.message : 'Unknown error'
       }, 500);
     }
-  });
+  }) as any);
 }


### PR DESCRIPTION
## Summary

Spec #55 Phase 2 third domain — converts the 3 supersede log endpoints (`/api/supersede*`) to `app.openapi()` pattern. Follows Phase 1 close (PR #112) and emoji domain (PR #114) precedent.

## Changes (2 files, +148/-9)

**src/server/openapi.ts** (+127):
- `supersedeListRoute`: GET /api/supersede → `{supersessions: array, total, limit, offset}` (query: project?, limit?, offset?)
- `supersedeChainRoute`: GET /api/supersede/chain/{path} → `{superseded_by: array, supersedes: array}` (path param)
- `supersedeCreateRoute`: POST /api/supersede → 201 `{id, message}` | 400 `{error}` | 500 `{error}`

Tags: `['supersede']`. Path params modeled via `z.object` on chain route per zod-openapi convention. Query params declared as `z.string().optional()` to match handler's `parseInt(... || '50')` lazy-default pattern.

**src/supersede/routes.ts** (+30/-9):
- All three routes migrated from `app.get/post` to `app.openapi(<route>, handler)`
- Handler casts to `any` per Phase 1 / emoji-PR precedent — Drizzle row JSON shape (`z.string().nullable()` unions on every text-nullable column) doesn't narrow cleanly to zod-openapi's strict handler return type
- `c.req.param('path') ?? ''` fallback added on chain route for strict typing on `decodeURIComponent` input

## Schema reconciliation (schema-narrows-actual class avoided)

Drizzle schema at `src/db/schema.ts:229` declares only `oldPath` + `supersededAt` as `notNull`. All other text columns (`old_id`, `old_title`, `old_type`, `new_path`, `new_id`, `new_title`, `reason`, `superseded_by`, `project`) are nullable — and the handler returns those nulls unchanged. Schemas model `z.string().nullable()` upfront to match actual return shape, avoiding the schema-narrows-actual regression class that bit Phase 1 auth on the owner/guest branch split.

## Scope-preserve discipline

Current handler auth pattern retained verbatim:
- All 3 endpoints are currently **unauthenticated** in the existing handlers (no `requireBeastIdentity` or `hasSessionAuth` gate present)
- `superseded_by` is body-derived with `'user'` string fallback — legacy pattern, kept verbatim

**Auth-derivation migration is Spec #60 cat-PR scope** (T#816) — explicitly NOT bundled here to keep Spec #55 Phase 2 lane clean.

## Acceptance gates (Spec #55 §92-98)

- [x] All supersede endpoints converted to zod schemas
- [x] Body validation enforced via schema (defaultHook handles malformed JSON; existing `!data.old_path` 400 friendly-message guard preserved as belt-and-braces since schema now requires it — documented for follow-up cleanup)
- [x] OpenAPI spec includes domain endpoints with full request/response shapes
- [x] Test coverage maintained (handler bodies preserved verbatim modulo the param-undefined-safety fix)

## Security gates (Bertus C-conditions carry from Phase 1)

- [x] C1: bearer-gating on /openapi.json + /docs preserved (no touch in this PR)
- [x] C3: zod replaces ad-hoc validation — POST body now schema-validated before handler executes
- [x] No secret leak in examples — schemas carry no example values
- [x] No new defaultHook special-cases — generic `Invalid request body` covers supersede POST validation failures

## Type compilation

Zero new TS errors. 56 pre-existing errors on origin/main carry through unchanged — out of this PR's scope. Verified by diffing baseline (`bunx tsc --noEmit` on origin/main) against post-change output: identical error file set.

## Reviewers

- @gnarl architect-pen — domain conversion pattern adherence + the nullable-string-array shape choice
- @bertus security-pen — auth-pattern preservation (intentional scope-split with Spec #60 cat-PR; these endpoints are currently unauthenticated and stay that way in this PR)
- @pip QA-pen — runtime probe matrix on the 3 supersede endpoints post-deploy

## Out of scope (deferred)

- `/api/help` array entry for supersede not yet retired (Spec #55 §97 — visibility-only, doesn't affect `/openapi.json`)
- SKILL.md `/denbook` supersede section update — same-PR atomicity deferral as PR #114
- Auth gate on these 3 endpoints — Spec #60 lane

## Test plan

- [ ] @pip GET /openapi.json — verify 3 new supersede endpoints present
- [ ] @pip GET /docs — Swagger UI renders `/api/supersede*` group under `supersede` tag
- [ ] @pip GET /api/supersede — list returns `{supersessions, total, limit, offset}` shape
- [ ] @pip GET /api/supersede?project=foo&limit=5&offset=0 — query filter + paging works
- [ ] @pip GET /api/supersede/chain/<url-encoded-path> — returns `{superseded_by, supersedes}` arrays
- [ ] @pip POST /api/supersede with `{old_path: "/tmp/x.md"}` — 201 `{id, message}`
- [ ] @pip POST /api/supersede with `{}` — 400 friendly via defaultHook (`Invalid request body`), no input echo
- [ ] @pip POST /api/supersede with `{old_path: 123}` (number) — 400 friendly, no `received:123` echo
- [ ] @bertus C3 spot-check on POST handler validation path

## PM-lane

@zaghnal — please file T# + flip to in_review. Third Phase 2 domain in the parallel-dispatch wave: emoji shipped (PR #114), queue dispatching alongside this.