### PR TITLE
T#? Spec #55 Phase 2 — remote domain conversion (/api/remote/*)

### DIFF
--- a/src/remote/routes.ts
+++ b/src/remote/routes.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono';
 import type { OpenAPIHono } from '@hono/zod-openapi';
 import { execSync } from 'child_process';
+import { remoteStatusRoute, remoteAttachRoute, remoteDetachRoute } from '../server/openapi.ts';
 
 const REMOTE_SESSION = 'Mindlink';
 
@@ -17,7 +18,7 @@ export function registerRemoteRoutes(app: OpenAPIHono, helpers: RemoteHelpers) {
   let attachedBeastName: string | null = null;
 
   // GET /api/remote/status — which beast is currently attached
-  app.get('/api/remote/status', (c) => {
+  app.openapi(remoteStatusRoute, ((c: Context) => {
     // Verify the Remote session still exists and has a linked window
     if (attachedBeastName) {
       try {
@@ -35,11 +36,13 @@ export function registerRemoteRoutes(app: OpenAPIHono, helpers: RemoteHelpers) {
       }
     }
 
-    return c.json({ session_exists: !!attachedBeastName, attached_beast: attachedBeastName });
-  });
+    return c.json({ session_exists: !!attachedBeastName, attached_beast: attachedBeastName }, 200);
+  }) as any);
 
   // POST /api/remote/attach — attach a beast's claude window (local only — requires tmux)
-  app.post('/api/remote/attach', async (c) => {
+  // Cast handler: multi-branch response shape (200/400/403/404/500) conflicts with
+  // strict zod-openapi handler typing. Runtime preserves current behavior verbatim.
+  app.openapi(remoteAttachRoute, (async (c: Context) => {
     // Remote attach requires local tmux access — reject non-local requests cleanly
     if (!isLocalNetwork(c) && !hasSessionAuth(c)) {
       return c.json({ error: 'forbidden' }, 403);
@@ -94,18 +97,18 @@ export function registerRemoteRoutes(app: OpenAPIHono, helpers: RemoteHelpers) {
       execSync(`tmux select-window -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
 
       attachedBeastName = beastName;
-      return c.json({ attached: beastName, session: REMOTE_SESSION });
+      return c.json({ attached: beastName, session: REMOTE_SESSION }, 200);
     } catch (e) {
       return c.json({ error: e instanceof Error ? e.message : 'Attach failed' }, 500);
     }
-  });
+  }) as any);
 
   // POST /api/remote/detach — detach current beast (local only — requires tmux)
-  app.post('/api/remote/detach', (_c) => {
+  app.openapi(remoteDetachRoute, ((c: Context) => {
     try {
       execSync(`tmux unlink-window -k -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
     } catch { /* already detached */ }
     attachedBeastName = null;
-    return _c.json({ detached: true });
-  });
+    return c.json({ detached: true as const }, 200);
+  }) as any);
 }

--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -516,6 +516,96 @@ export const supersedeCreateRoute = createRoute({
   },
 });
 
+// ============================================================================
+// /api/remote/* — remote tmux attach/detach (Spec #55 Phase 2 remote domain)
+// ============================================================================
+
+export const remoteStatusRoute = createRoute({
+  method: 'get',
+  path: '/api/remote/status',
+  tags: ['remote'],
+  summary: 'Get remote session attach status',
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            session_exists: z.boolean(),
+            attached_beast: z.string().nullable(),
+          }),
+        },
+      },
+      description: 'Whether a beast window is linked into the remote tmux session and which beast (if any)',
+    },
+  },
+});
+
+export const remoteAttachRoute = createRoute({
+  method: 'post',
+  path: '/api/remote/attach',
+  tags: ['remote'],
+  summary: 'Attach a beast claude window into the remote tmux session (local only)',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            beast: z.string(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            attached: z.string(),
+            session: z.string(),
+          }),
+        },
+      },
+      description: 'Beast window linked into remote session',
+    },
+    400: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Missing or invalid beast name',
+    },
+    403: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Forbidden — requires local network or session auth',
+    },
+    404: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'No tmux session for requested beast',
+    },
+    500: {
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+      description: 'Attach operation failed',
+    },
+  },
+});
+
+export const remoteDetachRoute = createRoute({
+  method: 'post',
+  path: '/api/remote/detach',
+  tags: ['remote'],
+  summary: 'Detach the currently-linked beast window from the remote tmux session',
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            detached: z.literal(true),
+          }),
+        },
+      },
+      description: 'Remote session detached (idempotent — succeeds even when no window was linked)',
+    },
+  },
+});
+
 
 export const OPENAPI_INFO = {
   openapi: '3.0.0' as const,


### PR DESCRIPTION
## Summary

Spec #55 Phase 2 sixth domain — converts 3 remote tmux session endpoints (`/api/remote/*`) to `app.openapi()` pattern. Follows the PR #114 emoji template + PR #115/#116/#117 (settings/queue/supersede) subagent-produced refinements.

## Changes (2 files, +102/-9)

**src/server/openapi.ts**:
- `remoteStatusRoute`: GET /api/remote/status → `{session_exists: boolean, attached_beast: string | null}`
- `remoteAttachRoute`: POST /api/remote/attach → `{attached, session}` | 400 `{error}` | 403 `{error}` | 404 `{error}` | 500 `{error}`
- `remoteDetachRoute`: POST /api/remote/detach → `{detached: true}` (idempotent)

Tags: `['remote']`. Request body schema on attach is intentionally narrow (`{beast: string}`) — the handler retains its own lowercasing + `/^[a-z]+$/` validation so the 400 branches stay verbatim (legacy "Invalid beast name" preserved).

**src/remote/routes.ts**:
- All three routes migrated from `app.get/app.post` to `app.openapi(<route>, handler)`
- Handler casts to `any` on all three per Phase 1 / emoji-PR precedent — multi-branch response shape (notably attach with 4 error codes: 400/403/404/500) conflicts with strict zod-openapi handler typing
- Handler bodies preserved verbatim modulo:
  - explicit status codes added to `c.json` calls (e.g. `c.json({...}, 200)`)
  - `detached: true` widened to `true as const` so the literal type aligns with the schema

## Scope-preserve discipline

Current handler auth pattern retained:
- POST /attach: `!isLocalNetwork(c) && !hasSessionAuth(c)` → 403 (verbatim)
- POST /detach: no auth gate (verbatim — module-local state reset only, tmux is source of truth)
- GET /status: no auth gate (verbatim — read-only)

**Auth-derivation migration is Spec #60 cat-PR scope** (T#816 Phase 1) — explicitly NOT bundled here to keep Spec #55 Phase 2 lane clean.

## Handler return-shape reconciliation (C3 check)

Walked all three handlers end-to-end; each schema branch matches a handler `c.json(...)` return verbatim:
- status: single 200 branch — `{session_exists, attached_beast}` with `attached_beast` nullable (handler nulls it on detected unlink/session-gone)
- attach: 200 + 400 (×2 branches share shape) + 403 + 404 + 500 — all return `{error: string}` for non-200
- detach: single 200 branch — `{detached: true}` always (tmux unlink failure swallowed by inner try/catch)

No schema-narrows-actual divergences caught.

## Security gates (Bertus C-conditions per PR)

- [x] C1: bearer-gating on /openapi.json + /docs preserved (no touch in this PR)
- [x] C3: zod replaces ad-hoc validation — POST /attach body validation runs via schema (`beast: string` required); defaultHook handles validation failures
- [x] No secret leak in examples — schemas don't carry examples
- [x] No new defaultHook special-cases — generic 'Invalid request body' handles attach POST validation failures

## Type compilation

56 pre-existing errors on origin/main carry through unchanged (verified via baseline-diff against HEAD with stash). Zero new TS errors introduced by this change. The two touched files (`src/server/openapi.ts`, `src/remote/routes.ts`) do not appear in the error list.

## Reviewers

- @gnarl architect-pen — domain conversion pattern adherence
- @bertus security-pen — auth-pattern preservation (intentional scope-split with Spec #60 cat-PR)
- @pip QA-pen — runtime probe matrix on the 3 remote endpoints post-deploy

## Out of scope (deferred)

- `/api/help` array entries for remote not yet retired (Spec #55 §97 — visibility-only)
- SKILL.md /denbook remote section update — same-PR atomicity rule per PR #40 applies; deferring to follow-up commit if reviewers want it bundled here

## Test plan

- [ ] @pip GET /openapi.json — verify 3 new remote endpoints present under `remote` tag
- [ ] @pip GET /docs — Swagger UI renders /api/remote/* group
- [ ] @pip GET /api/remote/status (no auth) — 200 `{session_exists, attached_beast}` matches current attach state
- [ ] @pip POST /api/remote/attach with `{beast: "karo"}` from localhost — 200 `{attached: "karo", session: "Mindlink"}`
- [ ] @pip POST /api/remote/attach with `{}` from localhost — 400 friendly via defaultHook (`Invalid request body`), no input echo
- [ ] @pip POST /api/remote/attach with `{beast: "no-such-beast"}` — 404 `{error: "No tmux session for no-such-beast"}`
- [ ] @pip POST /api/remote/attach with `{beast: "BadName!"}` — 400 `{error: "Invalid beast name"}` (handler-side validation still fires)
- [ ] POST /api/remote/attach from non-local IP (if reachable in env) — 403 `{error: "forbidden"}`
- [ ] @pip POST /api/remote/detach — 200 `{detached: true}` (idempotent — succeeds even when nothing was attached)
- [ ] @bertus C3 spot-check: confirm all three handlers return shape-matches the schema branches

## PM-lane

@zaghnal — please file T# for this work + flip to in_review. Sixth Phase 2 domain after emoji (#114) / settings (#115) / queue (#116) / supersede (#117). Phase 2 cadence holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)