### PR TITLE
T#719: split legacy ?as= audit tracking off settings_changed eventType

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -659,7 +659,7 @@ app.use('/api/*', async (c, next) => {
     const asParam = c.req.query('as') || '';
     if (asParam) {
       logSecurityEvent({
-        eventType: 'settings_changed', // Reuse existing type for legacy tracking
+        eventType: 'legacy_auth_used', // T#719 — dedicated type so legacy ?as= tracking no longer camouflages real settings_changed events
         severity: 'info',
         actor: actor || 'unknown',
         actorType: (actorType as any) || 'unknown',

--- a/src/server/security-logger.ts
+++ b/src/server/security-logger.ts
@@ -25,6 +25,7 @@ export type SecurityEventType =
   | 'token_revoked'          // OAuth token revoked/disconnected
   | 'settings_changed'       // Auth/security settings modified
   | 'impersonation_blocked'  // ?as= spoofing blocked on protected endpoint
+  | 'legacy_auth_used'       // T#719 — deprecated ?as= param seen on a bearer-carrying call (audit-only, not used as actor)
   | 'session_destroyed'      // Session logout
   | 'alert_triggered'        // Threshold alert fired by checkAlertThresholds
   | 'token_validated'        // Beast token validated (sampled, T#546)


### PR DESCRIPTION
## What

Split the legacy `?as=` audit tracking off the `settings_changed` eventType.

`server.ts:662` reused `eventType: 'settings_changed'` for the deprecated `?as=` param tracker. Every legacy `?as=` call therefore wrote a `settings_changed` security event — camouflaging real auth/settings-modification events in the audit dashboard's `GROUP BY event_type` breakdown (`audit/routes.ts:139`). This is the noise Bertus surfaced in the Day-63 wolf-hour scan (3× `actor=unknown` on my own recap GETs that appended `?as=karo` while already carrying a bearer).

## Change

- Add `'legacy_auth_used'` to the `SecurityEventType` union (`security-logger.ts`).
- Use it for the `?as=` tracker at `server.ts:662`.

2 lines, 2 files.

## Why it's safe

- `settings_changed` is **not** in `ALERT_THRESHOLDS` (only `auth_failure` / `rate_limited` / `permission_denied`) — **zero alerting behavior changes**.
- `event_type` is a free-form text column; the audit filter (`audit/routes.ts:102`) and the GROUP BY breakdown both pick up the new value automatically — `legacy_auth_used` surfaces as its own dashboard row.
- The `?as=` value is still **audit-only, never used as actor** (bearer derives the actor server-side) — unchanged.

## Context

Companion to the CLAUDE.md bearer-only-GET guidance shipped in `602d63f` (the *behavioral* half — stop emitting `?as=` when carrying a bearer). This is the *structural* half: even remaining `?as=` calls no longer pollute `settings_changed`. Leonard's Day-64 KL noted a 71% drop in `settings_changed` from migration alone; this makes the remaining trickle self-labeling.

## Out of scope (noted, not fixed here)

Typecheck surfaced pre-existing union drift — `suspicious_content`, `message_delete`, and several `actorType: 'guest'/'owner'` literals are used but not in their respective unions. Latent, unrelated to this fix; worth a separate cleanup task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
