### PR TITLE
Phase 1: Adopt Biome (format + lint) — formatting baseline

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["src/**/*.ts", "!src/**/*.html", "!**/*.d.ts"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.16",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.19.39",
         "better-sqlite3": "^12.9.0",
@@ -37,6 +38,24 @@
   },
   "packages": {
     "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "serve": "bun dist/server.js",
     "index": "bun src/indexer.ts",
     "build": "tsc --noEmit",
+    "format": "biome format --write ./src",
+    "format:check": "biome format ./src",
+    "lint": "biome lint ./src",
     "start": "bun dist/index.js",
     "test": "bun run test:unit && bun run test:integration",
     "test:unit": "ORACLE_DB_PATH=:memory: ORACLE_DATA_DIR=/tmp/oracle-test-data bun test src/tools/__tests__/ src/server/__tests__/ src/vault/__tests__/ src/drizzle-migration.test.ts src/indexer-preservation.test.ts",
@@ -67,6 +70,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.16",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.19.39",
     "better-sqlite3": "^12.9.0",

--- a/src/audit/routes.ts
+++ b/src/audit/routes.ts
@@ -22,7 +22,10 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // Closes localhost-host attacker pretending bertus/talon via ?as= query param.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && !AUDIT_READ_ALLOWLIST.includes(caller)) {
       return c.json({ error: 'Audit logs are restricted to Gorn and security team' }, 403);
@@ -42,12 +45,42 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const params: any[] = [];
     const countParams: any[] = [];
 
-    if (actor) { query += ' AND actor = ?'; countQuery += ' AND actor = ?'; params.push(actor); countParams.push(actor); }
-    if (resourceType) { query += ' AND resource_type = ?'; countQuery += ' AND resource_type = ?'; params.push(resourceType); countParams.push(resourceType); }
-    if (statusCode) { query += ' AND status_code = ?'; countQuery += ' AND status_code = ?'; params.push(parseInt(statusCode)); countParams.push(parseInt(statusCode)); }
-    if (method) { query += ' AND request_method = ?'; countQuery += ' AND request_method = ?'; params.push(method.toUpperCase()); countParams.push(method.toUpperCase()); }
-    if (requestId) { query += ' AND request_id = ?'; countQuery += ' AND request_id = ?'; params.push(requestId); countParams.push(requestId); }
-    if (since) { query += ' AND datetime(timestamp) >= datetime(?)'; countQuery += ' AND datetime(timestamp) >= datetime(?)'; params.push(since); countParams.push(since); }
+    if (actor) {
+      query += ' AND actor = ?';
+      countQuery += ' AND actor = ?';
+      params.push(actor);
+      countParams.push(actor);
+    }
+    if (resourceType) {
+      query += ' AND resource_type = ?';
+      countQuery += ' AND resource_type = ?';
+      params.push(resourceType);
+      countParams.push(resourceType);
+    }
+    if (statusCode) {
+      query += ' AND status_code = ?';
+      countQuery += ' AND status_code = ?';
+      params.push(parseInt(statusCode));
+      countParams.push(parseInt(statusCode));
+    }
+    if (method) {
+      query += ' AND request_method = ?';
+      countQuery += ' AND request_method = ?';
+      params.push(method.toUpperCase());
+      countParams.push(method.toUpperCase());
+    }
+    if (requestId) {
+      query += ' AND request_id = ?';
+      countQuery += ' AND request_id = ?';
+      params.push(requestId);
+      countParams.push(requestId);
+    }
+    if (since) {
+      query += ' AND datetime(timestamp) >= datetime(?)';
+      countQuery += ' AND datetime(timestamp) >= datetime(?)';
+      params.push(since);
+      countParams.push(since);
+    }
     query += ' ORDER BY timestamp DESC LIMIT ? OFFSET ?';
     params.push(limit, offset);
 
@@ -61,19 +94,52 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#808 — requireBeastIdentity cascade (replaces ?as= + isTrustedRequest read-bypass).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && !AUDIT_READ_ALLOWLIST.includes(caller)) {
       return c.json({ error: 'Audit stats are restricted to Gorn and security team' }, 403);
     }
 
-    const total = (sqlite.prepare('SELECT COUNT(*) as count FROM audit_log').get() as any)?.count || 0;
-    const denied = (sqlite.prepare("SELECT COUNT(*) as count FROM audit_log WHERE status_code = 403").get() as any)?.count || 0;
-    const errors = (sqlite.prepare("SELECT COUNT(*) as count FROM audit_log WHERE status_code >= 500").get() as any)?.count || 0;
-    const byActor = sqlite.prepare('SELECT actor, COUNT(*) as count FROM audit_log GROUP BY actor ORDER BY count DESC LIMIT 10').all();
-    const byResource = sqlite.prepare('SELECT resource_type, COUNT(*) as count FROM audit_log GROUP BY resource_type ORDER BY count DESC LIMIT 10').all();
-    const byMethod = sqlite.prepare('SELECT request_method, COUNT(*) as count FROM audit_log GROUP BY request_method ORDER BY count DESC').all();
-    return c.json({ total, denied, errors, by_actor: byActor, by_resource: byResource, by_method: byMethod });
+    const total =
+      (sqlite.prepare('SELECT COUNT(*) as count FROM audit_log').get() as any)?.count || 0;
+    const denied =
+      (
+        sqlite
+          .prepare('SELECT COUNT(*) as count FROM audit_log WHERE status_code = 403')
+          .get() as any
+      )?.count || 0;
+    const errors =
+      (
+        sqlite
+          .prepare('SELECT COUNT(*) as count FROM audit_log WHERE status_code >= 500')
+          .get() as any
+      )?.count || 0;
+    const byActor = sqlite
+      .prepare(
+        'SELECT actor, COUNT(*) as count FROM audit_log GROUP BY actor ORDER BY count DESC LIMIT 10',
+      )
+      .all();
+    const byResource = sqlite
+      .prepare(
+        'SELECT resource_type, COUNT(*) as count FROM audit_log GROUP BY resource_type ORDER BY count DESC LIMIT 10',
+      )
+      .all();
+    const byMethod = sqlite
+      .prepare(
+        'SELECT request_method, COUNT(*) as count FROM audit_log GROUP BY request_method ORDER BY count DESC',
+      )
+      .all();
+    return c.json({
+      total,
+      denied,
+      errors,
+      by_actor: byActor,
+      by_resource: byResource,
+      by_method: byMethod,
+    });
   });
 
   // GET /api/security/events — query security events
@@ -81,7 +147,10 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#808 — requireBeastIdentity cascade (replaces ?as= + isTrustedRequest read-bypass).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && !SECURITY_READ_ALLOWLIST.includes(caller)) {
       return c.json({ error: 'Security events are restricted to Gorn and security team' }, 403);
@@ -99,13 +168,30 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const params: any[] = [];
     const countParams: any[] = [];
 
-    if (eventType) { query += ' AND event_type = ?'; countQuery += ' AND event_type = ?'; params.push(eventType); countParams.push(eventType); }
-    if (severity) { query += ' AND severity = ?'; countQuery += ' AND severity = ?'; params.push(severity); countParams.push(severity); }
-    if (actor) { query += ' AND actor = ?'; countQuery += ' AND actor = ?'; params.push(actor); countParams.push(actor); }
+    if (eventType) {
+      query += ' AND event_type = ?';
+      countQuery += ' AND event_type = ?';
+      params.push(eventType);
+      countParams.push(eventType);
+    }
+    if (severity) {
+      query += ' AND severity = ?';
+      countQuery += ' AND severity = ?';
+      params.push(severity);
+      countParams.push(severity);
+    }
+    if (actor) {
+      query += ' AND actor = ?';
+      countQuery += ' AND actor = ?';
+      params.push(actor);
+      countParams.push(actor);
+    }
     if (since) {
       const sinceEpoch = Math.floor(new Date(since).getTime() / 1000);
-      query += ' AND timestamp >= ?'; countQuery += ' AND timestamp >= ?';
-      params.push(sinceEpoch); countParams.push(sinceEpoch);
+      query += ' AND timestamp >= ?';
+      countQuery += ' AND timestamp >= ?';
+      params.push(sinceEpoch);
+      countParams.push(sinceEpoch);
     }
     query += ' ORDER BY timestamp DESC LIMIT ? OFFSET ?';
     params.push(limit, offset);
@@ -114,7 +200,7 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const rows = sqlite.prepare(query).all(...params) as any[];
 
     // Parse details JSON for convenience
-    const events = rows.map(r => ({
+    const events = rows.map((r) => ({
       ...r,
       details: r.details ? JSON.parse(r.details) : null,
       timestamp_iso: new Date(r.timestamp * 1000).toISOString(),
@@ -128,19 +214,53 @@ export function registerAuditRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#808 — requireBeastIdentity cascade (replaces ?as= + isTrustedRequest read-bypass).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && !SECURITY_READ_ALLOWLIST.includes(caller)) {
-      return c.json({ error: 'Security event stats are restricted to Gorn and security team' }, 403);
+      return c.json(
+        { error: 'Security event stats are restricted to Gorn and security team' },
+        403,
+      );
     }
 
-    const total = (sqlite.prepare('SELECT COUNT(*) as count FROM security_events').get() as any)?.count || 0;
-    const bySeverity = sqlite.prepare('SELECT severity, COUNT(*) as count FROM security_events GROUP BY severity ORDER BY count DESC').all();
-    const byType = sqlite.prepare('SELECT event_type, COUNT(*) as count FROM security_events GROUP BY event_type ORDER BY count DESC').all();
-    const byActor = sqlite.prepare('SELECT actor, COUNT(*) as count FROM security_events WHERE actor IS NOT NULL GROUP BY actor ORDER BY count DESC LIMIT 10').all();
-    const last24h = (sqlite.prepare('SELECT COUNT(*) as count FROM security_events WHERE timestamp > ?').get(Math.floor(Date.now() / 1000) - 86400) as any)?.count || 0;
-    const criticalCount = (sqlite.prepare("SELECT COUNT(*) as count FROM security_events WHERE severity = 'critical'").get() as any)?.count || 0;
-    const warningCount = (sqlite.prepare("SELECT COUNT(*) as count FROM security_events WHERE severity = 'warning'").get() as any)?.count || 0;
+    const total =
+      (sqlite.prepare('SELECT COUNT(*) as count FROM security_events').get() as any)?.count || 0;
+    const bySeverity = sqlite
+      .prepare(
+        'SELECT severity, COUNT(*) as count FROM security_events GROUP BY severity ORDER BY count DESC',
+      )
+      .all();
+    const byType = sqlite
+      .prepare(
+        'SELECT event_type, COUNT(*) as count FROM security_events GROUP BY event_type ORDER BY count DESC',
+      )
+      .all();
+    const byActor = sqlite
+      .prepare(
+        'SELECT actor, COUNT(*) as count FROM security_events WHERE actor IS NOT NULL GROUP BY actor ORDER BY count DESC LIMIT 10',
+      )
+      .all();
+    const last24h =
+      (
+        sqlite
+          .prepare('SELECT COUNT(*) as count FROM security_events WHERE timestamp > ?')
+          .get(Math.floor(Date.now() / 1000) - 86400) as any
+      )?.count || 0;
+    const criticalCount =
+      (
+        sqlite
+          .prepare("SELECT COUNT(*) as count FROM security_events WHERE severity = 'critical'")
+          .get() as any
+      )?.count || 0;
+    const warningCount =
+      (
+        sqlite
+          .prepare("SELECT COUNT(*) as count FROM security_events WHERE severity = 'warning'")
+          .get() as any
+      )?.count || 0;
 
     return c.json({
       total,

--- a/src/board/routes.ts
+++ b/src/board/routes.ts
@@ -15,11 +15,14 @@ interface BoardHelpers {
   wsBroadcast: (event: string, data: any) => void;
 }
 
-export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: BoardHelpers): void {
+export function registerBoardRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: BoardHelpers,
+): void {
   const { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast } = helpers;
   // Shadow sqlite for the verbatim block below
   const sqlite: Database = sqliteDb;
-
 
   // ============================================================================
   // PM Board — Projects + Tasks + Task Comments
@@ -27,7 +30,8 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // Create projects table
   try {
-    sqlite.prepare(`CREATE TABLE IF NOT EXISTS projects (
+    sqlite
+      .prepare(`CREATE TABLE IF NOT EXISTS projects (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL,
       description TEXT DEFAULT '',
@@ -35,12 +39,16 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       created_by TEXT NOT NULL,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
-    )`).run();
-  } catch { /* already exists */ }
+    )`)
+      .run();
+  } catch {
+    /* already exists */
+  }
 
   // Create tasks table
   try {
-    sqlite.prepare(`CREATE TABLE IF NOT EXISTS tasks (
+    sqlite
+      .prepare(`CREATE TABLE IF NOT EXISTS tasks (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       project_id INTEGER REFERENCES projects(id),
       title TEXT NOT NULL,
@@ -53,42 +61,111 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       due_date TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
-    )`).run();
+    )`)
+      .run();
     // v2: add type column
-    try { sqlite.prepare(`ALTER TABLE tasks ADD COLUMN type TEXT DEFAULT 'task'`).run(); } catch { /* exists */ }
+    try {
+      sqlite.prepare(`ALTER TABLE tasks ADD COLUMN type TEXT DEFAULT 'task'`).run();
+    } catch {
+      /* exists */
+    }
     // Backfill existing tasks with no type
     sqlite.prepare(`UPDATE tasks SET type = 'task' WHERE type IS NULL`).run();
     // v3: SDD enforcement columns (T#317)
-    try { sqlite.prepare(`ALTER TABLE tasks ADD COLUMN approval_required INTEGER NOT NULL DEFAULT 0`).run(); } catch { /* exists */ }
-    try { sqlite.prepare(`ALTER TABLE tasks ADD COLUMN spec_id INTEGER`).run(); } catch { /* exists */ }
+    try {
+      sqlite
+        .prepare(`ALTER TABLE tasks ADD COLUMN approval_required INTEGER NOT NULL DEFAULT 0`)
+        .run();
+    } catch {
+      /* exists */
+    }
+    try {
+      sqlite.prepare(`ALTER TABLE tasks ADD COLUMN spec_id INTEGER`).run();
+    } catch {
+      /* exists */
+    }
     // v4: reviewer field for in_review workflow (T#418)
-    try { sqlite.prepare(`ALTER TABLE tasks ADD COLUMN reviewer TEXT`).run(); } catch { /* exists */ }
+    try {
+      sqlite.prepare(`ALTER TABLE tasks ADD COLUMN reviewer TEXT`).run();
+    } catch {
+      /* exists */
+    }
     // v5: risk_level for QA triage (T#617)
-    try { sqlite.prepare(`ALTER TABLE tasks ADD COLUMN risk_level TEXT DEFAULT 'medium'`).run(); } catch { /* exists */ }
+    try {
+      sqlite.prepare(`ALTER TABLE tasks ADD COLUMN risk_level TEXT DEFAULT 'medium'`).run();
+    } catch {
+      /* exists */
+    }
     sqlite.prepare(`UPDATE tasks SET risk_level = 'medium' WHERE risk_level IS NULL`).run();
     // v6: parent_task_id for subtasks (Spec #56)
-    try { sqlite.prepare(`ALTER TABLE tasks ADD COLUMN parent_task_id INTEGER REFERENCES tasks(id) ON DELETE SET NULL`).run(); } catch { /* exists */ }
-    try { sqlite.prepare(`CREATE INDEX idx_tasks_parent_task_id ON tasks(parent_task_id) WHERE parent_task_id IS NOT NULL`).run(); } catch { /* exists */ }
-  } catch { /* already exists */ }
+    try {
+      sqlite
+        .prepare(
+          `ALTER TABLE tasks ADD COLUMN parent_task_id INTEGER REFERENCES tasks(id) ON DELETE SET NULL`,
+        )
+        .run();
+    } catch {
+      /* exists */
+    }
+    try {
+      sqlite
+        .prepare(
+          `CREATE INDEX idx_tasks_parent_task_id ON tasks(parent_task_id) WHERE parent_task_id IS NOT NULL`,
+        )
+        .run();
+    } catch {
+      /* exists */
+    }
+  } catch {
+    /* already exists */
+  }
 
   const VALID_TASK_TYPES = ['bug', 'feature', 'improvement', 'chore', 'task'];
   const VALID_RISK_LEVELS = ['high', 'medium', 'low'];
 
   function validateParentTaskId(parentTaskId: number, selfId?: number): string | null {
-    const parent = sqlite.prepare('SELECT id, parent_task_id FROM tasks WHERE id = ? AND status != ?').get(parentTaskId, 'deleted') as any;
+    const parent = sqlite
+      .prepare('SELECT id, parent_task_id FROM tasks WHERE id = ? AND status != ?')
+      .get(parentTaskId, 'deleted') as any;
     if (!parent) return 'Parent task not found';
-    if (parent.parent_task_id) return 'Cannot nest deeper than 2 levels — parent task is already a subtask';
+    if (parent.parent_task_id)
+      return 'Cannot nest deeper than 2 levels — parent task is already a subtask';
     if (selfId !== undefined && parentTaskId === selfId) return 'Task cannot be its own parent';
     if (selfId !== undefined) {
-      const children = sqlite.prepare('SELECT id FROM tasks WHERE parent_task_id = ? AND status != ?').all(selfId, 'deleted') as any[];
-      if (children.length > 0) return 'Cannot make a parent task into a subtask — it already has subtasks';
+      const children = sqlite
+        .prepare('SELECT id FROM tasks WHERE parent_task_id = ? AND status != ?')
+        .all(selfId, 'deleted') as any[];
+      if (children.length > 0)
+        return 'Cannot make a parent task into a subtask — it already has subtasks';
     }
     return null;
   }
 
-  function getSubtasksSummary(taskId: number): { count: number; done: number; in_progress: number; todo: number; blocked: number; in_review: number; backlog: number; cancelled: number } {
-    const rows = sqlite.prepare('SELECT status, COUNT(*) as cnt FROM tasks WHERE parent_task_id = ? AND status != ? GROUP BY status').all(taskId, 'deleted') as any[];
-    const summary = { count: 0, done: 0, in_progress: 0, todo: 0, blocked: 0, in_review: 0, backlog: 0, cancelled: 0 };
+  function getSubtasksSummary(taskId: number): {
+    count: number;
+    done: number;
+    in_progress: number;
+    todo: number;
+    blocked: number;
+    in_review: number;
+    backlog: number;
+    cancelled: number;
+  } {
+    const rows = sqlite
+      .prepare(
+        'SELECT status, COUNT(*) as cnt FROM tasks WHERE parent_task_id = ? AND status != ? GROUP BY status',
+      )
+      .all(taskId, 'deleted') as any[];
+    const summary = {
+      count: 0,
+      done: 0,
+      in_progress: 0,
+      todo: 0,
+      blocked: 0,
+      in_review: 0,
+      backlog: 0,
+      cancelled: 0,
+    };
     for (const r of rows) {
       const s = r.status as keyof typeof summary;
       if (s in summary && s !== 'count') (summary as any)[s] = r.cnt;
@@ -100,22 +177,30 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // SDD enforcement: check if task can transition to in_progress or done
   function checkApprovalGate(task: any): string | null {
     if (!task.approval_required) return null;
-    if (!task.spec_id) return "Gorn's spec approval required before starting. Submit a spec via /spec submit and wait for approval at /specs.";
-    const spec = sqlite.prepare('SELECT status FROM spec_reviews WHERE id = ?').get(task.spec_id) as any;
-    if (!spec || spec.status !== 'approved') return "Spec not yet approved. Wait for Gorn's approval at /specs before starting.";
+    if (!task.spec_id)
+      return "Gorn's spec approval required before starting. Submit a spec via /spec submit and wait for approval at /specs.";
+    const spec = sqlite
+      .prepare('SELECT status FROM spec_reviews WHERE id = ?')
+      .get(task.spec_id) as any;
+    if (!spec || spec.status !== 'approved')
+      return "Spec not yet approved. Wait for Gorn's approval at /specs before starting.";
     return null;
   }
 
   // Create task_comments table
   try {
-    sqlite.prepare(`CREATE TABLE IF NOT EXISTS task_comments (
+    sqlite
+      .prepare(`CREATE TABLE IF NOT EXISTS task_comments (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       task_id INTEGER NOT NULL REFERENCES tasks(id),
       author TEXT NOT NULL,
       content TEXT NOT NULL,
       created_at TEXT NOT NULL
-    )`).run();
-  } catch { /* already exists */ }
+    )`)
+      .run();
+  } catch {
+    /* already exists */
+  }
 
   // --- Projects CRUD ---
 
@@ -124,13 +209,15 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const status = c.req.query('status');
     let rows;
     if (status) {
-      rows = sqlite.prepare(
-        'SELECT * FROM projects WHERE status = ? ORDER BY created_at DESC'
-      ).all(status) as any[];
+      rows = sqlite
+        .prepare('SELECT * FROM projects WHERE status = ? ORDER BY created_at DESC')
+        .all(status) as any[];
     } else {
-      rows = sqlite.prepare(
-        "SELECT * FROM projects ORDER BY CASE status WHEN 'active' THEN 0 WHEN 'paused' THEN 1 WHEN 'completed' THEN 2 END, created_at DESC"
-      ).all() as any[];
+      rows = sqlite
+        .prepare(
+          "SELECT * FROM projects ORDER BY CASE status WHEN 'active' THEN 0 WHEN 'paused' THEN 1 WHEN 'completed' THEN 2 END, created_at DESC",
+        )
+        .all() as any[];
     }
     return c.json({ projects: rows });
   });
@@ -140,20 +227,33 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // T#819 — auth-derive (T#788 pattern), reject body-asserted mismatch.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const data = await c.req.json();
     const { name, description } = data;
     if (!name) return c.json({ error: 'name required' }, 400);
     if (data.created_by && data.created_by.toLowerCase() !== caller) {
-      return c.json({ error: 'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.' }, 403);
+      return c.json(
+        {
+          error:
+            'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.',
+        },
+        403,
+      );
     }
     const created_by = caller;
     const now = new Date().toISOString();
-    const result = sqlite.prepare(
-      'INSERT INTO projects (name, description, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
-    ).run(name, description || '', created_by, now, now);
-    const project = sqlite.prepare('SELECT * FROM projects WHERE id = ?').get((result as any).lastInsertRowid);
+    const result = sqlite
+      .prepare(
+        'INSERT INTO projects (name, description, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      )
+      .run(name, description || '', created_by, now, now);
+    const project = sqlite
+      .prepare('SELECT * FROM projects WHERE id = ?')
+      .get((result as any).lastInsertRowid);
     wsBroadcast('project_created', { id: (project as any).id });
     return c.json(project, 201);
   });
@@ -163,10 +263,13 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const id = parseInt(c.req.param('id'), 10);
     const project = sqlite.prepare('SELECT * FROM projects WHERE id = ?').get(id) as any;
     if (!project) return c.json({ error: 'Project not found' }, 404);
-    const taskCounts = sqlite.prepare(
-      'SELECT status, COUNT(*) as count FROM tasks WHERE project_id = ? GROUP BY status'
-    ).all(id) as any[];
-    return c.json({ ...project, task_counts: Object.fromEntries(taskCounts.map(r => [r.status, r.count])) });
+    const taskCounts = sqlite
+      .prepare('SELECT status, COUNT(*) as count FROM tasks WHERE project_id = ? GROUP BY status')
+      .all(id) as any[];
+    return c.json({
+      ...project,
+      task_counts: Object.fromEntries(taskCounts.map((r) => [r.status, r.count])),
+    });
   });
 
   // PATCH /api/projects/:id — update project
@@ -174,17 +277,24 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // T#819 — auth-first.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const id = parseInt(c.req.param('id'), 10);
     const data = await c.req.json();
     const updates: string[] = [];
     const params: any[] = [];
     for (const field of ['name', 'description', 'status']) {
-      if (data[field] !== undefined) { updates.push(`${field} = ?`); params.push(data[field]); }
+      if (data[field] !== undefined) {
+        updates.push(`${field} = ?`);
+        params.push(data[field]);
+      }
     }
     if (updates.length === 0) return c.json({ error: 'No fields to update' }, 400);
-    updates.push('updated_at = ?'); params.push(new Date().toISOString());
+    updates.push('updated_at = ?');
+    params.push(new Date().toISOString());
     params.push(id);
     sqlite.prepare(`UPDATE projects SET ${updates.join(', ')} WHERE id = ?`).run(...params);
     const project = sqlite.prepare('SELECT * FROM projects WHERE id = ?').get(id);
@@ -196,7 +306,10 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // T#819 — auth-derive (T#795 P1 pattern), close localhost-trust ?as= bypass class.
     const requester = requireBeastIdentity(c);
     if (!requester) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (requester !== 'gorn' && requester !== 'pip') {
       return c.json({ error: 'Only Gorn or Pip can delete projects' }, 403);
@@ -224,41 +337,71 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const limit = Math.min(200, parseInt(c.req.query('limit') || '100', 10));
     const offset = parseInt(c.req.query('offset') || '0', 10);
 
-    let query = 'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE 1=1';
+    let query =
+      'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE 1=1';
     const params: any[] = [];
 
     // T#759: exclude soft-deleted tasks by default; ?include_deleted=true for audit/admin
     const includeDeleted = c.req.query('include_deleted') === 'true';
-    if (!includeDeleted) { query += " AND t.status != 'deleted'"; }
+    if (!includeDeleted) {
+      query += " AND t.status != 'deleted'";
+    }
 
-    if (projectId) { query += ' AND t.project_id = ?'; params.push(parseInt(projectId, 10)); }
+    if (projectId) {
+      query += ' AND t.project_id = ?';
+      params.push(parseInt(projectId, 10));
+    }
     if (status) {
-      const statuses = status.split(',').map(s => s.trim()).filter(Boolean);
+      const statuses = status
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
       if (statuses.length === 1) {
-        query += ' AND t.status = ?'; params.push(statuses[0]);
+        query += ' AND t.status = ?';
+        params.push(statuses[0]);
       } else {
         query += ` AND t.status IN (${statuses.map(() => '?').join(',')})`;
         params.push(...statuses);
       }
     }
-    if (assignedTo) { query += ' AND t.assigned_to = ?'; params.push(assignedTo); }
-    if (priority) { query += ' AND t.priority = ?'; params.push(priority); }
+    if (assignedTo) {
+      query += ' AND t.assigned_to = ?';
+      params.push(assignedTo);
+    }
+    if (priority) {
+      query += ' AND t.priority = ?';
+      params.push(priority);
+    }
     const type = c.req.query('type');
-    if (type) { query += ' AND t.type = ?'; params.push(type); }
+    if (type) {
+      query += ' AND t.type = ?';
+      params.push(type);
+    }
     const riskLevel = c.req.query('risk_level');
-    if (riskLevel) { query += ' AND t.risk_level = ?'; params.push(riskLevel); }
+    if (riskLevel) {
+      query += ' AND t.risk_level = ?';
+      params.push(riskLevel);
+    }
     const parentId = c.req.query('parent_id');
-    if (parentId === 'null') { query += ' AND t.parent_task_id IS NULL'; }
-    else if (parentId) { query += ' AND t.parent_task_id = ?'; params.push(parseInt(parentId, 10)); }
+    if (parentId === 'null') {
+      query += ' AND t.parent_task_id IS NULL';
+    } else if (parentId) {
+      query += ' AND t.parent_task_id = ?';
+      params.push(parseInt(parentId, 10));
+    }
 
-    const countQuery = query.replace('SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id', 'SELECT COUNT(*) as total FROM tasks t');
+    const countQuery = query.replace(
+      'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id',
+      'SELECT COUNT(*) as total FROM tasks t',
+    );
     const total = (sqlite.prepare(countQuery).get(...params) as any)?.total || 0;
 
     // Done tasks sort by most recently completed; others by priority then created_at
     if (status === 'done') {
       query += ' ORDER BY t.updated_at DESC';
     } else {
-      query += ' ORDER BY CASE t.priority WHEN \'critical\' THEN 0 WHEN \'high\' THEN 1 WHEN \'medium\' THEN 2 WHEN \'low\' THEN 3 END, t.created_at DESC';
+      query +=
+        " ORDER BY CASE t.priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 3 END, t.created_at DESC";
     }
     query += ' LIMIT ? OFFSET ?';
     params.push(limit, offset);
@@ -272,43 +415,113 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // T#819 — auth-derive (T#788 pattern), reject body-asserted mismatch.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const data = await c.req.json();
-    const { title, description, project_id, status, priority, assigned_to, thread_id, due_date, type, reviewer, risk_level, parent_task_id } = data;
+    const {
+      title,
+      description,
+      project_id,
+      status,
+      priority,
+      assigned_to,
+      thread_id,
+      due_date,
+      type,
+      reviewer,
+      risk_level,
+      parent_task_id,
+    } = data;
     if (!title) return c.json({ error: 'title required' }, 400);
     if (data.created_by && data.created_by.toLowerCase() !== caller) {
-      return c.json({ error: 'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.' }, 403);
+      return c.json(
+        {
+          error:
+            'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.',
+        },
+        403,
+      );
     }
     const created_by = caller;
-    if (!project_id) return c.json({ error: 'project_id required — every task must belong to a project' }, 400);
-    if (!assigned_to) return c.json({ error: 'assigned_to required — every task must have an assignee' }, 400);
-    if (!reviewer) return c.json({ error: 'reviewer required — every task must have a reviewer for the in_review workflow' }, 400);
+    if (!project_id)
+      return c.json({ error: 'project_id required — every task must belong to a project' }, 400);
+    if (!assigned_to)
+      return c.json({ error: 'assigned_to required — every task must have an assignee' }, 400);
+    if (!reviewer)
+      return c.json(
+        { error: 'reviewer required — every task must have a reviewer for the in_review workflow' },
+        400,
+      );
     if (parent_task_id != null) {
       const parsed = Number(parent_task_id);
-      if (!Number.isInteger(parsed) || parsed <= 0) return c.json({ error: 'parent_task_id must be a positive integer' }, 400);
+      if (!Number.isInteger(parsed) || parsed <= 0)
+        return c.json({ error: 'parent_task_id must be a positive integer' }, 400);
       const parentErr = validateParentTaskId(parsed);
       if (parentErr) return c.json({ error: parentErr }, 400);
     }
 
-    const validStatuses = ['todo', 'backlog', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
+    const validStatuses = [
+      'todo',
+      'backlog',
+      'in_progress',
+      'in_review',
+      'done',
+      'blocked',
+      'cancelled',
+    ];
     const validPriorities = ['critical', 'high', 'medium', 'low'];
     const taskStatus = validStatuses.includes(status) ? status : 'todo';
     const taskPriority = validPriorities.includes(priority) ? priority : 'medium';
-    if (type && !VALID_TASK_TYPES.includes(type)) return c.json({ error: `Invalid type. Valid: ${VALID_TASK_TYPES.join(', ')}` }, 400);
+    if (type && !VALID_TASK_TYPES.includes(type))
+      return c.json({ error: `Invalid type. Valid: ${VALID_TASK_TYPES.join(', ')}` }, 400);
     const taskType = type || 'task';
-    if (risk_level && !VALID_RISK_LEVELS.includes(risk_level)) return c.json({ error: `Invalid risk_level. Valid: ${VALID_RISK_LEVELS.join(', ')}` }, 400);
+    if (risk_level && !VALID_RISK_LEVELS.includes(risk_level))
+      return c.json({ error: `Invalid risk_level. Valid: ${VALID_RISK_LEVELS.join(', ')}` }, 400);
     const taskRiskLevel = VALID_RISK_LEVELS.includes(risk_level) ? risk_level : 'medium';
 
     const now = new Date().toISOString();
     const approvalRequired = data.approval_required ? 1 : 0;
     const parentId = parent_task_id != null ? parseInt(String(parent_task_id), 10) : null;
-    const result = sqlite.prepare(
-      'INSERT INTO tasks (project_id, title, description, status, priority, assigned_to, created_by, thread_id, due_date, type, approval_required, reviewer, risk_level, parent_task_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-    ).run(project_id || null, title, description || '', taskStatus, taskPriority, assigned_to || null, created_by, thread_id || null, due_date || null, taskType, approvalRequired, reviewer, taskRiskLevel, parentId, now, now);
+    const result = sqlite
+      .prepare(
+        'INSERT INTO tasks (project_id, title, description, status, priority, assigned_to, created_by, thread_id, due_date, type, approval_required, reviewer, risk_level, parent_task_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+      .run(
+        project_id || null,
+        title,
+        description || '',
+        taskStatus,
+        taskPriority,
+        assigned_to || null,
+        created_by,
+        thread_id || null,
+        due_date || null,
+        taskType,
+        approvalRequired,
+        reviewer,
+        taskRiskLevel,
+        parentId,
+        now,
+        now,
+      );
 
-    const task = sqlite.prepare('SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.id = ?').get((result as any).lastInsertRowid) as any;
-    searchIndexUpsert('task', task.id, task.title, task.description || '', task.assigned_to || '', now, `/board?task=${task.id}`);
+    const task = sqlite
+      .prepare(
+        'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.id = ?',
+      )
+      .get((result as any).lastInsertRowid) as any;
+    searchIndexUpsert(
+      'task',
+      task.id,
+      task.title,
+      task.description || '',
+      task.assigned_to || '',
+      now,
+      `/board?task=${task.id}`,
+    );
     wsBroadcast('task_created', { id: task.id });
 
     // Notify assignee + @mentioned beasts in description (T#378)
@@ -334,10 +547,16 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
           task.title,
           created_by,
           `New task T#${task.id}: ${task.title}${task.assigned_to ? ` (assigned to @${task.assigned_to})` : ''}`,
-          { type: 'PM Board', label: `task #${task.id}`, hint: `Use /board task ${task.id} to view.` },
+          {
+            type: 'PM Board',
+            label: `task #${task.id}`,
+            hint: `Use /board task ${task.id} to view.`,
+          },
         );
       }
-    } catch { /* notification failure is non-critical */ }
+    } catch {
+      /* notification failure is non-critical */
+    }
 
     return c.json(task, 201);
   });
@@ -345,11 +564,15 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // GET /api/tasks/:id — get task with comments
   app.get('/api/tasks/:id', (c) => {
     const id = parseInt(c.req.param('id'), 10);
-    const task = sqlite.prepare(
-      'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.id = ?'
-    ).get(id) as any;
+    const task = sqlite
+      .prepare(
+        'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.id = ?',
+      )
+      .get(id) as any;
     if (!task) return c.json({ error: 'Task not found' }, 404);
-    const comments = sqlite.prepare('SELECT * FROM task_comments WHERE task_id = ? ORDER BY created_at ASC').all(id) as any[];
+    const comments = sqlite
+      .prepare('SELECT * FROM task_comments WHERE task_id = ? ORDER BY created_at ASC')
+      .all(id) as any[];
     const subtasks = getSubtasksSummary(id);
     return c.json({ ...task, comments, subtasks: subtasks.count > 0 ? subtasks : undefined });
   });
@@ -359,7 +582,10 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // T#819 — auth-first.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const id = parseInt(c.req.param('id'), 10);
     const existing = sqlite.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as any;
@@ -367,17 +593,34 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
     const data = await c.req.json();
 
-    const validStatuses = ['todo', 'backlog', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
+    const validStatuses = [
+      'todo',
+      'backlog',
+      'in_progress',
+      'in_review',
+      'done',
+      'blocked',
+      'cancelled',
+    ];
     const validPriorities = ['critical', 'high', 'medium', 'low'];
-    if (data.status && !validStatuses.includes(data.status)) return c.json({ error: `Invalid status. Valid: ${validStatuses.join(', ')}` }, 400);
-    if (data.priority && !validPriorities.includes(data.priority)) return c.json({ error: `Invalid priority. Valid: ${validPriorities.join(', ')}` }, 400);
-    if (data.type && !VALID_TASK_TYPES.includes(data.type)) return c.json({ error: `Invalid type. Valid: ${VALID_TASK_TYPES.join(', ')}` }, 400);
-    if (data.risk_level && !VALID_RISK_LEVELS.includes(data.risk_level)) return c.json({ error: `Invalid risk_level. Valid: ${VALID_RISK_LEVELS.join(', ')}` }, 400);
+    if (data.status && !validStatuses.includes(data.status))
+      return c.json({ error: `Invalid status. Valid: ${validStatuses.join(', ')}` }, 400);
+    if (data.priority && !validPriorities.includes(data.priority))
+      return c.json({ error: `Invalid priority. Valid: ${validPriorities.join(', ')}` }, 400);
+    if (data.type && !VALID_TASK_TYPES.includes(data.type))
+      return c.json({ error: `Invalid type. Valid: ${VALID_TASK_TYPES.join(', ')}` }, 400);
+    if (data.risk_level && !VALID_RISK_LEVELS.includes(data.risk_level))
+      return c.json({ error: `Invalid risk_level. Valid: ${VALID_RISK_LEVELS.join(', ')}` }, 400);
 
     // Terminal status enforcement (T#529) — Done and Cancelled are final
     const terminalStatuses = ['done', 'cancelled'];
     if (data.status && terminalStatuses.includes((existing as any).status)) {
-      return c.json({ error: `Cannot change status: task is ${(existing as any).status}. Done and Cancelled are terminal statuses.` }, 400);
+      return c.json(
+        {
+          error: `Cannot change status: task is ${(existing as any).status}. Done and Cancelled are terminal statuses.`,
+        },
+        400,
+      );
     }
 
     // SDD enforcement: block forward transitions if approval_required and no approved spec
@@ -389,7 +632,11 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // Require reviewer when moving to in_review
     if (data.status === 'in_review') {
       const reviewer = data.reviewer || existing.reviewer;
-      if (!reviewer) return c.json({ error: 'Reviewer required when moving to in_review. Set reviewer field.' }, 400);
+      if (!reviewer)
+        return c.json(
+          { error: 'Reviewer required when moving to in_review. Set reviewer field.' },
+          400,
+        );
     }
 
     if (data.parent_task_id !== undefined) {
@@ -397,7 +644,8 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         // Promote to top-level — allowed
       } else {
         const parsed = Number(data.parent_task_id);
-        if (!Number.isInteger(parsed) || parsed <= 0) return c.json({ error: 'parent_task_id must be a positive integer' }, 400);
+        if (!Number.isInteger(parsed) || parsed <= 0)
+          return c.json({ error: 'parent_task_id must be a positive integer' }, 400);
         const parentErr = validateParentTaskId(parsed, id);
         if (parentErr) return c.json({ error: parentErr }, 400);
       }
@@ -405,24 +653,62 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
     // Spec #56 E2: block parent project-change while children exist
     if (data.project_id !== undefined && data.project_id !== (existing as any).project_id) {
-      const children = sqlite.prepare('SELECT COUNT(*) as cnt FROM tasks WHERE parent_task_id = ? AND status != ?').get(id, 'deleted') as any;
+      const children = sqlite
+        .prepare('SELECT COUNT(*) as cnt FROM tasks WHERE parent_task_id = ? AND status != ?')
+        .get(id, 'deleted') as any;
       if (children.cnt > 0) {
-        return c.json({ error: 'Cannot change project on a parent task with subtasks — reparent subtasks first' }, 400);
+        return c.json(
+          {
+            error: 'Cannot change project on a parent task with subtasks — reparent subtasks first',
+          },
+          400,
+        );
       }
     }
 
     const updates: string[] = [];
     const params: any[] = [];
-    for (const field of ['title', 'description', 'status', 'priority', 'assigned_to', 'project_id', 'thread_id', 'due_date', 'type', 'approval_required', 'spec_id', 'reviewer', 'risk_level', 'parent_task_id']) {
-      if (data[field] !== undefined) { updates.push(`${field} = ?`); params.push(data[field]); }
+    for (const field of [
+      'title',
+      'description',
+      'status',
+      'priority',
+      'assigned_to',
+      'project_id',
+      'thread_id',
+      'due_date',
+      'type',
+      'approval_required',
+      'spec_id',
+      'reviewer',
+      'risk_level',
+      'parent_task_id',
+    ]) {
+      if (data[field] !== undefined) {
+        updates.push(`${field} = ?`);
+        params.push(data[field]);
+      }
     }
     if (updates.length === 0) return c.json({ error: 'No fields to update' }, 400);
-    updates.push('updated_at = ?'); params.push(new Date().toISOString());
+    updates.push('updated_at = ?');
+    params.push(new Date().toISOString());
     params.push(id);
 
     sqlite.prepare(`UPDATE tasks SET ${updates.join(', ')} WHERE id = ?`).run(...params);
-    const task = sqlite.prepare('SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.id = ?').get(id) as any;
-    if (task) searchIndexUpsert('task', id, task.title, task.description || '', task.assigned_to || '', task.created_at);
+    const task = sqlite
+      .prepare(
+        'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.id = ?',
+      )
+      .get(id) as any;
+    if (task)
+      searchIndexUpsert(
+        'task',
+        id,
+        task.title,
+        task.description || '',
+        task.assigned_to || '',
+        task.created_at,
+      );
     wsBroadcast('task_updated', { id: task?.id });
 
     // Notify reviewer when task moves to in_review (T#439)
@@ -430,10 +716,21 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       try {
         const { notifyMentioned } = await import('../forum/mentions.ts');
         const updatedBy = data.updated_by || task.assigned_to || 'system';
-        notifyMentioned([task.reviewer], 0, `T#${id}: ${task.title}`, updatedBy, `Task moved to in_review — you are the reviewer.`, {
-          type: 'PM Board', label: `T#${id}`, hint: `Review at https://denbook.online/board?task=${id}`,
-        });
-      } catch { /* notification failure is non-critical */ }
+        notifyMentioned(
+          [task.reviewer],
+          0,
+          `T#${id}: ${task.title}`,
+          updatedBy,
+          `Task moved to in_review — you are the reviewer.`,
+          {
+            type: 'PM Board',
+            label: `T#${id}`,
+            hint: `Review at https://denbook.online/board?task=${id}`,
+          },
+        );
+      } catch {
+        /* notification failure is non-critical */
+      }
     }
 
     return c.json(task);
@@ -444,13 +741,20 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // T#819 — auth-first. Closes anonymous soft-delete-any-task class (Bertus #12602 sharpest edge).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const id = parseInt(c.req.param('id'), 10);
     const now = new Date().toISOString();
     sqlite.transaction(() => {
-      sqlite.prepare('UPDATE tasks SET parent_task_id = NULL, updated_at = ? WHERE parent_task_id = ?').run(now, id);
-      sqlite.prepare('UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?').run('deleted', now, id);
+      sqlite
+        .prepare('UPDATE tasks SET parent_task_id = NULL, updated_at = ? WHERE parent_task_id = ?')
+        .run(now, id);
+      sqlite
+        .prepare('UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?')
+        .run('deleted', now, id);
     })();
     searchIndexDelete('task', id);
     return c.json({ success: true, id });
@@ -459,15 +763,22 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // GET /api/tasks/:id/subtree — parent + all direct subtasks in one call (Spec #56)
   app.get('/api/tasks/:id/subtree', (c) => {
     const id = parseInt(c.req.param('id'), 10);
-    const parent = sqlite.prepare(
-      'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.id = ?'
-    ).get(id) as any;
+    const parent = sqlite
+      .prepare(
+        'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.id = ?',
+      )
+      .get(id) as any;
     if (!parent) return c.json({ error: 'Task not found' }, 404);
-    const subtasks = sqlite.prepare(
-      'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.parent_task_id = ? AND t.status != ? ORDER BY t.created_at ASC'
-    ).all(id, 'deleted') as any[];
+    const subtasks = sqlite
+      .prepare(
+        'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.parent_task_id = ? AND t.status != ? ORDER BY t.created_at ASC',
+      )
+      .all(id, 'deleted') as any[];
     const summary = getSubtasksSummary(id);
-    return c.json({ parent: { ...parent, subtasks: summary.count > 0 ? summary : undefined }, subtasks });
+    return c.json({
+      parent: { ...parent, subtasks: summary.count > 0 ? summary : undefined },
+      subtasks,
+    });
   });
 
   // POST /api/tasks/bulk-status — bulk status update (for PM)
@@ -475,13 +786,25 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // T#819 — auth-first. Closes anonymous mass-mutate class.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const data = await c.req.json();
     const { task_ids, status } = data;
-    if (!Array.isArray(task_ids) || !status) return c.json({ error: 'task_ids and status required' }, 400);
+    if (!Array.isArray(task_ids) || !status)
+      return c.json({ error: 'task_ids and status required' }, 400);
 
-    const validStatuses = ['todo', 'backlog', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
+    const validStatuses = [
+      'todo',
+      'backlog',
+      'in_progress',
+      'in_review',
+      'done',
+      'blocked',
+      'cancelled',
+    ];
     if (!validStatuses.includes(status)) return c.json({ error: 'Invalid status' }, 400);
 
     // SDD enforcement for bulk status
@@ -494,7 +817,8 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
           if (gateError) blocked.push({ id, error: gateError });
         }
       }
-      if (blocked.length > 0) return c.json({ error: 'Some tasks blocked by SDD approval gate', blocked }, 400);
+      if (blocked.length > 0)
+        return c.json({ error: 'Some tasks blocked by SDD approval gate', blocked }, 400);
     }
 
     const now = new Date().toISOString();
@@ -511,7 +835,9 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // GET /api/tasks/:id/comments
   app.get('/api/tasks/:id/comments', (c) => {
     const taskId = parseInt(c.req.param('id'), 10);
-    const comments = sqlite.prepare('SELECT * FROM task_comments WHERE task_id = ? ORDER BY created_at ASC').all(taskId) as any[];
+    const comments = sqlite
+      .prepare('SELECT * FROM task_comments WHERE task_id = ? ORDER BY created_at ASC')
+      .all(taskId) as any[];
     return c.json({ comments });
   });
 
@@ -520,39 +846,58 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // T#819 — auth-derive (T#788 pattern), reject body-asserted mismatch.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const taskId = parseInt(c.req.param('id'), 10);
     const data = await c.req.json();
     const { content } = data;
     if (!content) return c.json({ error: 'content required' }, 400);
     if (data.author && data.author.toLowerCase() !== caller) {
-      return c.json({ error: 'Sender impersonation blocked. body.author must match authenticated caller or be omitted.' }, 403);
+      return c.json(
+        {
+          error:
+            'Sender impersonation blocked. body.author must match authenticated caller or be omitted.',
+        },
+        403,
+      );
     }
     const author = caller;
 
     const now = new Date().toISOString();
-    const result = sqlite.prepare(
-      'INSERT INTO task_comments (task_id, author, content, created_at) VALUES (?, ?, ?, ?)'
-    ).run(taskId, author, content, now);
-    const comment = sqlite.prepare('SELECT * FROM task_comments WHERE id = ?').get((result as any).lastInsertRowid);
+    const result = sqlite
+      .prepare(
+        'INSERT INTO task_comments (task_id, author, content, created_at) VALUES (?, ?, ?, ?)',
+      )
+      .run(taskId, author, content, now);
+    const comment = sqlite
+      .prepare('SELECT * FROM task_comments WHERE id = ?')
+      .get((result as any).lastInsertRowid);
 
     // Notify task assignee, creator, and @mentioned beasts about the new comment
     try {
-      const task = sqlite.prepare('SELECT assigned_to, created_by, reviewer, title FROM tasks WHERE id = ?').get(taskId) as any;
+      const task = sqlite
+        .prepare('SELECT assigned_to, created_by, reviewer, title FROM tasks WHERE id = ?')
+        .get(taskId) as any;
       if (task) {
         const { parseMentions, notifyMentioned } = await import('../forum/mentions.ts');
         const commenter = author.split('@')[0].toLowerCase();
         const toNotify = new Set<string>();
         // Notify assignee, creator, and reviewer (T#575)
-        if (task.assigned_to && task.assigned_to !== commenter) toNotify.add(task.assigned_to.toLowerCase());
-        if (task.created_by && task.created_by !== commenter) toNotify.add(task.created_by.toLowerCase());
+        if (task.assigned_to && task.assigned_to !== commenter)
+          toNotify.add(task.assigned_to.toLowerCase());
+        if (task.created_by && task.created_by !== commenter)
+          toNotify.add(task.created_by.toLowerCase());
         if (task.reviewer && task.reviewer !== commenter) toNotify.add(task.reviewer.toLowerCase());
         // Parse @mentions from comment content
         const mentions = parseMentions(content, 0);
         for (const m of mentions) toNotify.add(m.toLowerCase());
         toNotify.delete(commenter);
-        toNotify.delete('gorn'); toNotify.delete('human'); toNotify.delete('user');
+        toNotify.delete('gorn');
+        toNotify.delete('human');
+        toNotify.delete('user');
         if (toNotify.size > 0) {
           notifyMentioned(
             [...toNotify],
@@ -564,13 +909,18 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
               type: 'PM Board',
               label: `task #${taskId}`,
               hint: `Use /board task ${taskId} to view. Use /board comment ${taskId} <message> to reply.`,
-            }
+            },
           );
         }
       }
-    } catch { /* notification failure is non-critical */ }
+    } catch {
+      /* notification failure is non-critical */
+    }
 
-    wsBroadcast('task_comment_added', { task_id: taskId, comment_id: (result as any).lastInsertRowid });
+    wsBroadcast('task_comment_added', {
+      task_id: taskId,
+      comment_id: (result as any).lastInsertRowid,
+    });
     return c.json(comment, 201);
   });
 
@@ -581,27 +931,49 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const projectId = c.req.query('project_id');
     const assignedTo = c.req.query('assigned_to') || c.req.query('assignee');
 
-    let query = 'SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.status != \'deleted\'';
+    let query =
+      "SELECT t.*, p.name as project_name FROM tasks t LEFT JOIN projects p ON t.project_id = p.id WHERE t.status != 'deleted'";
     const params: any[] = [];
 
     // Spec #56 Phase 3: board default is top-level only (parent_id IS NULL)
     const showSubtasks = c.req.query('show_subtasks');
-    if (showSubtasks !== 'true') { query += ' AND t.parent_task_id IS NULL'; }
+    if (showSubtasks !== 'true') {
+      query += ' AND t.parent_task_id IS NULL';
+    }
 
-    if (projectId) { query += ' AND t.project_id = ?'; params.push(parseInt(projectId, 10)); }
-    if (assignedTo) { query += ' AND t.assigned_to = ?'; params.push(assignedTo); }
+    if (projectId) {
+      query += ' AND t.project_id = ?';
+      params.push(parseInt(projectId, 10));
+    }
+    if (assignedTo) {
+      query += ' AND t.assigned_to = ?';
+      params.push(assignedTo);
+    }
 
-    query += ' ORDER BY CASE t.priority WHEN \'critical\' THEN 0 WHEN \'high\' THEN 1 WHEN \'medium\' THEN 2 WHEN \'low\' THEN 3 END, t.created_at DESC';
+    query +=
+      " ORDER BY CASE t.priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 3 END, t.created_at DESC";
 
     const tasks = sqlite.prepare(query).all(...params) as any[];
 
     // Enrich parent tasks with subtask summaries (Spec #56 Phase 2 — single aggregate query)
-    const subtaskRows = sqlite.prepare(
-      `SELECT parent_task_id, status, COUNT(*) as cnt FROM tasks WHERE parent_task_id IS NOT NULL AND status != 'deleted' GROUP BY parent_task_id, status`
-    ).all() as { parent_task_id: number; status: string; cnt: number }[];
+    const subtaskRows = sqlite
+      .prepare(
+        `SELECT parent_task_id, status, COUNT(*) as cnt FROM tasks WHERE parent_task_id IS NOT NULL AND status != 'deleted' GROUP BY parent_task_id, status`,
+      )
+      .all() as { parent_task_id: number; status: string; cnt: number }[];
     const subtaskMap: Record<number, any> = {};
     for (const r of subtaskRows) {
-      if (!subtaskMap[r.parent_task_id]) subtaskMap[r.parent_task_id] = { count: 0, done: 0, in_progress: 0, todo: 0, blocked: 0, in_review: 0, backlog: 0, cancelled: 0 };
+      if (!subtaskMap[r.parent_task_id])
+        subtaskMap[r.parent_task_id] = {
+          count: 0,
+          done: 0,
+          in_progress: 0,
+          todo: 0,
+          blocked: 0,
+          in_review: 0,
+          backlog: 0,
+          cancelled: 0,
+        };
       const s = subtaskMap[r.parent_task_id];
       if (r.status in s && r.status !== 'count') s[r.status] = r.cnt;
       s.count += r.cnt;
@@ -611,7 +983,13 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     }
 
     const columns: Record<string, any[]> = {
-      backlog: [], todo: [], in_progress: [], in_review: [], done: [], blocked: [], cancelled: [],
+      backlog: [],
+      todo: [],
+      in_progress: [],
+      in_review: [],
+      done: [],
+      blocked: [],
+      cancelled: [],
     };
     for (const task of tasks) {
       if (columns[task.status]) columns[task.status].push(task);
@@ -620,16 +998,16 @@ export function registerBoardRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     columns.done.sort((a: any, b: any) => (b.updated_at || '').localeCompare(a.updated_at || ''));
 
     const projectStatus = c.req.query('status');
-    let projectQuery = "SELECT * FROM projects";
+    let projectQuery = 'SELECT * FROM projects';
     const projectParams: any[] = [];
     if (projectStatus) {
-      projectQuery += " WHERE status = ?";
+      projectQuery += ' WHERE status = ?';
       projectParams.push(projectStatus);
     }
-    projectQuery += " ORDER BY CASE status WHEN 'active' THEN 0 WHEN 'paused' THEN 1 WHEN 'completed' THEN 2 END, name";
+    projectQuery +=
+      " ORDER BY CASE status WHEN 'active' THEN 0 WHEN 'paused' THEN 1 WHEN 'completed' THEN 2 END, name";
     const projects = sqlite.prepare(projectQuery).all(...projectParams) as any[];
 
     return c.json({ columns, projects, total: tasks.length });
   });
-
 }

--- a/src/chroma-mcp.ts
+++ b/src/chroma-mcp.ts
@@ -76,25 +76,31 @@ export class ChromaMcpClient {
       this.transport = new StdioClientTransport({
         command: 'uvx',
         args: [
-          '--python', this.pythonVersion,
+          '--python',
+          this.pythonVersion,
           'chroma-mcp',
-          '--client-type', 'persistent',
-          '--data-dir', this.dataDir
+          '--client-type',
+          'persistent',
+          '--data-dir',
+          this.dataDir,
         ],
-        stderr: 'ignore'
+        stderr: 'ignore',
       });
 
-      this.client = new Client({
-        name: 'denbook-chroma',
-        version: '1.0.0'
-      }, {
-        capabilities: {}
-      });
+      this.client = new Client(
+        {
+          name: 'denbook-chroma',
+          version: '1.0.0',
+        },
+        {
+          capabilities: {},
+        },
+      );
 
       await Promise.race([
         this.client.connect(this.transport),
         new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error(`Chroma connection timeout (${timeout}ms)`)), timeout)
+          setTimeout(() => reject(new Error(`Chroma connection timeout (${timeout}ms)`)), timeout),
         ),
       ]);
       this.connected = true;
@@ -102,7 +108,9 @@ export class ChromaMcpClient {
       console.log('Connected to chroma-mcp server');
     } catch (error) {
       this.resetConnection();
-      throw new Error(`Chroma connection failed: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Chroma connection failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 
@@ -129,7 +137,10 @@ export class ChromaMcpClient {
       try {
         await this.client.close();
       } catch (e) {
-        console.warn('[ChromaMCP] client.close() error:', e instanceof Error ? e.message : String(e));
+        console.warn(
+          '[ChromaMCP] client.close() error:',
+          e instanceof Error ? e.message : String(e),
+        );
       }
     }
 
@@ -138,7 +149,10 @@ export class ChromaMcpClient {
       try {
         await this.transport.close();
       } catch (e) {
-        console.warn('[ChromaMCP] transport.close() error:', e instanceof Error ? e.message : String(e));
+        console.warn(
+          '[ChromaMCP] transport.close() error:',
+          e instanceof Error ? e.message : String(e),
+        );
       }
     }
 
@@ -161,20 +175,23 @@ export class ChromaMcpClient {
       await this.client.callTool({
         name: 'chroma_get_collection_info',
         arguments: {
-          collection_name: this.collectionName
-        }
+          collection_name: this.collectionName,
+        },
       });
       console.log(`Collection '${this.collectionName}' exists`);
     } catch (error) {
       // Collection may not exist — or this could be a connection error
-      console.warn('[ChromaMCP] ensureCollection get failed, attempting create:', error instanceof Error ? error.message : String(error));
+      console.warn(
+        '[ChromaMCP] ensureCollection get failed, attempting create:',
+        error instanceof Error ? error.message : String(error),
+      );
       console.log(`Creating collection '${this.collectionName}'...`);
       await this.client.callTool({
         name: 'chroma_create_collection',
         arguments: {
           collection_name: this.collectionName,
-          embedding_function_name: 'default'
-        }
+          embedding_function_name: 'default',
+        },
       });
       console.log(`Collection '${this.collectionName}' created`);
     }
@@ -194,12 +211,15 @@ export class ChromaMcpClient {
       await this.client.callTool({
         name: 'chroma_delete_collection',
         arguments: {
-          collection_name: this.collectionName
-        }
+          collection_name: this.collectionName,
+        },
       });
       console.log(`Collection '${this.collectionName}' deleted`);
     } catch (error) {
-      console.warn('[ChromaMCP] deleteCollection failed (may not exist):', error instanceof Error ? error.message : String(error));
+      console.warn(
+        '[ChromaMCP] deleteCollection failed (may not exist):',
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 
@@ -221,10 +241,10 @@ export class ChromaMcpClient {
       name: 'chroma_add_documents',
       arguments: {
         collection_name: this.collectionName,
-        documents: documents.map(d => d.document),
-        ids: documents.map(d => d.id),
-        metadatas: documents.map(d => d.metadata)
-      }
+        documents: documents.map((d) => d.document),
+        ids: documents.map((d) => d.id),
+        metadatas: documents.map((d) => d.metadata),
+      },
     });
 
     console.log(`Added ${documents.length} documents to collection`);
@@ -237,7 +257,7 @@ export class ChromaMcpClient {
   async query(
     queryText: string,
     limit: number = 10,
-    whereFilter?: Record<string, any>
+    whereFilter?: Record<string, any>,
   ): Promise<{ ids: string[]; documents: string[]; distances: number[]; metadatas: any[] }> {
     // Reconnect if connection died
     try {
@@ -256,7 +276,7 @@ export class ChromaMcpClient {
       collection_name: this.collectionName,
       query_texts: [queryText],
       n_results: limit,
-      include: ['documents', 'metadatas', 'distances']
+      include: ['documents', 'metadatas', 'distances'],
     };
 
     if (whereFilter) {
@@ -267,7 +287,7 @@ export class ChromaMcpClient {
     try {
       result = await this.client.callTool({
         name: 'chroma_query_documents',
-        arguments: args
+        arguments: args,
       });
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -278,7 +298,7 @@ export class ChromaMcpClient {
         await this.connect();
         result = await this.client!.callTool({
           name: 'chroma_query_documents',
-          arguments: args
+          arguments: args,
         });
       } else {
         throw error;
@@ -297,7 +317,7 @@ export class ChromaMcpClient {
       ids: parsed.ids?.[0] || [],
       documents: parsed.documents?.[0] || [],
       distances: parsed.distances?.[0] || [],
-      metadatas: parsed.metadatas?.[0] || []
+      metadatas: parsed.metadatas?.[0] || [],
     };
   }
 
@@ -318,23 +338,28 @@ export class ChromaMcpClient {
       const result = await this.client.callTool({
         name: 'chroma_get_collection_count',
         arguments: {
-          collection_name: this.collectionName
-        }
+          collection_name: this.collectionName,
+        },
       });
 
       const content = result.content as Array<{ type: string; text?: string }>;
       const text = content[0]?.text ?? '0';
       // Response may be just a number or a JSON with count field
-      const count = parseInt(text, 10) || (() => {
-        try {
-          return safeJsonParse(text).count ?? 0;
-        } catch {
-          return 0;
-        }
-      })();
+      const count =
+        parseInt(text, 10) ||
+        (() => {
+          try {
+            return safeJsonParse(text).count ?? 0;
+          } catch {
+            return 0;
+          }
+        })();
       return { count };
     } catch (error) {
-      console.warn('[ChromaMCP] getStats failed:', error instanceof Error ? error.message : String(error));
+      console.warn(
+        '[ChromaMCP] getStats failed:',
+        error instanceof Error ? error.message : String(error),
+      );
       return { count: 0 };
     }
   }
@@ -344,7 +369,7 @@ export class ChromaMcpClient {
    */
   async queryById(
     docId: string,
-    nResults: number = 5
+    nResults: number = 5,
   ): Promise<{ ids: string[]; documents: string[]; distances: number[]; metadatas: any[] }> {
     // First get the document's embedding, then query by it
     await this.connect();
@@ -359,8 +384,8 @@ export class ChromaMcpClient {
       arguments: {
         collection_name: this.collectionName,
         ids: [docId],
-        include: ['embeddings', 'documents', 'metadatas']
-      }
+        include: ['embeddings', 'documents', 'metadatas'],
+      },
     });
 
     const getContent = getResult.content as Array<{ type: string; text?: string }>;
@@ -382,8 +407,8 @@ export class ChromaMcpClient {
         collection_name: this.collectionName,
         query_embeddings: [embeddings],
         n_results: nResults + 1,
-        include: ['documents', 'metadatas', 'distances']
-      }
+        include: ['documents', 'metadatas', 'distances'],
+      },
     });
 
     const queryContent = queryResult.content as Array<{ type: string; text?: string }>;
@@ -399,22 +424,25 @@ export class ChromaMcpClient {
     const metadatas = queryParsed.metadatas?.[0] || [];
 
     // Filter out the source document itself
-    const filtered = ids.reduce((acc: any, id: string, i: number) => {
-      if (id !== docId) {
-        acc.ids.push(id);
-        acc.documents.push(documents[i]);
-        acc.distances.push(distances[i]);
-        acc.metadatas.push(metadatas[i]);
-      }
-      return acc;
-    }, { ids: [], documents: [], distances: [], metadatas: [] });
+    const filtered = ids.reduce(
+      (acc: any, id: string, i: number) => {
+        if (id !== docId) {
+          acc.ids.push(id);
+          acc.documents.push(documents[i]);
+          acc.distances.push(distances[i]);
+          acc.metadatas.push(metadatas[i]);
+        }
+        return acc;
+      },
+      { ids: [], documents: [], distances: [], metadatas: [] },
+    );
 
     // Trim to requested count
     return {
       ids: filtered.ids.slice(0, nResults),
       documents: filtered.documents.slice(0, nResults),
       distances: filtered.distances.slice(0, nResults),
-      metadatas: filtered.metadatas.slice(0, nResults)
+      metadatas: filtered.metadatas.slice(0, nResults),
     };
   }
 
@@ -432,8 +460,8 @@ export class ChromaMcpClient {
       const result = await this.client.callTool({
         name: 'chroma_get_collection_info',
         arguments: {
-          collection_name: this.collectionName
-        }
+          collection_name: this.collectionName,
+        },
       });
 
       const content = result.content as Array<{ type: string; text?: string }>;
@@ -445,10 +473,13 @@ export class ChromaMcpClient {
       const parsed = safeJsonParse(data.text);
       return {
         count: parsed.count || 0,
-        name: this.collectionName
+        name: this.collectionName,
       };
     } catch (error) {
-      console.warn('[ChromaMCP] getCollectionInfo failed:', error instanceof Error ? error.message : String(error));
+      console.warn(
+        '[ChromaMCP] getCollectionInfo failed:',
+        error instanceof Error ? error.message : String(error),
+      );
       return { count: 0, name: this.collectionName };
     }
   }
@@ -473,8 +504,8 @@ export class ChromaMcpClient {
       arguments: {
         collection_name: this.collectionName,
         limit,
-        include: ['embeddings', 'metadatas']
-      }
+        include: ['embeddings', 'metadatas'],
+      },
     });
 
     const content = result.content as Array<{ type: string; text?: string }>;
@@ -487,7 +518,7 @@ export class ChromaMcpClient {
     return {
       ids: parsed.ids || [],
       embeddings: parsed.embeddings || [],
-      metadatas: parsed.metadatas || []
+      metadatas: parsed.metadatas || [],
     };
   }
 }

--- a/src/cli/commands/read.ts
+++ b/src/cli/commands/read.ts
@@ -9,9 +9,7 @@ export function registerRead(program: Command): void {
     .option('--json', 'Output raw JSON')
     .action(async (fileOrId, opts) => {
       const isFile = fileOrId.includes('/') || fileOrId.endsWith('.md');
-      const query = isFile
-        ? { file: fileOrId }
-        : { id: fileOrId };
+      const query = isFile ? { file: fileOrId } : { id: fileOrId };
 
       const data = await oracleFetch('/api/read', { query });
 

--- a/src/cli/commands/schedule.ts
+++ b/src/cli/commands/schedule.ts
@@ -3,9 +3,7 @@ import { oracleFetch } from '../http.ts';
 import { printJson, printSchedule } from '../format.ts';
 
 export function registerSchedule(program: Command): void {
-  const sched = program
-    .command('schedule')
-    .description('View and manage scheduled events');
+  const sched = program.command('schedule').description('View and manage scheduled events');
 
   sched
     .command('list')
@@ -56,9 +54,11 @@ export function registerSchedule(program: Command): void {
     });
 
   // Default action: list
-  sched.action(async (opts) => {
-    const data = await oracleFetch('/api/schedule');
-    if (opts.json) return printJson(data);
-    printSchedule(data.events || data.schedule || [], data.total || 0);
-  }).option('--json', 'Output raw JSON');
+  sched
+    .action(async (opts) => {
+      const data = await oracleFetch('/api/schedule');
+      if (opts.json) return printJson(data);
+      printSchedule(data.events || data.schedule || [], data.total || 0);
+    })
+    .option('--json', 'Output raw JSON');
 }

--- a/src/cli/commands/server.ts
+++ b/src/cli/commands/server.ts
@@ -6,9 +6,7 @@ import { printJson } from '../format.ts';
 import { PORT } from '../../config.ts';
 
 export function registerServer(program: Command): void {
-  const srv = program
-    .command('server')
-    .description('Manage Oracle HTTP server');
+  const srv = program.command('server').description('Manage Oracle HTTP server');
 
   srv
     .command('start')
@@ -74,13 +72,15 @@ export function registerServer(program: Command): void {
     });
 
   // Default action: status
-  srv.action(async (opts) => {
-    const status = await getServerStatus();
-    if (opts.json) return printJson(status);
-    console.log(`Running:  ${status.running ? 'yes' : 'no'}`);
-    if (status.pid) console.log(`PID:      ${status.pid}`);
-    console.log(`Port:     ${status.port}`);
-    console.log(`Healthy:  ${status.healthy ? 'yes' : 'no'}`);
-    console.log(`URL:      ${status.url}`);
-  }).option('--json', 'Output raw JSON');
+  srv
+    .action(async (opts) => {
+      const status = await getServerStatus();
+      if (opts.json) return printJson(status);
+      console.log(`Running:  ${status.running ? 'yes' : 'no'}`);
+      if (status.pid) console.log(`PID:      ${status.pid}`);
+      console.log(`Port:     ${status.port}`);
+      console.log(`Healthy:  ${status.healthy ? 'yes' : 'no'}`);
+      console.log(`URL:      ${status.url}`);
+    })
+    .option('--json', 'Output raw JSON');
 }

--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -20,9 +20,12 @@ export function registerStats(program: Command): void {
         }
       }
       if (data.vector) {
-        console.log(`  Vector: ${data.vector.enabled ? `${data.vector.count} embeddings` : 'disabled'}`);
+        console.log(
+          `  Vector: ${data.vector.enabled ? `${data.vector.count} embeddings` : 'disabled'}`,
+        );
       }
       if (data.vault_repo) console.log(`  Vault: ${data.vault_repo}`);
-      if (data.lastIndexed) console.log(`  Last indexed: ${new Date(data.lastIndexed).toISOString()}`);
+      if (data.lastIndexed)
+        console.log(`  Last indexed: ${new Date(data.lastIndexed).toISOString()}`);
     });
 }

--- a/src/cli/commands/vault.ts
+++ b/src/cli/commands/vault.ts
@@ -7,9 +7,7 @@ import path from 'path';
 import fs from 'fs';
 
 export function registerVault(program: Command): void {
-  const vault = program
-    .command('vault')
-    .description('Manage Oracle knowledge vault');
+  const vault = program.command('vault').description('Manage Oracle knowledge vault');
 
   const repoRoot = process.env.ORACLE_REPO_ROOT || process.cwd();
 
@@ -57,7 +55,9 @@ export function registerVault(program: Command): void {
       if (result.lastSync) console.log(`Last sync: ${result.lastSync}`);
       if (result.pending && result.pending.total > 0) {
         console.log(`\nPending changes: ${result.pending.total}`);
-        console.log(`  Added: ${result.pending.added}  Modified: ${result.pending.modified}  Deleted: ${result.pending.deleted}`);
+        console.log(
+          `  Added: ${result.pending.added}  Modified: ${result.pending.modified}  Deleted: ${result.pending.deleted}`,
+        );
       }
     });
 
@@ -98,18 +98,21 @@ export function registerVault(program: Command): void {
       }
 
       if (opts.dryRun) console.error('[Vault] DRY RUN — no files will be copied\n');
-      if (opts.symlink) console.error('[Vault] SYMLINK MODE — local psi will be replaced with symlinks\n');
+      if (opts.symlink)
+        console.error('[Vault] SYMLINK MODE — local psi will be replaced with symlinks\n');
       const result = migrate({ dryRun: opts.dryRun, symlink: opts.symlink });
       if (opts.json) return printJson(result);
       console.log(JSON.stringify(result, null, 2));
     });
 
   // Default action: status
-  vault.action(async (opts) => {
-    const result = vaultStatus(repoRoot);
-    if (opts.json) return printJson(result);
-    console.log(`Vault: ${result.enabled ? 'enabled' : 'disabled'}`);
-    if (result.repo) console.log(`Repo:  ${result.repo}`);
-    if (result.vaultPath) console.log(`Path:  ${result.vaultPath}`);
-  }).option('--json', 'Output raw JSON');
+  vault
+    .action(async (opts) => {
+      const result = vaultStatus(repoRoot);
+      if (opts.json) return printJson(result);
+      console.log(`Vault: ${result.enabled ? 'enabled' : 'disabled'}`);
+      if (result.repo) console.log(`Repo:  ${result.repo}`);
+      if (result.vaultPath) console.log(`Path:  ${result.vaultPath}`);
+    })
+    .option('--json', 'Output raw JSON');
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,7 +26,7 @@ import fs from 'fs';
 import path from 'path';
 
 const pkg = JSON.parse(
-  fs.readFileSync(path.join(import.meta.dirname || __dirname, '..', '..', 'package.json'), 'utf-8')
+  fs.readFileSync(path.join(import.meta.dirname || __dirname, '..', '..', 'package.json'), 'utf-8'),
 );
 
 const program = new Command();

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,8 @@ export const DB_PATH = process.env.ORACLE_DB_PATH || path.join(ORACLE_DATA_DIR, 
 // When running from source: defaults to project root (where ψ/ lives)
 // When running via bunx: set ORACLE_REPO_ROOT explicitly
 // Fallback: ~/.oracle for bunx installs
-export const REPO_ROOT = process.env.ORACLE_REPO_ROOT ||
+export const REPO_ROOT =
+  process.env.ORACLE_REPO_ROOT ||
   (fs.existsSync(path.join(PROJECT_ROOT, 'ψ')) ? PROJECT_ROOT : ORACLE_DATA_DIR);
 
 // Ensure data directory exists (for fresh installs via bunx)

--- a/src/daemons/routes.ts
+++ b/src/daemons/routes.ts
@@ -49,20 +49,27 @@ function perBeastDrainAlive(pidPath: string): boolean {
     const pid = parseInt(fs.readFileSync(pidPath, 'utf-8').trim(), 10);
     if (!pid || isNaN(pid)) return false;
     // Layer 1: process exists?
-    try { process.kill(pid, 0); }
-    catch { return false; } // ESRCH = process gone
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return false;
+    } // ESRCH = process gone
     // Layer 2: process is actually notify-drain.sh? (PID-reuse defense)
     try {
       const cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
       return cmdline.includes('notify-drain.sh');
-    } catch { return false; } // /proc gone or unreadable = treat as dead
-  } catch { return false; }
+    } catch {
+      return false;
+    } // /proc gone or unreadable = treat as dead
+  } catch {
+    return false;
+  }
 }
 
 function runDrainCycle() {
   try {
     if (!fs.existsSync(DRAIN_DIR)) return;
-    const files = fs.readdirSync(DRAIN_DIR).filter(f => f.endsWith('.queue'));
+    const files = fs.readdirSync(DRAIN_DIR).filter((f) => f.endsWith('.queue'));
 
     for (const file of files) {
       const beast = file.replace('.queue', '');
@@ -80,7 +87,9 @@ function runDrainCycle() {
       // T#738 / Spec #54 Phase 5 Window 2: log-only-warning when server-drain
       // falls back to handling a queue that should be per-Beast-drained.
       // After 7 days of zero warnings → Window 3 removes runDrainCycle entirely.
-      console.warn(`[Notify] WINDOW-2-WARNING: server-drain fallback for ${beast} — per-Beast drain NOT alive (pid: ${pidPath})`);
+      console.warn(
+        `[Notify] WINDOW-2-WARNING: server-drain fallback for ${beast} — per-Beast drain NOT alive (pid: ${pidPath})`,
+      );
 
       // Check spacing — don't send to same Beast within DRAIN_SPACING
       const lastSent = drainLastSent.get(beast) || 0;
@@ -90,12 +99,16 @@ function runDrainCycle() {
       try {
         const stat = fs.statSync(queuePath);
         if (stat.size === 0) continue;
-      } catch { continue; }
+      } catch {
+        continue;
+      }
 
       // Read and remove first line atomically via flock
       try {
-        const result = Bun.spawnSync(['bash', '-c',
-          `flock "${lockPath}" bash -c "head -1 '${queuePath}' && sed -i '1d' '${queuePath}'"`
+        const result = Bun.spawnSync([
+          'bash',
+          '-c',
+          `flock "${lockPath}" bash -c "head -1 '${queuePath}' && sed -i '1d' '${queuePath}'"`,
         ]);
         const encoded = result.stdout.toString().trim();
         if (!encoded) continue;
@@ -112,10 +125,14 @@ function runDrainCycle() {
         if (hasSession.exitCode !== 0) {
           // Beast offline — re-append to tail of queue so it retries next cycle
           try {
-            Bun.spawnSync(['bash', '-c',
-              `umask 0077 && flock "${lockPath}" bash -c "echo '${encoded}' >> '${queuePath}'"`
+            Bun.spawnSync([
+              'bash',
+              '-c',
+              `umask 0077 && flock "${lockPath}" bash -c "echo '${encoded}' >> '${queuePath}'"`,
             ]);
-          } catch { /* best effort re-queue */ }
+          } catch {
+            /* best effort re-queue */
+          }
           drainLastSent.set(beast, Date.now()); // avoid spinning on offline Beasts
           continue;
         }
@@ -135,7 +152,9 @@ function runDrainCycle() {
         // Silent — don't spam logs on queue errors
       }
     }
-  } catch { /* DRAIN_DIR doesn't exist yet */ }
+  } catch {
+    /* DRAIN_DIR doesn't exist yet */
+  }
 }
 
 // Startup setInterval/setTimeout for runDrainCycle moved into initDaemons() — see bottom.
@@ -154,9 +173,9 @@ function runDbMaintenance() {
     const cutoff = `-${DB_RETENTION_DAYS} days`;
 
     // Prune audit_log older than retention period
-    const auditResult = sqlite.prepare(
-      `DELETE FROM audit_log WHERE timestamp < datetime('now', ?)`
-    ).run(cutoff);
+    const auditResult = sqlite
+      .prepare(`DELETE FROM audit_log WHERE timestamp < datetime('now', ?)`)
+      .run(cutoff);
 
     // Prune security_events older than 90-day retention period
     const securityPruned = pruneSecurityEvents();
@@ -169,7 +188,9 @@ function runDbMaintenance() {
     if (pruned > 0) {
       // VACUUM to reclaim space after large deletes
       sqlite.exec('VACUUM');
-      console.log(`[DB Maintenance] Pruned ${auditResult.changes} audit rows (>${DB_RETENTION_DAYS}d), ${securityPruned} security events (>${SECURITY_RETENTION_DAYS}d), ${tokensPruned} expired tokens. VACUUM complete.`);
+      console.log(
+        `[DB Maintenance] Pruned ${auditResult.changes} audit rows (>${DB_RETENTION_DAYS}d), ${securityPruned} security events (>${SECURITY_RETENTION_DAYS}d), ${tokensPruned} expired tokens. VACUUM complete.`,
+      );
     } else {
       console.log(`[DB Maintenance] Nothing to prune.`);
     }
@@ -177,7 +198,6 @@ function runDbMaintenance() {
     console.error(`[DB Maintenance] Error: ${err}`);
   }
 }
-
 
 // ── File Archive Cycle (T#533) ──────────────────────────────────────
 // Moves soft-deleted files to compressed tar.gz archives after 7-day grace period.
@@ -190,13 +210,20 @@ function runFileArchive() {
   if (!moduleSqlite) return;
   const sqlite: Database = moduleSqlite;
   try {
-    const graceCutoff = Date.now() - (FILE_ARCHIVE_GRACE_DAYS * 24 * 60 * 60 * 1000);
+    const graceCutoff = Date.now() - FILE_ARCHIVE_GRACE_DAYS * 24 * 60 * 60 * 1000;
 
     // Find files deleted more than 7 days ago that haven't been archived yet
-    const filesToArchive = sqlite.prepare(
-      `SELECT id, filename, original_name, size_bytes FROM files
-       WHERE deleted_at IS NOT NULL AND deleted_at < ? AND archived_at IS NULL`
-    ).all(graceCutoff) as { id: number; filename: string; original_name: string; size_bytes: number }[];
+    const filesToArchive = sqlite
+      .prepare(
+        `SELECT id, filename, original_name, size_bytes FROM files
+       WHERE deleted_at IS NOT NULL AND deleted_at < ? AND archived_at IS NULL`,
+      )
+      .all(graceCutoff) as {
+      id: number;
+      filename: string;
+      original_name: string;
+      size_bytes: number;
+    }[];
 
     if (filesToArchive.length === 0) return;
 
@@ -234,11 +261,14 @@ function runFileArchive() {
       const suffix = Date.now().toString(36);
       finalArchivePath = path.join(archiveDir, `archive-${dateStr}-${suffix}.tar.gz`);
     }
-    const finalRelativePath = path.relative(path.join(ORACLE_DATA_DIR, 'uploads'), finalArchivePath);
+    const finalRelativePath = path.relative(
+      path.join(ORACLE_DATA_DIR, 'uploads'),
+      finalArchivePath,
+    );
 
     // Create a file list for tar
     const fileListPath = path.join(archiveDir, `.archive-list-${Date.now()}.txt`);
-    fs.writeFileSync(fileListPath, existingFiles.map(f => f.filename).join('\n'));
+    fs.writeFileSync(fileListPath, existingFiles.map((f) => f.filename).join('\n'));
 
     const { execSync } = require('child_process');
     execSync(`tar -czf "${finalArchivePath}" -C "${UPLOADS_DIR}" -T "${fileListPath}"`, {
@@ -258,7 +288,9 @@ function runFileArchive() {
 
     // Update DB: mark files as archived, remove originals
     const archiveTimestamp = Date.now();
-    const updateStmt = sqlite.prepare('UPDATE files SET archived_at = ?, archive_path = ? WHERE id = ?');
+    const updateStmt = sqlite.prepare(
+      'UPDATE files SET archived_at = ?, archive_path = ? WHERE id = ?',
+    );
     let totalFreed = 0;
 
     for (const f of existingFiles) {
@@ -272,13 +304,13 @@ function runFileArchive() {
       }
     }
 
-    console.log(`[File Archive] Archived ${existingFiles.length} files → ${finalRelativePath} (${(archiveSize / 1024).toFixed(1)}KB archive, ${(totalFreed / 1024 / 1024).toFixed(1)}MB freed)`);
+    console.log(
+      `[File Archive] Archived ${existingFiles.length} files → ${finalRelativePath} (${(archiveSize / 1024).toFixed(1)}KB archive, ${(totalFreed / 1024 / 1024).toFixed(1)}MB freed)`,
+    );
   } catch (err) {
     console.error(`[File Archive] Error:`, err);
   }
 }
-
-
 
 // ============================================================================
 // initDaemons — server startup entry: capture sqlite + start all daemons once
@@ -314,7 +346,11 @@ interface DaemonHelpers {
   isTrustedRequest: (c: Context) => boolean;
 }
 
-export function registerDaemonRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: DaemonHelpers): void {
+export function registerDaemonRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: DaemonHelpers,
+): void {
   // Shadow module-level sqlite (Database | null) with non-null local
   const sqlite: Database = sqliteDb;
   const { hasSessionAuth, isTrustedRequest } = helpers;
@@ -323,7 +359,10 @@ export function registerDaemonRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
   // Closes DAEMON-1..4 — missing-auth or broken Gorn-only checks.
   const requireOwner = (c: Context) => {
     if (!hasSessionAuth(c) && !isTrustedRequest(c)) {
-      return c.json({ error: 'Gorn-only — session or trusted-request required', requiresAuth: true }, 403);
+      return c.json(
+        { error: 'Gorn-only — session or trusted-request required', requiresAuth: true },
+        403,
+      );
     }
     return null;
   };
@@ -343,12 +382,16 @@ export function registerDaemonRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     // T#789 DAEMON-4 — owner-only read (table sizes are info-disclosure surface).
     const gate = requireOwner(c);
     if (gate) return gate;
-    const tables = sqlite.prepare(
-      `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`
-    ).all() as { name: string }[];
+    const tables = sqlite
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+      )
+      .all() as { name: string }[];
 
     const stats = tables.map((t) => {
-      const row = sqlite.prepare(`SELECT COUNT(*) as cnt FROM "${t.name}"`).get() as { cnt: number };
+      const row = sqlite.prepare(`SELECT COUNT(*) as cnt FROM "${t.name}"`).get() as {
+        cnt: number;
+      };
       return { table: t.name, rows: row.cnt };
     });
 
@@ -367,21 +410,24 @@ export function registerDaemonRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
   // Run maintenance on boot (after 30s) and every 6 hours
   setTimeout(runDbMaintenance, 30_000);
 
-
   // File archive routes
   // GET /api/files/archive/stats — archive statistics
   app.get('/api/files/archive/stats', (c) => {
     // T#789 DAEMON-4 — owner-only read (archive bundle filenames are info-disclosure surface).
     const gate = requireOwner(c);
     if (gate) return gate;
-    const archived = sqlite.prepare(
-      `SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as original_size FROM files WHERE archived_at IS NOT NULL`
-    ).get() as any;
+    const archived = sqlite
+      .prepare(
+        `SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as original_size FROM files WHERE archived_at IS NOT NULL`,
+      )
+      .get() as any;
 
-    const pending = sqlite.prepare(
-      `SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM files
-       WHERE deleted_at IS NOT NULL AND archived_at IS NULL`
-    ).get() as any;
+    const pending = sqlite
+      .prepare(
+        `SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM files
+       WHERE deleted_at IS NOT NULL AND archived_at IS NULL`,
+      )
+      .get() as any;
 
     // List archive bundles on disk
     const bundles: { path: string; size: number; created: string }[] = [];
@@ -457,7 +503,16 @@ export function registerDaemonRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     }
 
     // Clear deleted_at and archived_at
-    sqlite.prepare('UPDATE files SET deleted_at = NULL, archived_at = NULL, archive_path = NULL WHERE id = ?').run(id);
-    return c.json({ restored: true, id, filename: file.filename, original_name: file.original_name });
+    sqlite
+      .prepare(
+        'UPDATE files SET deleted_at = NULL, archived_at = NULL, archive_path = NULL WHERE id = ?',
+      )
+      .run(id);
+    return c.json({
+      restored: true,
+      id,
+      filename: file.filename,
+      original_name: file.original_name,
+    });
   });
 }

--- a/src/dashboard/routes.ts
+++ b/src/dashboard/routes.ts
@@ -24,9 +24,27 @@ interface DashboardHelpers {
   setOracleCache: (cache: { data: any; ts: number } | null) => void;
 }
 
-export function registerDashboardRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: DashboardHelpers): void {
+export function registerDashboardRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: DashboardHelpers,
+): void {
   const sqlite: Database = sqliteDb;
-  const { hasSessionAuth, handleDashboardSummary, handleDashboardActivity, handleDashboardGrowth, handleStats, handleReflect, handleList, handleGraph, handleMap, handleMap3d, handleVectorStats, getSetting, DB_PATH } = helpers;
+  const {
+    hasSessionAuth,
+    handleDashboardSummary,
+    handleDashboardActivity,
+    handleDashboardGrowth,
+    handleStats,
+    handleReflect,
+    handleList,
+    handleGraph,
+    handleMap,
+    handleMap3d,
+    handleVectorStats,
+    getSetting,
+    DB_PATH,
+  } = helpers;
   let oracleCache = helpers.oracleCache;
 
   app.get('/api/reflect', (c) => {
@@ -39,18 +57,21 @@ export function registerDashboardRoutes(app: OpenAPIHono, sqliteDb: Database, he
     let vectorStats = { vector: { enabled: false, count: 0, collection: 'oracle_knowledge' } };
     try {
       vectorStats = await handleVectorStats();
-    } catch { /* vector unavailable */ }
+    } catch {
+      /* vector unavailable */
+    }
     return c.json({ ...stats, ...vectorStats, vault_repo: vaultRepo });
   });
 
   app.get('/api/oracles', (c) => {
     const hours = parseInt(c.req.query('hours') || '168'); // default 7 days
     const now = Date.now();
-    if (oracleCache && (now - oracleCache.ts) < 60_000) return c.json(oracleCache.data);
+    if (oracleCache && now - oracleCache.ts < 60_000) return c.json(oracleCache.data);
 
     const cutoff = now - hours * 3600_000;
     // Active identities (forum authors, trace sessions, learn sources)
-    const identities = sqlite.prepare(`
+    const identities = sqlite
+      .prepare(`
       SELECT oracle_name, source, max(last_seen) as last_seen, sum(actions) as actions
       FROM (
         SELECT author as oracle_name, 'forum' as source, max(created_at) as last_seen, count(*) as actions
@@ -68,10 +89,12 @@ export function registerDashboardRoutes(app: OpenAPIHono, sqliteDb: Database, he
       WHERE oracle_name IS NOT NULL AND oracle_name != 'unknown'
       GROUP BY oracle_name
       ORDER BY last_seen DESC
-    `).all(cutoff, cutoff, cutoff);
+    `)
+      .all(cutoff, cutoff, cutoff);
 
     // Projects with indexed knowledge (each project = an Oracle's domain)
-    const projects = sqlite.prepare(`
+    const projects = sqlite
+      .prepare(`
       SELECT project, count(*) as docs,
              count(DISTINCT type) as types,
              max(created_at) as last_indexed
@@ -79,7 +102,8 @@ export function registerDashboardRoutes(app: OpenAPIHono, sqliteDb: Database, he
       WHERE project IS NOT NULL
       GROUP BY project
       ORDER BY last_indexed DESC
-    `).all();
+    `)
+      .all();
 
     const result = {
       identities,
@@ -138,6 +162,4 @@ export function registerDashboardRoutes(app: OpenAPIHono, sqliteDb: Database, he
     const period = c.req.query('period') || 'week';
     return c.json(handleDashboardGrowth(period));
   });
-
-
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -52,10 +52,16 @@ function initializeDatabase(sqliteDb: Database, drizzleDb: BunSQLiteDatabase<typ
   sqliteDb.exec('INSERT OR IGNORE INTO indexing_status (id, is_indexing) VALUES (1, 0)');
 
   // One-time migration: normalize project casing to lowercase
-  const migrated = sqliteDb.prepare("SELECT value FROM settings WHERE key = 'migration_lowercase_projects'").get() as { value: string } | undefined;
+  const migrated = sqliteDb
+    .prepare("SELECT value FROM settings WHERE key = 'migration_lowercase_projects'")
+    .get() as { value: string } | undefined;
   if (!migrated) {
-    sqliteDb.exec("UPDATE oracle_documents SET project = LOWER(project) WHERE project <> LOWER(project)");
-    sqliteDb.exec("INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('migration_lowercase_projects', '1', unixepoch() * 1000)");
+    sqliteDb.exec(
+      'UPDATE oracle_documents SET project = LOWER(project) WHERE project <> LOWER(project)',
+    );
+    sqliteDb.exec(
+      "INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('migration_lowercase_projects', '1', unixepoch() * 1000)",
+    );
   }
 }
 
@@ -109,7 +115,13 @@ export * from './schema.ts';
 // ============================================================================
 
 export function getBeastProfile(name: string) {
-  return db.select().from(schema.beastProfiles).where(eq(schema.beastProfiles.name, name.toLowerCase())).get() ?? null;
+  return (
+    db
+      .select()
+      .from(schema.beastProfiles)
+      .where(eq(schema.beastProfiles.name, name.toLowerCase()))
+      .get() ?? null
+  );
 }
 
 export function getAllBeastProfiles() {
@@ -129,7 +141,8 @@ export function upsertBeastProfile(profile: {
   const now = Date.now();
   const name = profile.name.toLowerCase();
 
-  return db.insert(schema.beastProfiles)
+  return db
+    .insert(schema.beastProfiles)
     .values({
       name,
       displayName: profile.displayName,
@@ -159,7 +172,8 @@ export function upsertBeastProfile(profile: {
 }
 
 export function updateBeastAvatar(name: string, avatarUrl: string) {
-  return db.update(schema.beastProfiles)
+  return db
+    .update(schema.beastProfiles)
     .set({ avatarUrl, updatedAt: Date.now() })
     .where(eq(schema.beastProfiles.name, name.toLowerCase()))
     .run();

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,29 +8,33 @@
 import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
 
 // Main document index table
-export const oracleDocuments = sqliteTable('oracle_documents', {
-  id: text('id').primaryKey(),
-  type: text('type').notNull(),
-  sourceFile: text('source_file').notNull(),
-  concepts: text('concepts').notNull(), // JSON array
-  createdAt: integer('created_at').notNull(),
-  updatedAt: integer('updated_at').notNull(),
-  indexedAt: integer('indexed_at').notNull(),
-  // Supersede pattern (Issue #19) - "Nothing is Deleted" but can be outdated
-  supersededBy: text('superseded_by'),      // ID of newer document
-  supersededAt: integer('superseded_at'),   // When it was superseded
-  supersededReason: text('superseded_reason'), // Why (optional)
-  // Provenance tracking (Issue #22)
-  origin: text('origin'),                   // 'mother' | 'arthur' | 'volt' | 'human' | null (legacy)
-  project: text('project'),                 // ghq-style: 'github.com/alliedgorn/denbook'
-  createdBy: text('created_by'),            // 'indexer' | 'oracle_learn' | 'manual'
-}, (table) => [
-  index('idx_source').on(table.sourceFile),
-  index('idx_type').on(table.type),
-  index('idx_superseded').on(table.supersededBy),
-  index('idx_origin').on(table.origin),
-  index('idx_project').on(table.project),
-]);
+export const oracleDocuments = sqliteTable(
+  'oracle_documents',
+  {
+    id: text('id').primaryKey(),
+    type: text('type').notNull(),
+    sourceFile: text('source_file').notNull(),
+    concepts: text('concepts').notNull(), // JSON array
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+    indexedAt: integer('indexed_at').notNull(),
+    // Supersede pattern (Issue #19) - "Nothing is Deleted" but can be outdated
+    supersededBy: text('superseded_by'), // ID of newer document
+    supersededAt: integer('superseded_at'), // When it was superseded
+    supersededReason: text('superseded_reason'), // Why (optional)
+    // Provenance tracking (Issue #22)
+    origin: text('origin'), // 'mother' | 'arthur' | 'volt' | 'human' | null (legacy)
+    project: text('project'), // ghq-style: 'github.com/alliedgorn/denbook'
+    createdBy: text('created_by'), // 'indexer' | 'oracle_learn' | 'manual'
+  },
+  (table) => [
+    index('idx_source').on(table.sourceFile),
+    index('idx_type').on(table.type),
+    index('idx_superseded').on(table.supersededBy),
+    index('idx_origin').on(table.origin),
+    index('idx_project').on(table.project),
+  ],
+);
 
 // Indexing status tracking
 export const indexingStatus = sqliteTable('indexing_status', {
@@ -41,91 +45,113 @@ export const indexingStatus = sqliteTable('indexing_status', {
   startedAt: integer('started_at'),
   completedAt: integer('completed_at'),
   error: text('error'),
-  repoRoot: text('repo_root'),  // Root directory being indexed
+  repoRoot: text('repo_root'), // Root directory being indexed
 });
 
 // Search query logging
-export const searchLog = sqliteTable('search_log', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  query: text('query').notNull(),
-  type: text('type'),
-  mode: text('mode'),
-  resultsCount: integer('results_count'),
-  searchTimeMs: integer('search_time_ms'),
-  createdAt: integer('created_at').notNull(),
-  project: text('project'),
-  results: text('results'), // JSON array of top 5 results (id, type, score, snippet)
-}, (table) => [
-  index('idx_search_project').on(table.project),
-  index('idx_search_created').on(table.createdAt),
-]);
+export const searchLog = sqliteTable(
+  'search_log',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    query: text('query').notNull(),
+    type: text('type'),
+    mode: text('mode'),
+    resultsCount: integer('results_count'),
+    searchTimeMs: integer('search_time_ms'),
+    createdAt: integer('created_at').notNull(),
+    project: text('project'),
+    results: text('results'), // JSON array of top 5 results (id, type, score, snippet)
+  },
+  (table) => [
+    index('idx_search_project').on(table.project),
+    index('idx_search_created').on(table.createdAt),
+  ],
+);
 
 // Learning/pattern logging
-export const learnLog = sqliteTable('learn_log', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  documentId: text('document_id').notNull(),
-  patternPreview: text('pattern_preview'),
-  source: text('source'),
-  concepts: text('concepts'), // JSON array
-  createdAt: integer('created_at').notNull(),
-  project: text('project'),
-}, (table) => [
-  index('idx_learn_project').on(table.project),
-  index('idx_learn_created').on(table.createdAt),
-]);
+export const learnLog = sqliteTable(
+  'learn_log',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    documentId: text('document_id').notNull(),
+    patternPreview: text('pattern_preview'),
+    source: text('source'),
+    concepts: text('concepts'), // JSON array
+    createdAt: integer('created_at').notNull(),
+    project: text('project'),
+  },
+  (table) => [
+    index('idx_learn_project').on(table.project),
+    index('idx_learn_created').on(table.createdAt),
+  ],
+);
 
 // Document access logging
-export const documentAccess = sqliteTable('document_access', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  documentId: text('document_id').notNull(),
-  accessType: text('access_type'),
-  createdAt: integer('created_at').notNull(),
-  project: text('project'),
-}, (table) => [
-  index('idx_access_project').on(table.project),
-  index('idx_access_created').on(table.createdAt),
-  index('idx_access_doc').on(table.documentId),
-]);
+export const documentAccess = sqliteTable(
+  'document_access',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    documentId: text('document_id').notNull(),
+    accessType: text('access_type'),
+    createdAt: integer('created_at').notNull(),
+    project: text('project'),
+  },
+  (table) => [
+    index('idx_access_project').on(table.project),
+    index('idx_access_created').on(table.createdAt),
+    index('idx_access_doc').on(table.documentId),
+  ],
+);
 
 // ============================================================================
 // Forum Tables (threaded discussions with Oracle)
 // ============================================================================
 
 // Forum threads - conversation topics
-export const forumThreads = sqliteTable('forum_threads', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  title: text('title').notNull(),
-  createdBy: text('created_by').default('human'),
-  status: text('status').default('active'), // active, answered, pending, closed
-  issueUrl: text('issue_url'),              // GitHub mirror URL
-  issueNumber: integer('issue_number'),
-  project: text('project'),
-  createdAt: integer('created_at').notNull(),
-  updatedAt: integer('updated_at').notNull(),
-  syncedAt: integer('synced_at'),
-}, (table) => [
-  index('idx_thread_status').on(table.status),
-  index('idx_thread_project').on(table.project),
-  index('idx_thread_created').on(table.createdAt),
-]);
+export const forumThreads = sqliteTable(
+  'forum_threads',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    title: text('title').notNull(),
+    createdBy: text('created_by').default('human'),
+    status: text('status').default('active'), // active, answered, pending, closed
+    issueUrl: text('issue_url'), // GitHub mirror URL
+    issueNumber: integer('issue_number'),
+    project: text('project'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+    syncedAt: integer('synced_at'),
+  },
+  (table) => [
+    index('idx_thread_status').on(table.status),
+    index('idx_thread_project').on(table.project),
+    index('idx_thread_created').on(table.createdAt),
+  ],
+);
 
 // Forum messages - individual Q&A in threads
-export const forumMessages = sqliteTable('forum_messages', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  threadId: integer('thread_id').notNull().references(() => forumThreads.id),
-  role: text('role').notNull(),             // human, oracle, claude
-  content: text('content').notNull(),
-  author: text('author'),                   // GitHub username or "oracle"
-  principlesFound: integer('principles_found'),
-  patternsFound: integer('patterns_found'),
-  searchQuery: text('search_query'),
-  commentId: integer('comment_id'),         // GitHub comment ID if synced
-  createdAt: integer('created_at').notNull(),
-}, (table) => [
-  index('idx_message_thread').on(table.threadId),
-  index('idx_message_role').on(table.role),
-  index('idx_message_created').on(table.createdAt),
-]);
+export const forumMessages = sqliteTable(
+  'forum_messages',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    threadId: integer('thread_id')
+      .notNull()
+      .references(() => forumThreads.id),
+    role: text('role').notNull(), // human, oracle, claude
+    content: text('content').notNull(),
+    author: text('author'), // GitHub username or "oracle"
+    principlesFound: integer('principles_found'),
+    patternsFound: integer('patterns_found'),
+    searchQuery: text('search_query'),
+    commentId: integer('comment_id'), // GitHub comment ID if synced
+    createdAt: integer('created_at').notNull(),
+  },
+  (table) => [
+    index('idx_message_thread').on(table.threadId),
+    index('idx_message_role').on(table.role),
+    index('idx_message_created').on(table.createdAt),
+  ],
+);
 
 // Note: FTS5 virtual table (oracle_fts) is managed via raw SQL
 // since Drizzle doesn't natively support FTS5
@@ -135,90 +161,104 @@ export const forumMessages = sqliteTable('forum_messages', {
 // ============================================================================
 
 // DM conversations - pair of participants
-export const dmConversations = sqliteTable('dm_conversations', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  participant1: text('participant1').notNull(),  // alphabetically first
-  participant2: text('participant2').notNull(),  // alphabetically second
-  createdAt: integer('created_at').notNull(),
-  updatedAt: integer('updated_at').notNull(),
-}, (table) => [
-  index('idx_dm_conv_p1').on(table.participant1),
-  index('idx_dm_conv_p2').on(table.participant2),
-  index('idx_dm_conv_updated').on(table.updatedAt),
-]);
+export const dmConversations = sqliteTable(
+  'dm_conversations',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    participant1: text('participant1').notNull(), // alphabetically first
+    participant2: text('participant2').notNull(), // alphabetically second
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    index('idx_dm_conv_p1').on(table.participant1),
+    index('idx_dm_conv_p2').on(table.participant2),
+    index('idx_dm_conv_updated').on(table.updatedAt),
+  ],
+);
 
 // DM messages - individual messages in a conversation
-export const dmMessages = sqliteTable('dm_messages', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  conversationId: integer('conversation_id').notNull().references(() => dmConversations.id),
-  sender: text('sender').notNull(),
-  content: text('content').notNull(),
-  readAt: integer('read_at'),               // null = unread
-  createdAt: integer('created_at').notNull(),
-}, (table) => [
-  index('idx_dm_msg_conv').on(table.conversationId),
-  index('idx_dm_msg_sender').on(table.sender),
-  index('idx_dm_msg_created').on(table.createdAt),
-]);
+export const dmMessages = sqliteTable(
+  'dm_messages',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    conversationId: integer('conversation_id')
+      .notNull()
+      .references(() => dmConversations.id),
+    sender: text('sender').notNull(),
+    content: text('content').notNull(),
+    readAt: integer('read_at'), // null = unread
+    createdAt: integer('created_at').notNull(),
+  },
+  (table) => [
+    index('idx_dm_msg_conv').on(table.conversationId),
+    index('idx_dm_msg_sender').on(table.sender),
+    index('idx_dm_msg_created').on(table.createdAt),
+  ],
+);
 
 // ============================================================================
 // Trace Log Tables (discovery tracing with dig points)
 // ============================================================================
 
 // Trace log - captures /trace sessions with actionable dig points
-export const traceLog = sqliteTable('trace_log', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  traceId: text('trace_id').unique().notNull(),
-  query: text('query').notNull(),
-  queryType: text('query_type').default('general'),  // general, project, pattern, evolution
+export const traceLog = sqliteTable(
+  'trace_log',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    traceId: text('trace_id').unique().notNull(),
+    query: text('query').notNull(),
+    queryType: text('query_type').default('general'), // general, project, pattern, evolution
 
-  // Dig Points (JSON arrays)
-  foundFiles: text('found_files'),            // [{path, type, matchReason, confidence}]
-  foundCommits: text('found_commits'),        // [{hash, shortHash, date, message}]
-  foundIssues: text('found_issues'),          // [{number, title, state, url}]
-  foundRetrospectives: text('found_retrospectives'),  // [paths]
-  foundLearnings: text('found_learnings'),    // [paths]
-  foundResonance: text('found_resonance'),    // [paths]
+    // Dig Points (JSON arrays)
+    foundFiles: text('found_files'), // [{path, type, matchReason, confidence}]
+    foundCommits: text('found_commits'), // [{hash, shortHash, date, message}]
+    foundIssues: text('found_issues'), // [{number, title, state, url}]
+    foundRetrospectives: text('found_retrospectives'), // [paths]
+    foundLearnings: text('found_learnings'), // [paths]
+    foundResonance: text('found_resonance'), // [paths]
 
-  // Counts (for quick stats)
-  fileCount: integer('file_count').default(0),
-  commitCount: integer('commit_count').default(0),
-  issueCount: integer('issue_count').default(0),
+    // Counts (for quick stats)
+    fileCount: integer('file_count').default(0),
+    commitCount: integer('commit_count').default(0),
+    issueCount: integer('issue_count').default(0),
 
-  // Recursion (hierarchical)
-  depth: integer('depth').default(0),         // 0 = initial, 1+ = dig from parent
-  parentTraceId: text('parent_trace_id'),     // Links to parent trace
-  childTraceIds: text('child_trace_ids').default('[]'),  // Links to child traces
+    // Recursion (hierarchical)
+    depth: integer('depth').default(0), // 0 = initial, 1+ = dig from parent
+    parentTraceId: text('parent_trace_id'), // Links to parent trace
+    childTraceIds: text('child_trace_ids').default('[]'), // Links to child traces
 
-  // Linked list (horizontal chain)
-  prevTraceId: text('prev_trace_id'),         // ← Previous trace in chain
-  nextTraceId: text('next_trace_id'),         // → Next trace in chain
+    // Linked list (horizontal chain)
+    prevTraceId: text('prev_trace_id'), // ← Previous trace in chain
+    nextTraceId: text('next_trace_id'), // → Next trace in chain
 
-  // Context
-  project: text('project'),                   // ghq format project path
-  scope: text('scope').default('project'),    // 'project' | 'cross-project' | 'human'
-  sessionId: text('session_id'),              // Claude session if available
-  agentCount: integer('agent_count').default(1),
-  durationMs: integer('duration_ms'),
+    // Context
+    project: text('project'), // ghq format project path
+    scope: text('scope').default('project'), // 'project' | 'cross-project' | 'human'
+    sessionId: text('session_id'), // Claude session if available
+    agentCount: integer('agent_count').default(1),
+    durationMs: integer('duration_ms'),
 
-  // Distillation
-  status: text('status').default('raw'),      // raw, reviewed, distilling, distilled
-  awakening: text('awakening'),               // Extracted insight (markdown)
-  distilledToId: text('distilled_to_id'),     // Learning ID if promoted
-  distilledAt: integer('distilled_at'),
+    // Distillation
+    status: text('status').default('raw'), // raw, reviewed, distilling, distilled
+    awakening: text('awakening'), // Extracted insight (markdown)
+    distilledToId: text('distilled_to_id'), // Learning ID if promoted
+    distilledAt: integer('distilled_at'),
 
-  // Timestamps
-  createdAt: integer('created_at').notNull(),
-  updatedAt: integer('updated_at').notNull(),
-}, (table) => [
-  index('idx_trace_query').on(table.query),
-  index('idx_trace_project').on(table.project),
-  index('idx_trace_status').on(table.status),
-  index('idx_trace_parent').on(table.parentTraceId),
-  index('idx_trace_prev').on(table.prevTraceId),
-  index('idx_trace_next').on(table.nextTraceId),
-  index('idx_trace_created').on(table.createdAt),
-]);
+    // Timestamps
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    index('idx_trace_query').on(table.query),
+    index('idx_trace_project').on(table.project),
+    index('idx_trace_status').on(table.status),
+    index('idx_trace_parent').on(table.parentTraceId),
+    index('idx_trace_prev').on(table.prevTraceId),
+    index('idx_trace_next').on(table.nextTraceId),
+    index('idx_trace_created').on(table.createdAt),
+  ],
+);
 
 // ============================================================================
 // Supersede Log (Issue #18) - Audit trail for "Nothing is Deleted"
@@ -226,90 +266,101 @@ export const traceLog = sqliteTable('trace_log', {
 
 // Tracks document supersessions even when original file is deleted
 // This is separate from oracle_documents.superseded_by to preserve history
-export const supersedeLog = sqliteTable('supersede_log', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
+export const supersedeLog = sqliteTable(
+  'supersede_log',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
 
-  // What was superseded
-  oldPath: text('old_path').notNull(),        // Original file path (may no longer exist)
-  oldId: text('old_id'),                       // Document ID if it was indexed
-  oldTitle: text('old_title'),                 // Preserved title for display
-  oldType: text('old_type'),                   // learning, principle, retro, etc.
+    // What was superseded
+    oldPath: text('old_path').notNull(), // Original file path (may no longer exist)
+    oldId: text('old_id'), // Document ID if it was indexed
+    oldTitle: text('old_title'), // Preserved title for display
+    oldType: text('old_type'), // learning, principle, retro, etc.
 
-  // What replaced it (null if just deleted/archived)
-  newPath: text('new_path'),                   // Replacement file path
-  newId: text('new_id'),                       // Document ID of replacement
-  newTitle: text('new_title'),                 // Title of replacement
+    // What replaced it (null if just deleted/archived)
+    newPath: text('new_path'), // Replacement file path
+    newId: text('new_id'), // Document ID of replacement
+    newTitle: text('new_title'), // Title of replacement
 
-  // Why and when
-  reason: text('reason'),                      // Why superseded (duplicate, outdated, merged)
-  supersededAt: integer('superseded_at').notNull(),
-  supersededBy: text('superseded_by'),         // Who made the decision (user, claude, indexer)
+    // Why and when
+    reason: text('reason'), // Why superseded (duplicate, outdated, merged)
+    supersededAt: integer('superseded_at').notNull(),
+    supersededBy: text('superseded_by'), // Who made the decision (user, claude, indexer)
 
-  // Context
-  project: text('project'),                    // ghq format project path
-
-}, (table) => [
-  index('idx_supersede_old_path').on(table.oldPath),
-  index('idx_supersede_new_path').on(table.newPath),
-  index('idx_supersede_created').on(table.supersededAt),
-  index('idx_supersede_project').on(table.project),
-]);
+    // Context
+    project: text('project'), // ghq format project path
+  },
+  (table) => [
+    index('idx_supersede_old_path').on(table.oldPath),
+    index('idx_supersede_new_path').on(table.newPath),
+    index('idx_supersede_created').on(table.supersededAt),
+    index('idx_supersede_project').on(table.project),
+  ],
+);
 
 // ============================================================================
 // Activity Log - User activity tracking
 // ============================================================================
 
-export const activityLog = sqliteTable('activity_log', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  date: text('date').notNull(),             // YYYY-MM-DD
-  timestamp: text('timestamp').notNull(),   // ISO timestamp
-  type: text('type').notNull(),             // file_created, file_modified, etc.
-  path: text('path'),                        // File path if applicable
-  sizeBytes: integer('size_bytes'),
-  project: text('project'),                  // ghq format project path
-  metadata: text('metadata', { mode: 'json' }), // Additional data as JSON
-  createdAt: text('created_at'),             // Auto timestamp
-}, (table) => [
-  index('idx_activity_date').on(table.date),
-  index('idx_activity_type').on(table.type),
-  index('idx_activity_project').on(table.project),
-]);
+export const activityLog = sqliteTable(
+  'activity_log',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    date: text('date').notNull(), // YYYY-MM-DD
+    timestamp: text('timestamp').notNull(), // ISO timestamp
+    type: text('type').notNull(), // file_created, file_modified, etc.
+    path: text('path'), // File path if applicable
+    sizeBytes: integer('size_bytes'),
+    project: text('project'), // ghq format project path
+    metadata: text('metadata', { mode: 'json' }), // Additional data as JSON
+    createdAt: text('created_at'), // Auto timestamp
+  },
+  (table) => [
+    index('idx_activity_date').on(table.date),
+    index('idx_activity_type').on(table.type),
+    index('idx_activity_project').on(table.project),
+  ],
+);
 
 // ============================================================================
 // Schedule Table - Appointments & events (per-human, shared across Oracles)
 // ============================================================================
 
-export const schedule = sqliteTable('schedule', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  date: text('date').notNull(),          // YYYY-MM-DD (canonical, for queries)
-  dateRaw: text('date_raw'),             // Original input ("5 Mar", "28 ก.พ.")
-  time: text('time'),                    // HH:MM or "TBD"
-  event: text('event').notNull(),        // Event description
-  notes: text('notes'),                  // Optional notes
-  recurring: text('recurring'),          // null | "daily" | "weekly" | "monthly"
-  status: text('status').default('pending'), // pending | done | cancelled
-  createdAt: integer('created_at').notNull(),
-  updatedAt: integer('updated_at').notNull(),
-}, (table) => [
-  index('idx_schedule_date').on(table.date),
-  index('idx_schedule_status').on(table.status),
-]);
+export const schedule = sqliteTable(
+  'schedule',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    date: text('date').notNull(), // YYYY-MM-DD (canonical, for queries)
+    dateRaw: text('date_raw'), // Original input ("5 Mar", "28 ก.พ.")
+    time: text('time'), // HH:MM or "TBD"
+    event: text('event').notNull(), // Event description
+    notes: text('notes'), // Optional notes
+    recurring: text('recurring'), // null | "daily" | "weekly" | "monthly"
+    status: text('status').default('pending'), // pending | done | cancelled
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    index('idx_schedule_date').on(table.date),
+    index('idx_schedule_status').on(table.status),
+  ],
+);
 
 // ============================================================================
 // Beast Profiles - Pack member identity & avatars
 // ============================================================================
 
 export const beastProfiles = sqliteTable('beast_profiles', {
-  name: text('name').primaryKey(),              // lowercase identifier: karo, zaghnal, gnarl, etc.
-  displayName: text('display_name').notNull(),  // Display name: Karo, Zaghnal, etc.
-  animal: text('animal').notNull(),             // Animal theme: hyena, horse, alligator, etc.
-  avatarUrl: text('avatar_url'),                // URL or data URI for avatar image
-  bio: text('bio'),                             // Short bio / tagline
-  interests: text('interests'),                 // JSON array of interests/tags
-  themeColor: text('theme_color'),              // Hex color for UI accent
-  role: text('role'),                           // Beast role: Software Engineering, PM, etc.
-  birthdate: text('birthdate'),                 // Date string: YYYY-MM-DD (chosen birthday)
-  sex: text('sex'),                              // male, female, or null
+  name: text('name').primaryKey(), // lowercase identifier: karo, zaghnal, gnarl, etc.
+  displayName: text('display_name').notNull(), // Display name: Karo, Zaghnal, etc.
+  animal: text('animal').notNull(), // Animal theme: hyena, horse, alligator, etc.
+  avatarUrl: text('avatar_url'), // URL or data URI for avatar image
+  bio: text('bio'), // Short bio / tagline
+  interests: text('interests'), // JSON array of interests/tags
+  themeColor: text('theme_color'), // Hex color for UI accent
+  role: text('role'), // Beast role: Software Engineering, PM, etc.
+  birthdate: text('birthdate'), // Date string: YYYY-MM-DD (chosen birthday)
+  sex: text('sex'), // male, female, or null
   restStatus: text('rest_status').default('active'), // T#658 — Norm #65: active | rest (nap reserved)
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
@@ -329,21 +380,25 @@ export const settings = sqliteTable('settings', {
 // Security Events (T#545) — Security-specific event logging
 // ============================================================================
 
-export const securityEvents = sqliteTable('security_events', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  timestamp: integer('timestamp').notNull(),
-  eventType: text('event_type').notNull(),
-  severity: text('severity').notNull().default('info'),
-  actor: text('actor'),
-  actorType: text('actor_type'),
-  target: text('target'),
-  details: text('details'),          // JSON blob for event-specific data
-  ipSource: text('ip_source'),
-  requestId: text('request_id'),     // Correlation ID to link back to audit_log
-}, (table) => [
-  index('idx_security_events_timestamp').on(table.timestamp),
-  index('idx_security_events_type').on(table.eventType),
-  index('idx_security_events_severity').on(table.severity),
-  index('idx_security_events_actor').on(table.actor),
-  index('idx_security_events_request_id').on(table.requestId),
-]);
+export const securityEvents = sqliteTable(
+  'security_events',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    timestamp: integer('timestamp').notNull(),
+    eventType: text('event_type').notNull(),
+    severity: text('severity').notNull().default('info'),
+    actor: text('actor'),
+    actorType: text('actor_type'),
+    target: text('target'),
+    details: text('details'), // JSON blob for event-specific data
+    ipSource: text('ip_source'),
+    requestId: text('request_id'), // Correlation ID to link back to audit_log
+  },
+  (table) => [
+    index('idx_security_events_timestamp').on(table.timestamp),
+    index('idx_security_events_type').on(table.eventType),
+    index('idx_security_events_severity').on(table.severity),
+    index('idx_security_events_actor').on(table.actor),
+    index('idx_security_events_request_id').on(table.requestId),
+  ],
+);

--- a/src/dm/handler.ts
+++ b/src/dm/handler.ts
@@ -28,11 +28,7 @@ function sortPair(a: string, b: string): [string, string] {
  * Sanitize text for tmux injection.
  */
 function sanitizeForTmux(text: string, maxLen: number = 200): string {
-  return text
-    .replace(/\n/g, ' ')
-    .replace(/"/g, "'")
-    .replace(/\\/g, '\\\\')
-    .slice(0, maxLen);
+  return text.replace(/\n/g, ' ').replace(/"/g, "'").replace(/\\/g, '\\\\').slice(0, maxLen);
 }
 
 // ============================================================================
@@ -47,12 +43,10 @@ export function getOrCreateConversation(name1: string, name2: string): DmConvers
   const now = Date.now();
 
   // Try to find existing
-  const existing = db.select()
+  const existing = db
+    .select()
     .from(dmConversations)
-    .where(and(
-      eq(dmConversations.participant1, p1),
-      eq(dmConversations.participant2, p2),
-    ))
+    .where(and(eq(dmConversations.participant1, p1), eq(dmConversations.participant2, p2)))
     .get();
 
   if (existing) {
@@ -66,12 +60,16 @@ export function getOrCreateConversation(name1: string, name2: string): DmConvers
   }
 
   // Create new
-  const result = db.insert(dmConversations).values({
-    participant1: p1,
-    participant2: p2,
-    createdAt: now,
-    updatedAt: now,
-  }).returning({ id: dmConversations.id }).get();
+  const result = db
+    .insert(dmConversations)
+    .values({
+      participant1: p1,
+      participant2: p2,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: dmConversations.id })
+    .get();
 
   return {
     id: result.id,
@@ -101,12 +99,16 @@ export function sendDm(
   const now = Date.now();
 
   // Insert message
-  const result = db.insert(dmMessages).values({
-    conversationId: conversation.id,
-    sender: fromLower,
-    content,
-    createdAt: now,
-  }).returning({ id: dmMessages.id }).get();
+  const result = db
+    .insert(dmMessages)
+    .values({
+      conversationId: conversation.id,
+      sender: fromLower,
+      content,
+      createdAt: now,
+    })
+    .returning({ id: dmMessages.id })
+    .get();
 
   // Update conversation timestamp
   db.update(dmConversations)
@@ -138,7 +140,9 @@ function notifyDmRecipient(from: string, to: string, content: string): boolean {
   const isGuestDm = from.startsWith('[Guest] ');
   const guestUsername = isGuestDm ? from.slice(8) : null;
   const dmLabel = isGuestDm ? `[DM [Guest] from ${guestUsername}]` : `[DM from ${from}]`;
-  const replyHint = isGuestDm ? `Use /dm to read. use /dm ${guestUsername} <message> to reply.` : `Use /dm to read and /dm ${from} <message> to reply.`;
+  const replyHint = isGuestDm
+    ? `Use /dm to read. use /dm ${guestUsername} <message> to reply.`
+    : `Use /dm to read and /dm ${from} <message> to reply.`;
   const message = `${dmLabel}: ${preview}...\n\n${replyHint}`;
 
   try {
@@ -155,22 +159,26 @@ export function listConversations(
   oracleName: string,
   limit: number = 20,
   offset: number = 0,
-): { conversations: Array<{
-  id: number;
-  with: string;
-  lastMessage: string;
-  lastSender: string;
-  lastAt: number;
-  unreadCount: number;
-  createdAt: number;
-}>; total: number } {
+): {
+  conversations: Array<{
+    id: number;
+    with: string;
+    lastMessage: string;
+    lastSender: string;
+    lastAt: number;
+    unreadCount: number;
+    createdAt: number;
+  }>;
+  total: number;
+} {
   const name = oracleName.toLowerCase();
 
   // Find all conversations where this oracle is a participant
-  const allConvs = db.select()
+  const allConvs = db
+    .select()
     .from(dmConversations)
     .where(
-      sql`${dmConversations.participant1} = ${name} OR ${dmConversations.participant2} = ${name}`
+      sql`${dmConversations.participant1} = ${name} OR ${dmConversations.participant2} = ${name}`,
     )
     .orderBy(desc(dmConversations.updatedAt))
     .all();
@@ -178,11 +186,12 @@ export function listConversations(
   const total = allConvs.length;
   const paged = allConvs.slice(offset, offset + limit);
 
-  const conversations = paged.map(conv => {
+  const conversations = paged.map((conv) => {
     const other = conv.participant1 === name ? conv.participant2 : conv.participant1;
 
     // Get last message
-    const lastMsg = db.select()
+    const lastMsg = db
+      .select()
       .from(dmMessages)
       .where(eq(dmMessages.conversationId, conv.id))
       .orderBy(desc(dmMessages.createdAt))
@@ -190,13 +199,16 @@ export function listConversations(
       .get();
 
     // Count unread (messages from the other person that I haven't read)
-    const unreadResult = db.select({ count: sql<number>`count(*)` })
+    const unreadResult = db
+      .select({ count: sql<number>`count(*)` })
       .from(dmMessages)
-      .where(and(
-        eq(dmMessages.conversationId, conv.id),
-        eq(dmMessages.sender, other),
-        isNull(dmMessages.readAt),
-      ))
+      .where(
+        and(
+          eq(dmMessages.conversationId, conv.id),
+          eq(dmMessages.sender, other),
+          isNull(dmMessages.readAt),
+        ),
+      )
       .get();
 
     return {
@@ -222,27 +234,32 @@ export function getMessages(
   limit: number = 50,
   offset: number = 0,
   order: 'asc' | 'desc' = 'asc',
-): { conversationId: number | null; participants: [string, string]; messages: DmMessage[]; total: number } {
+): {
+  conversationId: number | null;
+  participants: [string, string];
+  messages: DmMessage[];
+  total: number;
+} {
   const [p1, p2] = sortPair(name1, name2);
 
-  const conv = db.select()
+  const conv = db
+    .select()
     .from(dmConversations)
-    .where(and(
-      eq(dmConversations.participant1, p1),
-      eq(dmConversations.participant2, p2),
-    ))
+    .where(and(eq(dmConversations.participant1, p1), eq(dmConversations.participant2, p2)))
     .get();
 
   if (!conv) {
     return { conversationId: null, participants: [p1, p2], messages: [], total: 0 };
   }
 
-  const countResult = db.select({ count: sql<number>`count(*)` })
+  const countResult = db
+    .select({ count: sql<number>`count(*)` })
     .from(dmMessages)
     .where(eq(dmMessages.conversationId, conv.id))
     .get();
 
-  const rows = db.select()
+  const rows = db
+    .select()
     .from(dmMessages)
     .where(eq(dmMessages.conversationId, conv.id))
     .orderBy(order === 'desc' ? desc(dmMessages.createdAt) : dmMessages.createdAt)
@@ -253,7 +270,7 @@ export function getMessages(
   return {
     conversationId: conv.id,
     participants: [p1, p2],
-    messages: rows.map(r => ({
+    messages: rows.map((r) => ({
       id: r.id,
       conversationId: r.conversationId,
       sender: r.sender,
@@ -268,17 +285,18 @@ export function getMessages(
 /**
  * Mark all messages from `other` to `reader` as read.
  */
-export function markRead(reader: string, other: string): { markedRead: number; conversationId: number | null } {
+export function markRead(
+  reader: string,
+  other: string,
+): { markedRead: number; conversationId: number | null } {
   const [p1, p2] = sortPair(reader, other);
   const readerLower = reader.toLowerCase();
   const otherLower = other.toLowerCase();
 
-  const conv = db.select()
+  const conv = db
+    .select()
     .from(dmConversations)
-    .where(and(
-      eq(dmConversations.participant1, p1),
-      eq(dmConversations.participant2, p2),
-    ))
+    .where(and(eq(dmConversations.participant1, p1), eq(dmConversations.participant2, p2)))
     .get();
 
   if (!conv) {
@@ -286,13 +304,16 @@ export function markRead(reader: string, other: string): { markedRead: number; c
   }
 
   const now = Date.now();
-  const result = db.update(dmMessages)
+  const result = db
+    .update(dmMessages)
     .set({ readAt: now })
-    .where(and(
-      eq(dmMessages.conversationId, conv.id),
-      eq(dmMessages.sender, otherLower),
-      isNull(dmMessages.readAt),
-    ))
+    .where(
+      and(
+        eq(dmMessages.conversationId, conv.id),
+        eq(dmMessages.sender, otherLower),
+        isNull(dmMessages.readAt),
+      ),
+    )
     .run();
 
   return {
@@ -304,15 +325,16 @@ export function markRead(reader: string, other: string): { markedRead: number; c
 /**
  * Mark ALL unread messages in a conversation as read (for observer/god-view).
  */
-export function markAllRead(name1: string, name2: string): { markedRead: number; conversationId: number | null } {
+export function markAllRead(
+  name1: string,
+  name2: string,
+): { markedRead: number; conversationId: number | null } {
   const [p1, p2] = sortPair(name1, name2);
 
-  const conv = db.select()
+  const conv = db
+    .select()
     .from(dmConversations)
-    .where(and(
-      eq(dmConversations.participant1, p1),
-      eq(dmConversations.participant2, p2),
-    ))
+    .where(and(eq(dmConversations.participant1, p1), eq(dmConversations.participant2, p2)))
     .get();
 
   if (!conv) {
@@ -320,12 +342,10 @@ export function markAllRead(name1: string, name2: string): { markedRead: number;
   }
 
   const now = Date.now();
-  const result = db.update(dmMessages)
+  const result = db
+    .update(dmMessages)
     .set({ readAt: now })
-    .where(and(
-      eq(dmMessages.conversationId, conv.id),
-      isNull(dmMessages.readAt),
-    ))
+    .where(and(eq(dmMessages.conversationId, conv.id), isNull(dmMessages.readAt)))
     .run();
 
   return {
@@ -351,39 +371,41 @@ export function getDashboard(limit: number = 50): {
   totalConversations: number;
   totalMessages: number;
 } {
-  const allConvs = db.select()
+  const allConvs = db
+    .select()
     .from(dmConversations)
     .orderBy(desc(dmConversations.updatedAt))
     .limit(limit)
     .all();
 
-  const totalConvsResult = db.select({ count: sql<number>`count(*)` })
-    .from(dmConversations)
-    .get();
+  const totalConvsResult = db.select({ count: sql<number>`count(*)` }).from(dmConversations).get();
 
-  const totalMsgsResult = db.select({ count: sql<number>`count(*)` })
-    .from(dmMessages)
-    .get();
+  const totalMsgsResult = db.select({ count: sql<number>`count(*)` }).from(dmMessages).get();
 
-  const conversations = allConvs.map(conv => {
+  const conversations = allConvs.map((conv) => {
     // Message count
-    const msgCount = db.select({ count: sql<number>`count(*)` })
+    const msgCount = db
+      .select({ count: sql<number>`count(*)` })
       .from(dmMessages)
       .where(eq(dmMessages.conversationId, conv.id))
       .get();
 
     // Unread count — only messages NOT sent by gorn (messages from beasts to gorn)
-    const unreadCount = db.select({ count: sql<number>`count(*)` })
+    const unreadCount = db
+      .select({ count: sql<number>`count(*)` })
       .from(dmMessages)
-      .where(and(
-        eq(dmMessages.conversationId, conv.id),
-        isNull(dmMessages.readAt),
-        sql`${dmMessages.sender} != 'gorn'`,
-      ))
+      .where(
+        and(
+          eq(dmMessages.conversationId, conv.id),
+          isNull(dmMessages.readAt),
+          sql`${dmMessages.sender} != 'gorn'`,
+        ),
+      )
       .get();
 
     // Last message
-    const lastMsg = db.select()
+    const lastMsg = db
+      .select()
       .from(dmMessages)
       .where(eq(dmMessages.conversationId, conv.id))
       .orderBy(desc(dmMessages.createdAt))

--- a/src/dm/routes.ts
+++ b/src/dm/routes.ts
@@ -2,9 +2,20 @@ import type { Context } from 'hono';
 import type { OpenAPIHono } from '@hono/zod-openapi';
 import type { Database } from 'bun:sqlite';
 import type { Role } from '../server/rbac.ts';
-import { checkGuestDmRate, checkGuestContentLength, scanForInjection } from '../server/guest-safety.ts';
+import {
+  checkGuestDmRate,
+  checkGuestContentLength,
+  scanForInjection,
+} from '../server/guest-safety.ts';
 import { logSecurityEvent } from '../server/security-logger.ts';
-import { getDashboard, listConversations, markRead, markAllRead, getMessages as getDmMessages, sendDm as _sendDmHelper } from './handler.ts';
+import {
+  getDashboard,
+  listConversations,
+  markRead,
+  markAllRead,
+  getMessages as getDmMessages,
+  sendDm as _sendDmHelper,
+} from './handler.ts';
 import { getBeastProfile } from '../db/index.ts';
 import { listGuests, getGuestByUsername, getGuestByDisplayName } from '../server/guest-accounts.ts';
 
@@ -33,16 +44,22 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
     // T#795 P1 — close localhost-trust read-bypass. Require bearer-token or owner session.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const limit = parseInt(c.req.query('limit') || '50');
     const data = getDashboard(limit);
     // T#728 + T#795 P1: non-gorn callers see only their own conversations.
-    const filtered = (caller !== 'gorn')
-      ? data.conversations.filter(conv => conv.participants.some((p: string) => p.toLowerCase() === caller))
-      : data.conversations;
+    const filtered =
+      caller !== 'gorn'
+        ? data.conversations.filter((conv) =>
+            conv.participants.some((p: string) => p.toLowerCase() === caller),
+          )
+        : data.conversations;
     return c.json({
-      conversations: filtered.map(conv => ({
+      conversations: filtered.map((conv) => ({
         id: conv.id,
         participants: conv.participants,
         message_count: conv.messageCount,
@@ -52,15 +69,15 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
         last_at: new Date(conv.lastAt).toISOString(),
         created_at: new Date(conv.createdAt).toISOString(),
       })),
-      total_conversations: (caller !== 'gorn') ? filtered.length : data.totalConversations,
+      total_conversations: caller !== 'gorn' ? filtered.length : data.totalConversations,
       total_messages: data.totalMessages,
     });
   });
 
   app.get('/api/dm/unread-count', (c) => {
     const data = getDashboard(100);
-    const gornConvos = data.conversations.filter(conv =>
-      conv.participants.some((p: string) => p.toLowerCase() === 'gorn')
+    const gornConvos = data.conversations.filter((conv) =>
+      conv.participants.some((p: string) => p.toLowerCase() === 'gorn'),
     );
     const unread = gornConvos.reduce((sum, conv) => sum + conv.unreadCount, 0);
     return c.json({ unread });
@@ -115,10 +132,22 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
         // authenticated caller, or the request is rejected.
         const caller = requireBeastIdentity(c);
         if (!caller) {
-          return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+          return c.json(
+            {
+              error: 'Beast identity required — bearer-token or owner session',
+              requiresAuth: true,
+            },
+            401,
+          );
         }
         if (data.from && data.from.toLowerCase() !== caller) {
-          return c.json({ error: 'Sender impersonation blocked. body.from must match authenticated caller or be omitted.' }, 403);
+          return c.json(
+            {
+              error:
+                'Sender impersonation blocked. body.from must match authenticated caller or be omitted.',
+            },
+            403,
+          );
         }
         data.from = caller;
       }
@@ -133,11 +162,20 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
         // T#635: Suggest similar guest usernames on mismatch
         const allGuests = listGuests(sqlite);
         const suggestions = allGuests
-          .filter(g => g.username.includes(rawTo.toLowerCase()) || (g.display_name || '').toLowerCase().includes(rawTo.toLowerCase()))
-          .map(g => `${g.username} (${g.display_name || g.username})`)
+          .filter(
+            (g) =>
+              g.username.includes(rawTo.toLowerCase()) ||
+              (g.display_name || '').toLowerCase().includes(rawTo.toLowerCase()),
+          )
+          .map((g) => `${g.username} (${g.display_name || g.username})`)
           .slice(0, 3);
         const hint = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(', ')}?` : '';
-        return c.json({ error: `Recipient "${data.to}" not found. Must be a valid beast name or guest username.${hint}` }, 404);
+        return c.json(
+          {
+            error: `Recipient "${data.to}" not found. Must be a valid beast name or guest username.${hint}`,
+          },
+          404,
+        );
       }
 
       // Resolve guest usernames to [Guest] tags so messages land in the same conversation
@@ -151,24 +189,33 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
       const result = await withRetry(() => sendDm(dmFrom, dmTo, data.message));
       // Set author_role on DM message (Spec #32, T#557 — Talon review fix)
       if (result.messageId) {
-        const authorRole = role === 'guest' ? 'guest' : (role === 'owner' ? 'owner' : 'beast');
+        const authorRole = role === 'guest' ? 'guest' : role === 'owner' ? 'owner' : 'beast';
         try {
-          sqlite.prepare('UPDATE dm_messages SET author_role = ? WHERE id = ?')
+          sqlite
+            .prepare('UPDATE dm_messages SET author_role = ? WHERE id = ?')
             .run(authorRole, result.messageId);
-        } catch { /* column may not exist yet */ }
+        } catch {
+          /* column may not exist yet */
+        }
       }
       wsBroadcast('new_dm', { conversation_id: result.conversationId });
-      return c.json({
-        conversation_id: result.conversationId,
-        message_id: result.messageId,
-        from: data.from.toLowerCase(),
-        to: data.to.toLowerCase(),
-        notified: result.notified,
-      }, 201);
+      return c.json(
+        {
+          conversation_id: result.conversationId,
+          message_id: result.messageId,
+          from: data.from.toLowerCase(),
+          to: data.to.toLowerCase(),
+          notified: result.notified,
+        },
+        201,
+      );
     } catch (error) {
-      return c.json({
-        error: error instanceof Error ? error.message : 'Unknown error'
-      }, 500);
+      return c.json(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        500,
+      );
     }
   });
 
@@ -178,7 +225,10 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
     // then scope to caller (gorn sees all; beasts see their own).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && caller !== name.toLowerCase()) {
       return c.json({ error: 'Access denied. You can only view your own conversations.' }, 403);
@@ -187,7 +237,7 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
     const offset = parseInt(c.req.query('offset') || '0');
     const data = listConversations(name, limit, offset);
     return c.json({
-      conversations: data.conversations.map(conv => ({
+      conversations: data.conversations.map((conv) => ({
         id: conv.id,
         with: conv.with,
         last_message: conv.lastMessage,
@@ -221,10 +271,16 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
     // then scope to participants (gorn sees all; beasts see only conversations they are part of).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && caller !== name.toLowerCase() && caller !== other.toLowerCase()) {
-      return c.json({ error: 'Access denied. You can only read conversations you are part of.' }, 403);
+      return c.json(
+        { error: 'Access denied. You can only read conversations you are part of.' },
+        403,
+      );
     }
     const parsedDmLimit = parseInt(c.req.query('limit') || '50', 10);
     const limit = isNaN(parsedDmLimit) || parsedDmLimit < 1 ? 50 : parsedDmLimit;
@@ -235,7 +291,7 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
     return c.json({
       conversation_id: data.conversationId,
       participants: data.participants,
-      messages: data.messages.map(m => ({
+      messages: data.messages.map((m) => ({
         id: m.id,
         sender: m.sender,
         message: m.content,
@@ -253,13 +309,17 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
     // then scope to caller (gorn marks any; beasts mark only their own).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && caller !== reader.toLowerCase()) {
       return c.json({ error: 'Can only mark your own messages as read' }, 403);
     }
     const result = markRead(reader, other);
-    if (result.markedRead > 0) wsBroadcast('dm_read', { conversation_id: result.conversationId, reader });
+    if (result.markedRead > 0)
+      wsBroadcast('dm_read', { conversation_id: result.conversationId, reader });
     return c.json({
       marked_read: result.markedRead,
       conversation_id: result.conversationId,
@@ -273,13 +333,17 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
     // then scope to participants (gorn marks any; beasts mark only conversations they are part of).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && caller !== name.toLowerCase() && caller !== other.toLowerCase()) {
       return c.json({ error: 'Can only mark messages as read in your own conversations' }, 403);
     }
     const result = markAllRead(name, other);
-    if (result.markedRead > 0) wsBroadcast('dm_read', { conversation_id: result.conversationId, reader: name });
+    if (result.markedRead > 0)
+      wsBroadcast('dm_read', { conversation_id: result.conversationId, reader: name });
     return c.json({
       marked_read: result.markedRead,
       conversation_id: result.conversationId,
@@ -292,14 +356,24 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
     // T#718 — derive caller from auth, reject ?as= mismatch
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const claimedAs = c.req.query('as')?.toLowerCase();
     if (claimedAs && claimedAs !== caller) {
-      return c.json({ error: 'Identity spoof blocked. ?as= must match authenticated caller or be omitted.' }, 403);
+      return c.json(
+        { error: 'Identity spoof blocked. ?as= must match authenticated caller or be omitted.' },
+        403,
+      );
     }
     const as = caller;
-    const msg = sqlite.prepare('SELECT m.*, c.participant1, c.participant2 FROM dm_messages m JOIN dm_conversations c ON c.id = m.conversation_id WHERE m.id = ?').get(id) as any;
+    const msg = sqlite
+      .prepare(
+        'SELECT m.*, c.participant1, c.participant2 FROM dm_messages m JOIN dm_conversations c ON c.id = m.conversation_id WHERE m.id = ?',
+      )
+      .get(id) as any;
     if (!msg) return c.json({ error: 'Message not found' }, 404);
     if (as !== 'gorn' && as !== msg.sender && as !== msg.participant1 && as !== msg.participant2) {
       return c.json({ error: 'Can only delete messages in your own conversations' }, 403);
@@ -307,6 +381,4 @@ export function registerDmRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: 
     sqlite.prepare('DELETE FROM dm_messages WHERE id = ?').run(id);
     return c.json({ deleted: id });
   });
-
-
 }

--- a/src/drizzle-migration.test.ts
+++ b/src/drizzle-migration.test.ts
@@ -142,12 +142,14 @@ afterAll(() => {
 
 describe('handleReflect - SELECT oracle_documents', () => {
   it('should select random document of type principle or learning', () => {
-    const result = db.prepare(`
+    const result = db
+      .prepare(`
       SELECT id, type, source_file, concepts FROM oracle_documents
       WHERE type IN ('principle', 'learning')
       ORDER BY RANDOM()
       LIMIT 1
-    `).get() as any;
+    `)
+      .get() as any;
 
     expect(result).toBeDefined();
     expect(['principle', 'learning']).toContain(result.type);
@@ -160,12 +162,14 @@ describe('handleReflect - SELECT oracle_documents', () => {
 
     // Run multiple times to verify randomness
     for (let i = 0; i < 20; i++) {
-      const result = db.prepare(`
+      const result = db
+        .prepare(`
         SELECT id FROM oracle_documents
         WHERE type IN ('principle', 'learning')
         ORDER BY RANDOM()
         LIMIT 1
-      `).get() as any;
+      `)
+        .get() as any;
       results.add(result.id);
     }
 
@@ -175,12 +179,14 @@ describe('handleReflect - SELECT oracle_documents', () => {
 
   it('should only return principle and learning types', () => {
     for (let i = 0; i < 10; i++) {
-      const result = db.prepare(`
+      const result = db
+        .prepare(`
         SELECT type FROM oracle_documents
         WHERE type IN ('principle', 'learning')
         ORDER BY RANDOM()
         LIMIT 1
-      `).get() as any;
+      `)
+        .get() as any;
 
       expect(result.type).not.toBe('retro');
     }
@@ -209,7 +215,7 @@ describe('handleLearn - INSERT oracle_documents', () => {
       now,
       null,
       'github.com/test/repo',
-      'oracle_learn'
+      'oracle_learn',
     );
 
     const result = db.prepare('SELECT * FROM oracle_documents WHERE id = ?').get(id) as any;
@@ -250,14 +256,16 @@ describe('handleList - COUNT oracle_documents', () => {
   });
 
   it('should count documents by type', () => {
-    const result = db.prepare('SELECT COUNT(*) as total FROM oracle_documents WHERE type = ?')
+    const result = db
+      .prepare('SELECT COUNT(*) as total FROM oracle_documents WHERE type = ?')
       .get('principle') as any;
 
     expect(result.total).toBe(2);
   });
 
   it('should return 0 for non-existent type', () => {
-    const result = db.prepare('SELECT COUNT(*) as total FROM oracle_documents WHERE type = ?')
+    const result = db
+      .prepare('SELECT COUNT(*) as total FROM oracle_documents WHERE type = ?')
       .get('nonexistent') as any;
 
     expect(result.total).toBe(0);
@@ -270,34 +278,40 @@ describe('handleList - COUNT oracle_documents', () => {
 
 describe('handleStats - Aggregation queries', () => {
   it('should count documents grouped by type', () => {
-    const results = db.prepare(`
+    const results = db
+      .prepare(`
       SELECT type, COUNT(*) as count
       FROM oracle_documents
       GROUP BY type
-    `).all() as Array<{ type: string; count: number }>;
+    `)
+      .all() as Array<{ type: string; count: number }>;
 
     expect(results.length).toBeGreaterThan(0);
 
-    const typeMap = new Map(results.map(r => [r.type, r.count]));
+    const typeMap = new Map(results.map((r) => [r.type, r.count]));
     expect(typeMap.get('principle')).toBe(2);
     expect(typeMap.get('learning')).toBeGreaterThanOrEqual(2);
     expect(typeMap.get('retro')).toBe(1);
   });
 
   it('should get max indexed_at timestamp', () => {
-    const result = db.prepare(`
+    const result = db
+      .prepare(`
       SELECT MAX(indexed_at) as last_indexed FROM oracle_documents
-    `).get() as any;
+    `)
+      .get() as any;
 
     expect(result.last_indexed).toBeDefined();
     expect(result.last_indexed).toBeGreaterThan(0);
   });
 
   it('should select all concepts (non-empty)', () => {
-    const results = db.prepare(`
+    const results = db
+      .prepare(`
       SELECT concepts FROM oracle_documents
       WHERE concepts IS NOT NULL AND concepts != '[]'
-    `).all() as Array<{ concepts: string }>;
+    `)
+      .all() as Array<{ concepts: string }>;
 
     expect(results.length).toBeGreaterThan(0);
 
@@ -308,10 +322,12 @@ describe('handleStats - Aggregation queries', () => {
   });
 
   it('should calculate unique concepts count', () => {
-    const results = db.prepare(`
+    const results = db
+      .prepare(`
       SELECT concepts FROM oracle_documents
       WHERE concepts IS NOT NULL AND concepts != '[]'
-    `).all() as Array<{ concepts: string }>;
+    `)
+      .all() as Array<{ concepts: string }>;
 
     const uniqueConcepts = new Set<string>();
     for (const row of results) {
@@ -334,30 +350,36 @@ describe('handleStats - Aggregation queries', () => {
 
 describe('handleConcepts - SELECT concepts', () => {
   it('should select concepts from all documents', () => {
-    const results = db.prepare(`
+    const results = db
+      .prepare(`
       SELECT concepts FROM oracle_documents
       WHERE concepts IS NOT NULL AND concepts != '[]'
-    `).all() as Array<{ concepts: string }>;
+    `)
+      .all() as Array<{ concepts: string }>;
 
     expect(results.length).toBeGreaterThan(0);
   });
 
   it('should select concepts filtered by type', () => {
-    const results = db.prepare(`
+    const results = db
+      .prepare(`
       SELECT concepts FROM oracle_documents
       WHERE type = ? AND concepts IS NOT NULL AND concepts != '[]'
-    `).all('principle') as Array<{ concepts: string }>;
+    `)
+      .all('principle') as Array<{ concepts: string }>;
 
     expect(results.length).toBe(2); // Our 2 test principles have concepts
   });
 
   it('should count concept occurrences correctly', () => {
     // Only check the original 5 test documents
-    const results = db.prepare(`
+    const results = db
+      .prepare(`
       SELECT concepts FROM oracle_documents
       WHERE id IN ('principle_1', 'principle_2', 'learning_1', 'learning_2', 'retro_1')
       AND concepts IS NOT NULL AND concepts != '[]'
-    `).all() as Array<{ concepts: string }>;
+    `)
+      .all() as Array<{ concepts: string }>;
 
     const conceptCounts = new Map<string, number>();
     for (const row of results) {
@@ -502,9 +524,11 @@ describe('storeDocuments - INSERT oracle_documents (batch)', () => {
       insertStmt.run(doc.id, doc.type, doc.source_file, doc.concepts, now, now, now, null);
     }
 
-    const count = db.prepare(`
+    const count = db
+      .prepare(`
       SELECT COUNT(*) as count FROM oracle_documents WHERE id LIKE ?
-    `).get(`batch_%_${now}`) as any;
+    `)
+      .get(`batch_%_${now}`) as any;
 
     expect(count.count).toBe(3);
   });
@@ -553,9 +577,11 @@ describe('storeDocuments - INSERT oracle_documents (batch)', () => {
     `).run(id, content, concepts);
 
     // Verify FTS indexing works
-    const ftsResult = db.prepare(`
+    const ftsResult = db
+      .prepare(`
       SELECT id, content FROM oracle_fts WHERE oracle_fts MATCH 'indexing'
-    `).get() as any;
+    `)
+      .get() as any;
 
     expect(ftsResult).toBeDefined();
     expect(ftsResult.id).toBe(id);
@@ -583,7 +609,7 @@ describe('Edge Cases', () => {
   it('should handle special characters in content', () => {
     const now = Date.now();
     const id = `special_chars_${now}`;
-    const content = "Test with 'quotes', \"double quotes\", and unicode: ψ 日本語";
+    const content = 'Test with \'quotes\', "double quotes", and unicode: ψ 日本語';
 
     db.prepare(`
       INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)
@@ -619,11 +645,13 @@ describe('Drizzle Pattern Verification', () => {
     // db.select({ type: oracleDocuments.type, count: sql`count(*)` })
     //   .from(oracleDocuments).groupBy(oracleDocuments.type).all()
 
-    const results = db.prepare(`
+    const results = db
+      .prepare(`
       SELECT type, COUNT(*) as count
       FROM oracle_documents
       GROUP BY type
-    `).all() as Array<{ type: string; count: number }>;
+    `)
+      .all() as Array<{ type: string; count: number }>;
 
     // Verify structure matches Drizzle output
     expect(results[0]).toHaveProperty('type');
@@ -643,9 +671,11 @@ describe('Drizzle Pattern Verification', () => {
   it('should verify ORDER BY RANDOM() LIMIT 1 pattern', () => {
     // db.select().from(oracleDocuments).orderBy(sql`RANDOM()`).limit(1).get()
 
-    const result = db.prepare(`
+    const result = db
+      .prepare(`
       SELECT * FROM oracle_documents ORDER BY RANDOM() LIMIT 1
-    `).get() as any;
+    `)
+      .get() as any;
 
     expect(result).toBeDefined();
     expect(result).toHaveProperty('id');
@@ -658,11 +688,13 @@ describe('Drizzle Pattern Verification', () => {
 
     // Drizzle .returning() returns the inserted row
     // SQLite supports RETURNING clause
-    const result = db.prepare(`
+    const result = db
+      .prepare(`
       INSERT INTO oracle_documents (id, type, source_file, concepts, created_at, updated_at, indexed_at)
       VALUES (?, ?, ?, ?, ?, ?, ?)
       RETURNING *
-    `).get(id, 'learning', 'test-returning.md', '["test"]', now, now, now) as any;
+    `)
+      .get(id, 'learning', 'test-returning.md', '["test"]', now, now, now) as any;
 
     expect(result).toBeDefined();
     expect(result.id).toBe(id);

--- a/src/ensure-server.ts
+++ b/src/ensure-server.ts
@@ -98,10 +98,10 @@ function cleanupStalePidFile(verbose = false): void {
 async function isServerHealthy(): Promise<boolean> {
   try {
     const response = await fetch(HEALTH_URL, {
-      signal: AbortSignal.timeout(2000)
+      signal: AbortSignal.timeout(2000),
     });
     if (response.ok) {
-      const data = await response.json() as import('./server/types.js').HealthResponse;
+      const data = (await response.json()) as import('./server/types.js').HealthResponse;
       return data.status === 'ok';
     }
     return false;
@@ -129,7 +129,8 @@ export async function ensureServerRunning(options: EnsureServerOptions = {}): Pr
   // 2. Check PID file - maybe process exists but not healthy yet
   const pidInfo = readPidFile();
   if (pidInfo && isProcessAlive(pidInfo.pid)) {
-    if (verbose) console.log(`🔮 Oracle server process exists (PID ${pidInfo.pid}), waiting for health...`);
+    if (verbose)
+      console.log(`🔮 Oracle server process exists (PID ${pidInfo.pid}), waiting for health...`);
 
     // Wait for it to become healthy
     const healthy = await waitForHealthWithTimeout(timeout);
@@ -211,7 +212,7 @@ async function waitForHealthWithTimeout(timeoutMs: number): Promise<boolean> {
     if (await isServerHealthy()) {
       return true;
     }
-    await new Promise(r => setTimeout(r, checkInterval));
+    await new Promise((r) => setTimeout(r, checkInterval));
   }
 
   return false;

--- a/src/files/routes.ts
+++ b/src/files/routes.ts
@@ -22,17 +22,26 @@ const ALLOWED_EXTENSIONS: Record<string, { mime: string; category: string }> = {
   '.csv': { mime: 'text/csv', category: 'document' },
   '.json': { mime: 'application/json', category: 'document' },
   '.doc': { mime: 'application/msword', category: 'document' },
-  '.docx': { mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', category: 'document' },
+  '.docx': {
+    mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    category: 'document',
+  },
   '.xls': { mime: 'application/vnd.ms-excel', category: 'document' },
-  '.xlsx': { mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', category: 'document' },
+  '.xlsx': {
+    mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    category: 'document',
+  },
   '.ppt': { mime: 'application/vnd.ms-powerpoint', category: 'document' },
-  '.pptx': { mime: 'application/vnd.openxmlformats-officedocument.presentationml.presentation', category: 'document' },
+  '.pptx': {
+    mime: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    category: 'document',
+  },
   '.zip': { mime: 'application/zip', category: 'archive' },
 };
 
 // Allowed image types by magic bytes
 const IMAGE_MAGIC: Record<string, { ext: string; mime: string }> = {
-  'ffd8ff': { ext: '.jpg', mime: 'image/jpeg' },
+  ffd8ff: { ext: '.jpg', mime: 'image/jpeg' },
   '89504e47': { ext: '.png', mime: 'image/png' },
   '47494638': { ext: '.gif', mime: 'image/gif' },
   '52494646': { ext: '.webp', mime: 'image/webp' }, // RIFF header for WebP
@@ -60,10 +69,18 @@ interface FilesHelpers {
 }
 
 export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers: FilesHelpers) {
-  const { hasSessionAuth, isTrustedRequest, isLocalNetwork, verifySessionToken, uploadsDir: UPLOADS_DIR, sessionCookieName: SESSION_COOKIE_NAME } = helpers;
+  const {
+    hasSessionAuth,
+    isTrustedRequest,
+    isLocalNetwork,
+    verifySessionToken,
+    uploadsDir: UPLOADS_DIR,
+    sessionCookieName: SESSION_COOKIE_NAME,
+  } = helpers;
 
   app.post('/api/upload', async (c) => {
-    if (!hasSessionAuth(c) && !isTrustedRequest(c)) return c.json({ error: 'Authentication required' }, 403);
+    if (!hasSessionAuth(c) && !isTrustedRequest(c))
+      return c.json({ error: 'Authentication required' }, 403);
     try {
       const formData = await c.req.formData();
       const file = formData.get('file') as File;
@@ -97,19 +114,25 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       // For images: validate via magic bytes (existing behavior)
       // For non-images: validate via extension allowlist
       if (!isImage && !allowed) {
-        return c.json({ error: `File type '${ext}' not allowed. Allowed: ${Object.keys(ALLOWED_EXTENSIONS).join(', ')}` }, 400);
+        return c.json(
+          {
+            error: `File type '${ext}' not allowed. Allowed: ${Object.keys(ALLOWED_EXTENSIONS).join(', ')}`,
+          },
+          400,
+        );
       }
 
       // Size limits
       const sizeLimit = isImage ? MAX_IMAGE_SIZE : MAX_FILE_SIZE;
-      if (file.size > sizeLimit) return c.json({ error: `File too large. Max ${sizeLimit / 1024 / 1024}MB` }, 400);
+      if (file.size > sizeLimit)
+        return c.json({ error: `File too large. Max ${sizeLimit / 1024 / 1024}MB` }, 400);
 
       const buffer = Buffer.from(await file.arrayBuffer());
       if (!fs.existsSync(UPLOADS_DIR)) fs.mkdirSync(UPLOADS_DIR, { recursive: true });
 
       let processedBuffer = buffer;
-      let finalExt = isImage ? (imageType!.ext) : ext;
-      let finalMime = isImage ? (imageType!.mime) : (allowed?.mime || 'application/octet-stream');
+      let finalExt = isImage ? imageType!.ext : ext;
+      let finalMime = isImage ? imageType!.mime : allowed?.mime || 'application/octet-stream';
 
       // Image processing: resize, EXIF strip (existing behavior)
       if (isImage) {
@@ -139,7 +162,9 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
               .withMetadata({ orientation: undefined })
               .toBuffer();
           }
-        } catch { /* sharp not available — save original */ }
+        } catch {
+          /* sharp not available — save original */
+        }
       }
 
       const filename = `${crypto.randomUUID()}${finalExt}`;
@@ -147,19 +172,40 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       fs.writeFileSync(filePath, processedBuffer);
 
       const now = Date.now();
-      const category = isImage ? 'image' : (allowed?.category || 'other');
+      const category = isImage ? 'image' : allowed?.category || 'other';
 
       // Insert into files table (T#382)
-      const result = sqlite.prepare(`
+      const result = sqlite
+        .prepare(`
         INSERT INTO files (filename, original_name, mime_type, size_bytes, uploaded_by, context, context_id, created_at)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(filename, file.name, finalMime, processedBuffer.length, beast || null, context, contextId ? Number(contextId) : null, now);
+      `)
+        .run(
+          filename,
+          file.name,
+          finalMime,
+          processedBuffer.length,
+          beast || null,
+          context,
+          contextId ? Number(contextId) : null,
+          now,
+        );
 
       // Also insert into forum_attachments for backwards compatibility
-      sqlite.prepare(`
+      sqlite
+        .prepare(`
         INSERT INTO forum_attachments (message_id, filename, original_name, mime_type, size_bytes, uploaded_by, created_at)
         VALUES (?, ?, ?, ?, ?, ?, ?)
-      `).run(contextId ? Number(contextId) : null, filename, file.name, finalMime, processedBuffer.length, beast || null, now);
+      `)
+        .run(
+          contextId ? Number(contextId) : null,
+          filename,
+          file.name,
+          finalMime,
+          processedBuffer.length,
+          beast || null,
+          now,
+        );
 
       return c.json({
         id: (result as any).lastInsertRowid,
@@ -190,10 +236,19 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     if (type) {
       const typeExts: Record<string, string[]> = {
         image: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
-        document: ['application/pdf', 'text/plain', 'text/markdown', 'text/csv', 'application/json',
-          'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-          'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-          'application/vnd.ms-powerpoint', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+        document: [
+          'application/pdf',
+          'text/plain',
+          'text/markdown',
+          'text/csv',
+          'application/json',
+          'application/msword',
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          'application/vnd.ms-excel',
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          'application/vnd.ms-powerpoint',
+          'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        ],
         archive: ['application/zip'],
       };
       const mimes = typeExts[type];
@@ -202,14 +257,24 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
         params.push(...mimes);
       }
     }
-    if (uploadedBy) { where += ' AND uploaded_by = ?'; params.push(uploadedBy); }
-    if (context) { where += ' AND context = ?'; params.push(context); }
+    if (uploadedBy) {
+      where += ' AND uploaded_by = ?';
+      params.push(uploadedBy);
+    }
+    if (context) {
+      where += ' AND context = ?';
+      params.push(context);
+    }
 
-    const total = (sqlite.prepare(`SELECT COUNT(*) as c FROM files WHERE ${where}`).get(...params) as any)?.c || 0;
-    const files = sqlite.prepare(`SELECT * FROM files WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`).all(...params, limit, offset) as any[];
+    const total =
+      (sqlite.prepare(`SELECT COUNT(*) as c FROM files WHERE ${where}`).get(...params) as any)?.c ||
+      0;
+    const files = sqlite
+      .prepare(`SELECT * FROM files WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`)
+      .all(...params, limit, offset) as any[];
 
     return c.json({
-      files: files.map(f => ({
+      files: files.map((f) => ({
         ...f,
         url: `/api/files/${f.id}/download`,
         is_image: f.mime_type.startsWith('image/'),
@@ -223,8 +288,13 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // GET /api/files/stats — storage statistics (must be before :id)
   app.get('/api/files/stats', (c) => {
-    const total = sqlite.prepare('SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM files WHERE deleted_at IS NULL').get() as any;
-    const byType = sqlite.prepare(`
+    const total = sqlite
+      .prepare(
+        'SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM files WHERE deleted_at IS NULL',
+      )
+      .get() as any;
+    const byType = sqlite
+      .prepare(`
       SELECT
         CASE
           WHEN mime_type LIKE 'image/%' THEN 'image'
@@ -238,15 +308,24 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
         COALESCE(SUM(size_bytes), 0) as total_size
       FROM files WHERE deleted_at IS NULL
       GROUP BY category
-    `).all() as any[];
-    const byContext = sqlite.prepare('SELECT context, COUNT(*) as count FROM files WHERE deleted_at IS NULL GROUP BY context').all() as any[];
+    `)
+      .all() as any[];
+    const byContext = sqlite
+      .prepare(
+        'SELECT context, COUNT(*) as count FROM files WHERE deleted_at IS NULL GROUP BY context',
+      )
+      .all() as any[];
 
-    const archived = sqlite.prepare(
-      'SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM files WHERE archived_at IS NOT NULL'
-    ).get() as any;
-    const pendingArchive = sqlite.prepare(
-      'SELECT COUNT(*) as count FROM files WHERE deleted_at IS NOT NULL AND archived_at IS NULL'
-    ).get() as any;
+    const archived = sqlite
+      .prepare(
+        'SELECT COUNT(*) as count, COALESCE(SUM(size_bytes), 0) as total_size FROM files WHERE archived_at IS NOT NULL',
+      )
+      .get() as any;
+    const pendingArchive = sqlite
+      .prepare(
+        'SELECT COUNT(*) as count FROM files WHERE deleted_at IS NOT NULL AND archived_at IS NULL',
+      )
+      .get() as any;
 
     return c.json({
       total_files: total.count,
@@ -264,7 +343,9 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const role = (c.get as any)('role');
     if (role !== 'owner') return c.json({ error: 'Owner access only' }, 403);
     const id = parseInt(c.req.param('id'), 10);
-    const file = sqlite.prepare('SELECT * FROM files WHERE id = ? AND deleted_at IS NULL').get(id) as any;
+    const file = sqlite
+      .prepare('SELECT * FROM files WHERE id = ? AND deleted_at IS NULL')
+      .get(id) as any;
     if (!file) return c.json({ error: 'File not found' }, 404);
     return c.json({
       ...file,
@@ -279,7 +360,9 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const role = (c.get as any)('role');
     if (role !== 'owner') return c.json({ error: 'Owner access only' }, 403);
     const id = parseInt(c.req.param('id'), 10);
-    const file = sqlite.prepare('SELECT * FROM files WHERE id = ? AND deleted_at IS NULL').get(id) as any;
+    const file = sqlite
+      .prepare('SELECT * FROM files WHERE id = ? AND deleted_at IS NULL')
+      .get(id) as any;
     if (!file) return c.json({ error: 'File not found' }, 404);
 
     const filePath = path.join(UPLOADS_DIR, file.filename);
@@ -297,7 +380,10 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const isImage = safeImageTypes.has(file.mime_type);
 
     c.header('Content-Type', isImage ? file.mime_type : 'application/octet-stream');
-    c.header('Content-Disposition', isImage ? 'inline' : `attachment; filename="${file.original_name.replace(/"/g, '_')}"`);
+    c.header(
+      'Content-Disposition',
+      isImage ? 'inline' : `attachment; filename="${file.original_name.replace(/"/g, '_')}"`,
+    );
     if (!isImage) c.header('Content-Security-Policy', 'sandbox');
     c.header('Cache-Control', 'public, max-age=31536000, immutable');
     c.header('ETag', etag);
@@ -318,16 +404,21 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
     const hash = c.req.param('hash');
     // Validate: alphanumeric, hyphens, dots — no path traversal
-    if (hash.includes('..') || hash.includes('/')) return c.json({ error: 'Invalid file hash' }, 400);
+    if (hash.includes('..') || hash.includes('/'))
+      return c.json({ error: 'Invalid file hash' }, 400);
     if (!/^[\w.-]+$/.test(hash)) return c.json({ error: 'Invalid file hash' }, 400);
 
     // Try files table first, then fall back to disk (legacy avatar files)
-    const file = sqlite.prepare('SELECT * FROM files WHERE filename = ? AND deleted_at IS NULL').get(hash) as any;
+    const file = sqlite
+      .prepare('SELECT * FROM files WHERE filename = ? AND deleted_at IS NULL')
+      .get(hash) as any;
     const filePath = path.join(UPLOADS_DIR, hash);
 
     // If not in active files, check if it was soft-deleted — return 404 rather than serving it from disk
     if (!file) {
-      const deleted = sqlite.prepare('SELECT id FROM files WHERE filename = ? AND deleted_at IS NOT NULL').get(hash);
+      const deleted = sqlite
+        .prepare('SELECT id FROM files WHERE filename = ? AND deleted_at IS NOT NULL')
+        .get(hash);
       if (deleted) return c.json({ error: 'File not found' }, 404);
     }
 
@@ -345,13 +436,23 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
     // Determine mime type from files table or extension
     const ext = hash.split('.').pop()?.toLowerCase() || '';
-    const extMimeMap: Record<string, string> = { jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', gif: 'image/gif', webp: 'image/webp', svg: 'image/svg+xml' };
+    const extMimeMap: Record<string, string> = {
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      png: 'image/png',
+      gif: 'image/gif',
+      webp: 'image/webp',
+      svg: 'image/svg+xml',
+    };
     const mimeType = file?.mime_type || extMimeMap[ext] || 'application/octet-stream';
     const isImage = safeImageTypes.has(mimeType);
     const originalName = file?.original_name || hash;
 
     c.header('Content-Type', isImage ? mimeType : 'application/octet-stream');
-    c.header('Content-Disposition', isImage ? 'inline' : `attachment; filename="${originalName.replace(/"/g, '_')}"`);
+    c.header(
+      'Content-Disposition',
+      isImage ? 'inline' : `attachment; filename="${originalName.replace(/"/g, '_')}"`,
+    );
     if (!isImage) c.header('Content-Security-Policy', 'sandbox');
     // private — browser can cache, but CDN/reverse proxy (Caddy) must not
     c.header('Cache-Control', 'private, max-age=86400');
@@ -363,7 +464,9 @@ export function registerFilesRoutes(app: OpenAPIHono, sqlite: Database, helpers:
   // Only file uploader or owner can delete
   app.delete('/api/files/:id', (c) => {
     const id = parseInt(c.req.param('id'), 10);
-    const file = sqlite.prepare('SELECT * FROM files WHERE id = ? AND deleted_at IS NULL').get(id) as any;
+    const file = sqlite
+      .prepare('SELECT * FROM files WHERE id = ? AND deleted_at IS NULL')
+      .get(id) as any;
     if (!file) return c.json({ error: 'File not found' }, 404);
 
     const role = (c.get as any)('role');

--- a/src/forge/routes.ts
+++ b/src/forge/routes.ts
@@ -10,17 +10,38 @@ import { ORACLE_DATA_DIR } from '../config.ts';
 function detectImageType(buffer: Buffer): { ext: string; mime: string } | null {
   if (buffer.length < 12) return null;
   // JPEG
-  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return { ext: 'jpg', mime: 'image/jpeg' };
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff)
+    return { ext: 'jpg', mime: 'image/jpeg' };
   // PNG
-  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) return { ext: 'png', mime: 'image/png' };
+  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47)
+    return { ext: 'png', mime: 'image/png' };
   // GIF
-  if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) return { ext: 'gif', mime: 'image/gif' };
+  if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46)
+    return { ext: 'gif', mime: 'image/gif' };
   // WebP
-  if (buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
-      buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50) return { ext: 'webp', mime: 'image/webp' };
+  if (
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  )
+    return { ext: 'webp', mime: 'image/webp' };
   // HEIC
-  if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70 &&
-      buffer[8] === 0x68 && buffer[9] === 0x65 && buffer[10] === 0x69 && buffer[11] === 0x63) return { ext: 'heic', mime: 'image/heic' };
+  if (
+    buffer[4] === 0x66 &&
+    buffer[5] === 0x74 &&
+    buffer[6] === 0x79 &&
+    buffer[7] === 0x70 &&
+    buffer[8] === 0x68 &&
+    buffer[9] === 0x65 &&
+    buffer[10] === 0x69 &&
+    buffer[11] === 0x63
+  )
+    return { ext: 'heic', mime: 'image/heic' };
   return null;
 }
 
@@ -40,7 +61,11 @@ interface ForgeHelpers {
 // for /api/withings/devices auth gate) receive isForgeAuthorized via server.ts's
 // surviving copy passed through the helpers DI. T#788 cleanup may dedupe.
 
-export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: ForgeHelpers): void {
+export function registerForgeRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: ForgeHelpers,
+): void {
   const { hasSessionAuth, isTrustedRequest, wsBroadcast } = helpers;
   const sqlite: Database = sqliteDb;
 
@@ -104,13 +129,22 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       INSERT INTO routine_logs SELECT * FROM routine_logs_new;
       DROP TABLE routine_logs_new;
     `);
-  } catch { /* already migrated or no constraint to remove */ }
+  } catch {
+    /* already migrated or no constraint to remove */
+  }
 
   // T#496: Normalize logged_at to UTC — fix entries stored without Z suffix
   try {
-    const fixed = sqlite.prepare("UPDATE routine_logs SET logged_at = logged_at || 'Z' WHERE logged_at NOT LIKE '%Z' AND logged_at NOT LIKE '%+%' AND deleted_at IS NULL").run();
-    if ((fixed as any).changes > 0) console.log(`[Forge] Normalized ${(fixed as any).changes} logged_at entries to UTC`);
-  } catch { /* table may not exist yet */ }
+    const fixed = sqlite
+      .prepare(
+        "UPDATE routine_logs SET logged_at = logged_at || 'Z' WHERE logged_at NOT LIKE '%Z' AND logged_at NOT LIKE '%+%' AND deleted_at IS NULL",
+      )
+      .run();
+    if ((fixed as any).changes > 0)
+      console.log(`[Forge] Normalized ${(fixed as any).changes} logged_at entries to UTC`);
+  } catch {
+    /* table may not exist yet */
+  }
 
   // Ensure uploads/routine dir exists
   const ROUTINE_UPLOADS = path.join(ORACLE_DATA_DIR, 'uploads', 'routine');
@@ -119,10 +153,10 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // Forge beast → mode map. 'write' implies 'read'. Owner session always full write.
   // Library #96 lever 1: scope-for-post-compromise-damage — grant the minimum mode each lane needs.
   const FORGE_BEAST_MODES: Record<string, 'read' | 'write'> = {
-    gorn: 'write',   // owner
-    sable: 'write',  // gatekeeper — logs meals for bear
-    karo: 'write',   // partner — bedrock 04-09 grant
-    boro: 'read',    // coach — periodization + progression reads only; writes route through Sable
+    gorn: 'write', // owner
+    sable: 'write', // gatekeeper — logs meals for bear
+    karo: 'write', // partner — bedrock 04-09 grant
+    boro: 'read', // coach — periodization + progression reads only; writes route through Sable
   };
 
   // Auth helper: Gorn (session) + allowlisted beasts per FORGE_BEAST_MODES.
@@ -132,7 +166,10 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // the legacy ?as= query param shape. Bearer-token-actor path is checked first;
   // ?as= path retained for backwards-compat with existing callers (Sable TG flows,
   // legacy scripts) until follow-up T# removes it post-migration audit.
-  function isForgeAuthorized(c: any, options: { mode: 'read' | 'write' } = { mode: 'write' }): boolean {
+  function isForgeAuthorized(
+    c: any,
+    options: { mode: 'read' | 'write' } = { mode: 'write' },
+  ): boolean {
     if (hasSessionAuth(c)) return true; // Gorn browser session — owner, full write
 
     // T#718 path: read requester from authenticated bearer-token actor (no ?as= needed)
@@ -141,7 +178,7 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       const beastMode = FORGE_BEAST_MODES[actor];
       if (!beastMode) return false;
       if (options.mode === 'read') return true; // either mode satisfies read
-      return beastMode === 'write';              // write requires write
+      return beastMode === 'write'; // write requires write
     }
 
     // Backwards-compat: ?as= query param + isTrustedRequest local-network bypass.
@@ -162,7 +199,8 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // GET /api/routine/logs — list logs
   app.get('/api/routine/logs', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const type = c.req.query('type');
     const from = c.req.query('from');
     const to = c.req.query('to');
@@ -171,36 +209,55 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
     let query = 'SELECT * FROM routine_logs WHERE deleted_at IS NULL';
     const params: any[] = [];
-    if (type) { query += ' AND type = ?'; params.push(type); }
-    if (from) { query += ' AND logged_at >= ?'; params.push(from); }
-    if (to) { query += ' AND logged_at <= ?'; params.push(to); }
+    if (type) {
+      query += ' AND type = ?';
+      params.push(type);
+    }
+    if (from) {
+      query += ' AND logged_at >= ?';
+      params.push(from);
+    }
+    if (to) {
+      query += ' AND logged_at <= ?';
+      params.push(to);
+    }
     query += ' ORDER BY logged_at DESC LIMIT ? OFFSET ?';
     params.push(limit, offset);
 
     const logs = sqlite.prepare(query).all(...params);
-    const total = (sqlite.prepare('SELECT COUNT(*) as c FROM routine_logs WHERE deleted_at IS NULL').get() as any).c;
+    const total = (
+      sqlite.prepare('SELECT COUNT(*) as c FROM routine_logs WHERE deleted_at IS NULL').get() as any
+    ).c;
     return c.json({ logs, total });
   });
 
   // GET /api/routine/today — today's logs grouped by type
   app.get('/api/routine/today', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const today = new Date().toISOString().slice(0, 10);
-    const logs = sqlite.prepare(
-      "SELECT * FROM routine_logs WHERE deleted_at IS NULL AND date(logged_at) = ? ORDER BY logged_at DESC"
-    ).all(today);
+    const logs = sqlite
+      .prepare(
+        'SELECT * FROM routine_logs WHERE deleted_at IS NULL AND date(logged_at) = ? ORDER BY logged_at DESC',
+      )
+      .all(today);
     return c.json({ logs, date: today });
   });
 
   // GET /api/routine/weight — weight history for chart (with time-based grouping)
   app.get('/api/routine/weight', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const range = c.req.query('range'); // week, month, year, 3y, 10y, all
     let dateFilter = '';
     if (range) {
       const now = new Date();
       const rangeMap: Record<string, number> = {
-        week: 7, month: 30, year: 365, '3y': 365 * 3, '10y': 365 * 10,
+        week: 7,
+        month: 30,
+        year: 365,
+        '3y': 365 * 3,
+        '10y': 365 * 10,
       };
       const days = rangeMap[range];
       if (days) {
@@ -211,25 +268,29 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
     // Grouping strategy per range (Dex/Quill spec, thread #323)
     // week/month/3m: daily points, 6m/year: weekly avg, 3y/10y/all: monthly avg
-    const grouping = (['3y', '10y', 'all'].includes(range || ''))
+    const grouping = ['3y', '10y', 'all'].includes(range || '')
       ? 'monthly'
-      : (['year'].includes(range || '') ? 'weekly' : 'daily');
+      : ['year'].includes(range || '')
+        ? 'weekly'
+        : 'daily';
 
     if (grouping === 'daily') {
-      const rows = sqlite.prepare(
-        `SELECT id, logged_at, json_extract(data, '$.value') as value, json_extract(data, '$.unit') as unit
-         FROM routine_logs WHERE type = 'weight' AND deleted_at IS NULL${dateFilter} ORDER BY logged_at ASC`
-      ).all();
+      const rows = sqlite
+        .prepare(
+          `SELECT id, logged_at, json_extract(data, '$.value') as value, json_extract(data, '$.unit') as unit
+         FROM routine_logs WHERE type = 'weight' AND deleted_at IS NULL${dateFilter} ORDER BY logged_at ASC`,
+        )
+        .all();
       return c.json({ weights: rows, grouping: 'daily' });
     }
 
     // Grouped query — return avg, min, max per period
-    const groupExpr = grouping === 'weekly'
-      ? "strftime('%Y-W%W', logged_at)"
-      : "strftime('%Y-%m', logged_at)";
+    const groupExpr =
+      grouping === 'weekly' ? "strftime('%Y-W%W', logged_at)" : "strftime('%Y-%m', logged_at)";
 
-    const rows = sqlite.prepare(
-      `SELECT ${groupExpr} as period,
+    const rows = sqlite
+      .prepare(
+        `SELECT ${groupExpr} as period,
               ROUND(AVG(json_extract(data, '$.value')), 1) as value,
               ROUND(MIN(json_extract(data, '$.value')), 1) as min_value,
               ROUND(MAX(json_extract(data, '$.value')), 1) as max_value,
@@ -239,21 +300,27 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
        FROM routine_logs
        WHERE type = 'weight' AND deleted_at IS NULL${dateFilter}
        GROUP BY ${groupExpr}
-       ORDER BY period ASC`
-    ).all();
+       ORDER BY period ASC`,
+      )
+      .all();
     return c.json({ weights: rows, grouping });
   });
 
   // GET /api/routine/blood-pressure — BP history for chart (Prowl #80)
   // Mirrors /api/routine/weight: range filter + time-based grouping
   app.get('/api/routine/blood-pressure', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const range = c.req.query('range');
     let dateFilter = '';
     if (range) {
       const now = new Date();
       const rangeMap: Record<string, number> = {
-        week: 7, month: 30, year: 365, '3y': 365 * 3, '10y': 365 * 10,
+        week: 7,
+        month: 30,
+        year: 365,
+        '3y': 365 * 3,
+        '10y': 365 * 10,
       };
       const days = rangeMap[range];
       if (days) {
@@ -262,26 +329,30 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       }
     }
 
-    const grouping = (['3y', '10y', 'all'].includes(range || ''))
+    const grouping = ['3y', '10y', 'all'].includes(range || '')
       ? 'monthly'
-      : (['year'].includes(range || '') ? 'weekly' : 'daily');
+      : ['year'].includes(range || '')
+        ? 'weekly'
+        : 'daily';
 
     if (grouping === 'daily') {
-      const rows = sqlite.prepare(
-        `SELECT id, logged_at,
+      const rows = sqlite
+        .prepare(
+          `SELECT id, logged_at,
                 json_extract(data, '$.systolic') as systolic,
                 json_extract(data, '$.diastolic') as diastolic
-         FROM routine_logs WHERE type = 'blood_pressure' AND deleted_at IS NULL${dateFilter} ORDER BY logged_at ASC`
-      ).all();
+         FROM routine_logs WHERE type = 'blood_pressure' AND deleted_at IS NULL${dateFilter} ORDER BY logged_at ASC`,
+        )
+        .all();
       return c.json({ readings: rows, grouping: 'daily' });
     }
 
-    const groupExpr = grouping === 'weekly'
-      ? "strftime('%Y-W%W', logged_at)"
-      : "strftime('%Y-%m', logged_at)";
+    const groupExpr =
+      grouping === 'weekly' ? "strftime('%Y-W%W', logged_at)" : "strftime('%Y-%m', logged_at)";
 
-    const rows = sqlite.prepare(
-      `SELECT ${groupExpr} as period,
+    const rows = sqlite
+      .prepare(
+        `SELECT ${groupExpr} as period,
               ROUND(AVG(json_extract(data, '$.systolic')), 0) as systolic,
               ROUND(AVG(json_extract(data, '$.diastolic')), 0) as diastolic,
               ROUND(MIN(json_extract(data, '$.systolic')), 0) as systolic_min,
@@ -293,8 +364,9 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
        FROM routine_logs
        WHERE type = 'blood_pressure' AND deleted_at IS NULL${dateFilter}
        GROUP BY ${groupExpr}
-       ORDER BY period ASC`
-    ).all();
+       ORDER BY period ASC`,
+      )
+      .all();
     return c.json({ readings: rows, grouping });
   });
 
@@ -304,17 +376,20 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // (Bar Shrug 04-22 / Shoulder Press 04-23 / Bench Press 04-24). Replaces
   // 20-page pull-and-filter workflow with a single structured summary.
   app.get('/api/routine/exercise-summary', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const exercise = c.req.query('exercise');
     if (!exercise) return c.json({ error: 'exercise query param required' }, 400);
     const needle = exercise.toLowerCase().trim();
     if (!needle) return c.json({ error: 'exercise query param must be non-empty after trim' }, 400);
 
-    const rows = sqlite.prepare(
-      `SELECT id, logged_at, data FROM routine_logs
+    const rows = sqlite
+      .prepare(
+        `SELECT id, logged_at, data FROM routine_logs
        WHERE type = 'workout' AND deleted_at IS NULL
-       ORDER BY logged_at DESC`
-    ).all() as any[];
+       ORDER BY logged_at DESC`,
+      )
+      .all() as any[];
 
     interface MatchedSession {
       date: string;
@@ -325,10 +400,14 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
     for (const row of rows) {
       let data: any;
-      try { data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data; } catch { continue; }
+      try {
+        data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data;
+      } catch {
+        continue;
+      }
       const exercises: any[] = data.exercises || [];
       for (const ex of exercises) {
-        const rawName = typeof ex === 'string' ? ex : (ex.name || '');
+        const rawName = typeof ex === 'string' ? ex : ex.name || '';
         const { name, equipment } = parseExerciseName(rawName);
         const fullName = (equipment ? `${name} · ${equipment}` : name).trim();
         if (!fullName) continue;
@@ -366,7 +445,12 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         peak: null,
         recent: [],
         trend: 'cold',
-        frequency: { total_sessions: 0, last_session_date: null, sessions_last_30d: 0, sessions_last_90d: 0 },
+        frequency: {
+          total_sessions: 0,
+          last_session_date: null,
+          sessions_last_30d: 0,
+          sessions_last_90d: 0,
+        },
         note: 'No matching sessions found. Try broader search term or check spelling.',
       });
     }
@@ -388,7 +472,7 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     }
 
     // Recent: last 5 sessions (already sorted DESC)
-    const recent = matching.slice(0, 5).map(m => ({
+    const recent = matching.slice(0, 5).map((m) => ({
       date: m.date.slice(0, 10),
       session_title: m.session_title,
       sets: m.sets,
@@ -398,8 +482,8 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const now = Date.now();
     const d30 = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
     const d90 = new Date(now - 90 * 24 * 60 * 60 * 1000).toISOString();
-    const sessions_last_30d = matching.filter(m => m.date >= d30).length;
-    const sessions_last_90d = matching.filter(m => m.date >= d90).length;
+    const sessions_last_30d = matching.filter((m) => m.date >= d30).length;
+    const sessions_last_90d = matching.filter((m) => m.date >= d90).length;
 
     // Trend: compare last 3 sessions peak-weight to prior 3-6 sessions peak-weight
     let trend: string;
@@ -445,11 +529,13 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // GET /api/routine/prs — sibling endpoint per Boro spec (Prowl #83).
   // Alias to /api/routine/personal-records?grouped=true for cleaner call-site naming.
   app.get('/api/routine/prs', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const range = c.req.query('range');
     let dateFilter = '';
     if (range === 'month') dateFilter = "AND achieved_at >= datetime('now', '-30 days')";
-    const records = sqlite.prepare(`
+    const records = sqlite
+      .prepare(`
       SELECT pr.* FROM personal_records pr
       INNER JOIN (
         SELECT exercise_name, MAX(weight) as max_weight
@@ -460,7 +546,8 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       WHERE 1=1 ${dateFilter}
       GROUP BY pr.exercise_name
       ORDER BY pr.weight DESC, pr.reps DESC
-    `).all();
+    `)
+      .all();
     return c.json({ records, total_exercises: records.length });
   });
 
@@ -473,26 +560,38 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   }
 
   // Parse string-format exercises like "Chest Press 190lbs 8/8/6" into sets
-  function parseExerciseString(raw: string): { name: string; sets: { weight: number; reps: number; unit: string }[] } {
+  function parseExerciseString(raw: string): {
+    name: string;
+    sets: { weight: number; reps: number; unit: string }[];
+  } {
     // Match: "Exercise Name <weight><unit> <reps>/<reps>/..."
     const match = raw.match(/^(.+?)\s+(\d+(?:\.\d+)?)\s*(kg|lbs?|KG|LBS?)\s+([\d/]+)$/);
     if (!match) return { name: raw, sets: [] };
     const name = match[1].trim();
     const weight = parseFloat(match[2]);
     const unit = match[3].toLowerCase().startsWith('lb') ? 'lbs' : 'kg';
-    const repsList = match[4].split('/').map(r => parseInt(r) || 0).filter(r => r > 0);
-    return { name, sets: repsList.map(reps => ({ weight, reps, unit })) };
+    const repsList = match[4]
+      .split('/')
+      .map((r) => parseInt(r) || 0)
+      .filter((r) => r > 0);
+    return { name, sets: repsList.map((reps) => ({ weight, reps, unit })) };
   }
 
   // GET /api/routine/workout-trends — exercise progress over time (T#397)
   app.get('/api/routine/workout-trends', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const range = c.req.query('range') || 'year';
     const exercise = c.req.query('exercise'); // optional: filter to specific exercise
 
     let dateFilter = '';
     const rangeMap: Record<string, number> = {
-      week: 7, month: 30, '3m': 90, year: 365, '3y': 365 * 3, '10y': 365 * 10,
+      week: 7,
+      month: 30,
+      '3m': 90,
+      year: 365,
+      '3y': 365 * 3,
+      '10y': 365 * 10,
     };
     const days = rangeMap[range];
     if (days) {
@@ -501,31 +600,40 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     }
 
     // Get all workout logs in range
-    const rows = sqlite.prepare(
-      `SELECT id, logged_at, data FROM routine_logs
+    const rows = sqlite
+      .prepare(
+        `SELECT id, logged_at, data FROM routine_logs
        WHERE type = 'workout' AND deleted_at IS NULL${dateFilter}
-       ORDER BY logged_at ASC`
-    ).all() as any[];
+       ORDER BY logged_at ASC`,
+      )
+      .all() as any[];
 
     // Parse exercises from each workout, compute per-exercise stats
-    const exerciseData: Map<string, Array<{
-      date: string;
-      maxWeight: number;
-      totalVolume: number;
-      totalSets: number;
-      totalReps: number;
-      unit: string;
-    }>> = new Map();
+    const exerciseData: Map<
+      string,
+      Array<{
+        date: string;
+        maxWeight: number;
+        totalVolume: number;
+        totalSets: number;
+        totalReps: number;
+        unit: string;
+      }>
+    > = new Map();
 
     const exerciseFrequency: Map<string, number> = new Map();
 
     for (const row of rows) {
       let data: any;
-      try { data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data; } catch { continue; }
+      try {
+        data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data;
+      } catch {
+        continue;
+      }
       const exercises: any[] = data.exercises || [];
 
       for (const ex of exercises) {
-        const rawName = typeof ex === 'string' ? ex : (ex.name || '');
+        const rawName = typeof ex === 'string' ? ex : ex.name || '';
         const { name, equipment } = parseExerciseName(rawName);
         if (!name) continue;
         // Include equipment in the key to split Machine vs Dumbbell etc.
@@ -566,8 +674,7 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     }
 
     // Top 5 by frequency (default selection), but include ALL trend data
-    const sortedExercises = [...exerciseFrequency.entries()]
-      .sort((a, b) => b[1] - a[1]);
+    const sortedExercises = [...exerciseFrequency.entries()].sort((a, b) => b[1] - a[1]);
     const topExercises = exercise
       ? [...exerciseData.keys()]
       : sortedExercises.slice(0, 5).map(([name]) => name);
@@ -588,23 +695,33 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // GET /api/routine/body-composition — body comp history from Withings (T#479, Spec #28)
   app.get('/api/routine/body-composition', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge access required' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge access required' }, 403);
     const range = c.req.query('range') || 'month';
     const rangeMap: Record<string, string> = {
-      '1w': '-7 days', week: '-7 days', '1m': '-30 days', month: '-30 days',
-      '3m': '-90 days', '1y': '-365 days', year: '-365 days',
-      '3y': '-1095 days', '10y': '-3650 days', all: '-36500 days',
+      '1w': '-7 days',
+      week: '-7 days',
+      '1m': '-30 days',
+      month: '-30 days',
+      '3m': '-90 days',
+      '1y': '-365 days',
+      year: '-365 days',
+      '3y': '-1095 days',
+      '10y': '-3650 days',
+      all: '-36500 days',
     };
     const dateOffset = rangeMap[range] || '-30 days';
 
-    const rows = sqlite.prepare(
-      `SELECT logged_at, data FROM routine_logs
+    const rows = sqlite
+      .prepare(
+        `SELECT logged_at, data FROM routine_logs
        WHERE type = 'measurement' AND source = 'withings' AND deleted_at IS NULL
        AND logged_at >= datetime('now', 'localtime', ?)
-       ORDER BY logged_at ASC`
-    ).all(dateOffset) as any[];
+       ORDER BY logged_at ASC`,
+      )
+      .all(dateOffset) as any[];
 
-    const measurements = rows.map(r => {
+    const measurements = rows.map((r) => {
       const d = typeof r.data === 'string' ? JSON.parse(r.data) : r.data;
       return {
         logged_at: r.logged_at,
@@ -623,13 +740,27 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const previous = measurements.length > 1 ? measurements[measurements.length - 2] : null;
 
     // Compute trends
-    const trends: Record<string, { current: number | null; previous: number | null; direction: string }> = {};
+    const trends: Record<
+      string,
+      { current: number | null; previous: number | null; direction: string }
+    > = {};
     if (latest && previous) {
-      for (const key of ['body_fat_pct', 'fat_mass', 'muscle_mass', 'bone_mass', 'hydration', 'visceral_fat'] as const) {
+      for (const key of [
+        'body_fat_pct',
+        'fat_mass',
+        'muscle_mass',
+        'bone_mass',
+        'hydration',
+        'visceral_fat',
+      ] as const) {
         const curr = (latest as any)[key];
         const prev = (previous as any)[key];
         if (curr != null && prev != null) {
-          trends[key] = { current: curr, previous: prev, direction: curr > prev ? 'up' : curr < prev ? 'down' : 'stable' };
+          trends[key] = {
+            current: curr,
+            previous: prev,
+            direction: curr > prev ? 'up' : curr < prev ? 'down' : 'stable',
+          };
         }
       }
     }
@@ -639,37 +770,66 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // GET /api/routine/stats — summary stats
   app.get('/api/routine/stats', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
-    const totalLogs = (sqlite.prepare('SELECT COUNT(*) as c FROM routine_logs WHERE deleted_at IS NULL').get() as any).c;
-    const byType = sqlite.prepare('SELECT type, COUNT(*) as count FROM routine_logs WHERE deleted_at IS NULL GROUP BY type').all();
-    const thisWeek = (sqlite.prepare("SELECT COUNT(*) as c FROM routine_logs WHERE deleted_at IS NULL AND type = 'workout' AND logged_at >= datetime('now', '-7 days')").get() as any).c;
-    const latestWeight = sqlite.prepare("SELECT json_extract(data, '$.value') as value, logged_at FROM routine_logs WHERE type = 'weight' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1").get() as any;
-    return c.json({ total_logs: totalLogs, by_type: byType, workouts_this_week: thisWeek, latest_weight: latestWeight });
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    const totalLogs = (
+      sqlite.prepare('SELECT COUNT(*) as c FROM routine_logs WHERE deleted_at IS NULL').get() as any
+    ).c;
+    const byType = sqlite
+      .prepare(
+        'SELECT type, COUNT(*) as count FROM routine_logs WHERE deleted_at IS NULL GROUP BY type',
+      )
+      .all();
+    const thisWeek = (
+      sqlite
+        .prepare(
+          "SELECT COUNT(*) as c FROM routine_logs WHERE deleted_at IS NULL AND type = 'workout' AND logged_at >= datetime('now', '-7 days')",
+        )
+        .get() as any
+    ).c;
+    const latestWeight = sqlite
+      .prepare(
+        "SELECT json_extract(data, '$.value') as value, logged_at FROM routine_logs WHERE type = 'weight' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1",
+      )
+      .get() as any;
+    return c.json({
+      total_logs: totalLogs,
+      by_type: byType,
+      workouts_this_week: thisWeek,
+      latest_weight: latestWeight,
+    });
   });
 
   // GET /api/routine/summary — enhanced summary for Stats tab (T#410)
   app.get('/api/routine/summary', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const range = c.req.query('range') || 'week';
     const rangeMap: Record<string, number> = { week: 7, month: 30, '3m': 90, year: 365 };
     const days = rangeMap[range] || 7;
     const from = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 
-    const workoutsThisRange = (sqlite.prepare(
-      "SELECT COUNT(*) as c FROM routine_logs WHERE deleted_at IS NULL AND type = 'workout' AND logged_at >= ?"
-    ).get(from) as any).c;
+    const workoutsThisRange = (
+      sqlite
+        .prepare(
+          "SELECT COUNT(*) as c FROM routine_logs WHERE deleted_at IS NULL AND type = 'workout' AND logged_at >= ?",
+        )
+        .get(from) as any
+    ).c;
 
     // Total volume this range (sum of weight * reps across all sets)
-    const workoutRows = sqlite.prepare(
-      "SELECT data FROM routine_logs WHERE deleted_at IS NULL AND type = 'workout' AND logged_at >= ?"
-    ).all(from) as any[];
+    const workoutRows = sqlite
+      .prepare(
+        "SELECT data FROM routine_logs WHERE deleted_at IS NULL AND type = 'workout' AND logged_at >= ?",
+      )
+      .all(from) as any[];
 
     let totalVolume = 0;
     let bestLift = { exercise: '', weight: 0, reps: 0, unit: 'kg' };
     for (const row of workoutRows) {
       try {
         const data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data;
-        for (const ex of (data.exercises || [])) {
+        for (const ex of data.exercises || []) {
           if (typeof ex === 'string') {
             const parsed = parseExerciseString(ex);
             for (const s of parsed.sets) {
@@ -680,7 +840,7 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
             }
           } else {
             const { name } = parseExerciseName(ex.name || '');
-            for (const s of (ex.sets || [])) {
+            for (const s of ex.sets || []) {
               const w = parseFloat(s.weight) || 0;
               const r = parseInt(s.reps) || 0;
               totalVolume += w * r;
@@ -690,18 +850,31 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
             }
           }
         }
-      } catch { /* skip */ }
+      } catch {
+        /* skip */
+      }
     }
 
-    const latestWeight = sqlite.prepare(
-      "SELECT json_extract(data, '$.value') as value, logged_at FROM routine_logs WHERE type = 'weight' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1"
-    ).get() as any;
+    const latestWeight = sqlite
+      .prepare(
+        "SELECT json_extract(data, '$.value') as value, logged_at FROM routine_logs WHERE type = 'weight' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1",
+      )
+      .get() as any;
 
-    const prevWeight = sqlite.prepare(
-      "SELECT json_extract(data, '$.value') as value FROM routine_logs WHERE type = 'weight' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1 OFFSET 1"
-    ).get() as any;
+    const prevWeight = sqlite
+      .prepare(
+        "SELECT json_extract(data, '$.value') as value FROM routine_logs WHERE type = 'weight' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1 OFFSET 1",
+      )
+      .get() as any;
 
-    const weightTrend = latestWeight && prevWeight ? (latestWeight.value > prevWeight.value ? 'up' : latestWeight.value < prevWeight.value ? 'down' : 'stable') : null;
+    const weightTrend =
+      latestWeight && prevWeight
+        ? latestWeight.value > prevWeight.value
+          ? 'up'
+          : latestWeight.value < prevWeight.value
+            ? 'down'
+            : 'stable'
+        : null;
 
     return c.json({
       workouts: workoutsThisRange,
@@ -714,14 +887,21 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // GET /api/routine/exercises — exercise library (T#410)
   app.get('/api/routine/exercises', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const q = c.req.query('q');
     const muscleGroup = c.req.query('muscle_group');
 
     let query = 'SELECT * FROM exercises WHERE 1=1';
     const params: any[] = [];
-    if (q) { query += ' AND name LIKE ?'; params.push(`%${q}%`); }
-    if (muscleGroup) { query += ' AND muscle_group = ?'; params.push(muscleGroup); }
+    if (q) {
+      query += ' AND name LIKE ?';
+      params.push(`%${q}%`);
+    }
+    if (muscleGroup) {
+      query += ' AND muscle_group = ?';
+      params.push(muscleGroup);
+    }
     query += ' ORDER BY name ASC';
 
     const exercises = sqlite.prepare(query).all(...params);
@@ -730,44 +910,52 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // POST /api/routine/exercises — add custom exercise (T#410)
   app.post('/api/routine/exercises', async (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     try {
       const body = await c.req.json();
       const { name, muscle_group, equipment } = body;
       if (!name) return c.json({ error: 'Exercise name is required' }, 400);
       try {
-        sqlite.prepare(
-          'INSERT INTO exercises (name, muscle_group, equipment, created_by) VALUES (?, ?, ?, ?)'
-        ).run(name, muscle_group || null, equipment || null, 'manual');
+        sqlite
+          .prepare(
+            'INSERT INTO exercises (name, muscle_group, equipment, created_by) VALUES (?, ?, ?, ?)',
+          )
+          .run(name, muscle_group || null, equipment || null, 'manual');
       } catch (e: any) {
         if (e.message?.includes('UNIQUE')) return c.json({ error: 'Exercise already exists' }, 409);
         throw e;
       }
-      const exercise = sqlite.prepare('SELECT * FROM exercises WHERE name = ? AND equipment IS ?').get(name, equipment || null);
+      const exercise = sqlite
+        .prepare('SELECT * FROM exercises WHERE name = ? AND equipment IS ?')
+        .get(name, equipment || null);
       return c.json(exercise, 201);
-    } catch { return c.json({ error: 'Invalid request' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
   });
 
   // POST /api/routine/exercises/seed — seed exercise library from existing workout data (T#410)
   app.post('/api/routine/exercises/seed', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
 
-    const rows = sqlite.prepare(
-      "SELECT data FROM routine_logs WHERE type = 'workout' AND deleted_at IS NULL"
-    ).all() as any[];
+    const rows = sqlite
+      .prepare("SELECT data FROM routine_logs WHERE type = 'workout' AND deleted_at IS NULL")
+      .all() as any[];
 
     const seen = new Set<string>();
     let seeded = 0;
 
     const insert = sqlite.prepare(
-      'INSERT OR IGNORE INTO exercises (name, muscle_group, equipment, created_by) VALUES (?, ?, ?, ?)'
+      'INSERT OR IGNORE INTO exercises (name, muscle_group, equipment, created_by) VALUES (?, ?, ?, ?)',
     );
 
     for (const row of rows) {
       try {
         const data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data;
-        for (const ex of (data.exercises || [])) {
-          const rawName = typeof ex === 'string' ? ex : (ex.name || '');
+        for (const ex of data.exercises || []) {
+          const rawName = typeof ex === 'string' ? ex : ex.name || '';
           const { name, equipment } = parseExerciseName(rawName);
           const key = `${name}|${equipment}`;
           if (!name || seen.has(key)) continue;
@@ -775,7 +963,9 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
           const result = insert.run(name, data.muscle_group || null, equipment || null, 'import');
           if (result.changes > 0) seeded++;
         }
-      } catch { /* skip */ }
+      } catch {
+        /* skip */
+      }
     }
 
     return c.json({ seeded, total: seen.size });
@@ -783,7 +973,8 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // GET /api/routine/personal-records — personal records list (T#410, T#543)
   app.get('/api/routine/personal-records', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const exercise = c.req.query('exercise');
     const range = c.req.query('range');
     const grouped = c.req.query('grouped'); // 'true' = best lift per exercise
@@ -792,7 +983,8 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       // Best lift per exercise — highest weight, then highest reps at that weight
       let dateFilter = '';
       if (range === 'month') dateFilter = "AND achieved_at >= datetime('now', '-30 days')";
-      const records = sqlite.prepare(`
+      const records = sqlite
+        .prepare(`
         SELECT pr.* FROM personal_records pr
         INNER JOIN (
           SELECT exercise_name, MAX(weight) as max_weight
@@ -803,13 +995,17 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         WHERE 1=1 ${dateFilter}
         GROUP BY pr.exercise_name
         ORDER BY pr.weight DESC, pr.reps DESC
-      `).all();
+      `)
+        .all();
       return c.json({ records });
     }
 
     let query = 'SELECT * FROM personal_records WHERE 1=1';
     const params: any[] = [];
-    if (exercise) { query += ' AND exercise_name = ?'; params.push(exercise); }
+    if (exercise) {
+      query += ' AND exercise_name = ?';
+      params.push(exercise);
+    }
     if (range === 'month') {
       query += " AND achieved_at >= datetime('now', '-30 days')";
     }
@@ -821,34 +1017,44 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // POST /api/routine/personal-records/seed — backfill PRs from all workout logs (T#543)
   app.post('/api/routine/personal-records/seed', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
-    const workouts = sqlite.prepare(
-      "SELECT id, logged_at, data FROM routine_logs WHERE type = 'workout' AND deleted_at IS NULL"
-    ).all() as any[];
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    const workouts = sqlite
+      .prepare(
+        "SELECT id, logged_at, data FROM routine_logs WHERE type = 'workout' AND deleted_at IS NULL",
+      )
+      .all() as any[];
 
     const prInsert = sqlite.prepare(
-      'INSERT OR IGNORE INTO personal_records (exercise_name, weight, reps, unit, achieved_at, log_id) VALUES (?, ?, ?, ?, ?, ?)'
+      'INSERT OR IGNORE INTO personal_records (exercise_name, weight, reps, unit, achieved_at, log_id) VALUES (?, ?, ?, ?, ?, ?)',
     );
 
     let inserted = 0;
     const insertPR = sqlite.transaction(() => {
       for (const log of workouts) {
         const d = typeof log.data === 'string' ? JSON.parse(log.data) : log.data;
-        for (const ex of (d.exercises || [])) {
+        for (const ex of d.exercises || []) {
           if (typeof ex === 'string') {
             // Manual format: "Chest Press 190lbs 8/8/6"
             const parsed = parseExerciseString(ex);
             for (const s of parsed.sets) {
               if (s.weight > 0 && s.reps > 0) {
-                const res = prInsert.run(parsed.name, s.weight, s.reps, s.unit, log.logged_at, log.id);
+                const res = prInsert.run(
+                  parsed.name,
+                  s.weight,
+                  s.reps,
+                  s.unit,
+                  log.logged_at,
+                  log.id,
+                );
                 if ((res as any).changes > 0) inserted++;
               }
             }
           } else {
             // Structured format from Alpha Progression
-            const { name } = parseExerciseName(typeof ex === 'string' ? ex : (ex.name || ''));
+            const { name } = parseExerciseName(typeof ex === 'string' ? ex : ex.name || '');
             if (!name) continue;
-            for (const s of (ex.sets || [])) {
+            for (const s of ex.sets || []) {
               const w = parseFloat(s.weight) || 0;
               const r = parseInt(s.reps) || 0;
               if (w > 0 && r > 0) {
@@ -868,11 +1074,15 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // GET /api/routine/photos — photo gallery
   app.get('/api/routine/photos', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const tag = c.req.query('tag');
     let query = "SELECT * FROM routine_logs WHERE type = 'photo' AND deleted_at IS NULL";
     const params: any[] = [];
-    if (tag) { query += " AND json_extract(data, '$.tag') = ?"; params.push(tag); }
+    if (tag) {
+      query += " AND json_extract(data, '$.tag') = ?";
+      params.push(tag);
+    }
     query += ' ORDER BY logged_at DESC';
     const photos = sqlite.prepare(query).all(...params);
     return c.json({ photos });
@@ -882,8 +1092,15 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // identically. Also addresses the inconsistency between create-path and
   // edit-path discipline (same shape as T#706 parseDaysOfWeek helper).
   // Mutates workoutData in place to coerce rpe to Number.
-  function validateWorkoutData(workoutData: any): { ok: true; data: any } | { ok: false; error: string; hint?: string } {
-    if (!workoutData || typeof workoutData !== 'object' || !workoutData.exercises || !Array.isArray(workoutData.exercises)) {
+  function validateWorkoutData(
+    workoutData: any,
+  ): { ok: true; data: any } | { ok: false; error: string; hint?: string } {
+    if (
+      !workoutData ||
+      typeof workoutData !== 'object' ||
+      !workoutData.exercises ||
+      !Array.isArray(workoutData.exercises)
+    ) {
       return {
         ok: false,
         error: 'Workout must include an exercises array.',
@@ -900,46 +1117,82 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         };
       }
       if (!ex.name?.trim()) {
-        return { ok: false, error: `Exercise ${i + 1}: name is required.`, hint: '{ name: "Bench Press", sets: [{ weight: 80, reps: 10, unit: "kg" }] }' };
+        return {
+          ok: false,
+          error: `Exercise ${i + 1}: name is required.`,
+          hint: '{ name: "Bench Press", sets: [{ weight: 80, reps: 10, unit: "kg" }] }',
+        };
       }
       if (!ex.sets || !Array.isArray(ex.sets) || ex.sets.length === 0) {
-        return { ok: false, error: `Exercise ${i + 1} ("${ex.name}"): sets array is required with at least one set.`, hint: 'sets: [{ weight: 80, reps: 10, unit: "kg" }]' };
+        return {
+          ok: false,
+          error: `Exercise ${i + 1} ("${ex.name}"): sets array is required with at least one set.`,
+          hint: 'sets: [{ weight: 80, reps: 10, unit: "kg" }]',
+        };
       }
       // T#710: per-exercise notes — optional string
       if (ex.notes != null && typeof ex.notes !== 'string') {
-        return { ok: false, error: `Exercise ${i + 1} ("${ex.name}"): notes must be a string if provided.`, hint: 'notes: "felt strong, depth good"' };
+        return {
+          ok: false,
+          error: `Exercise ${i + 1} ("${ex.name}"): notes must be a string if provided.`,
+          hint: 'notes: "felt strong, depth good"',
+        };
       }
       // T#711: hevy_template_id — optional string, cross-link to Hevy exercise library
       if (ex.hevy_template_id != null && typeof ex.hevy_template_id !== 'string') {
-        return { ok: false, error: `Exercise ${i + 1} ("${ex.name}"): hevy_template_id must be a string if provided.`, hint: 'hevy_template_id: "D04AC939"' };
+        return {
+          ok: false,
+          error: `Exercise ${i + 1} ("${ex.name}"): hevy_template_id must be a string if provided.`,
+          hint: 'hevy_template_id: "D04AC939"',
+        };
       }
       // T#711: superset_id — optional finite number, preserves Hevy superset grouping
       if (ex.superset_id != null) {
         if (typeof ex.superset_id !== 'number' || !Number.isFinite(ex.superset_id)) {
-          return { ok: false, error: `Exercise ${i + 1} ("${ex.name}"): superset_id must be a finite number if provided.`, hint: 'superset_id: 0' };
+          return {
+            ok: false,
+            error: `Exercise ${i + 1} ("${ex.name}"): superset_id must be a finite number if provided.`,
+            hint: 'superset_id: 0',
+          };
         }
       }
       for (let j = 0; j < ex.sets.length; j++) {
         const s = ex.sets[j];
         if (s.weight == null || s.reps == null) {
-          return { ok: false, error: `Exercise ${i + 1} ("${ex.name}"), set ${j + 1}: weight and reps are required.`, hint: '{ weight: 80, reps: 10, unit: "kg" }' };
+          return {
+            ok: false,
+            error: `Exercise ${i + 1} ("${ex.name}"), set ${j + 1}: weight and reps are required.`,
+            hint: '{ weight: 80, reps: 10, unit: "kg" }',
+          };
         }
         // T#710: per-set RPE — optional number 1-10
         if (s.rpe != null) {
           const rpeNum = Number(s.rpe);
           if (isNaN(rpeNum) || rpeNum < 1 || rpeNum > 10) {
-            return { ok: false, error: `Exercise ${i + 1} ("${ex.name}"), set ${j + 1}: rpe must be a number between 1 and 10 if provided.`, hint: '{ weight: 80, reps: 10, rpe: 8 }' };
+            return {
+              ok: false,
+              error: `Exercise ${i + 1} ("${ex.name}"), set ${j + 1}: rpe must be a number between 1 and 10 if provided.`,
+              hint: '{ weight: 80, reps: 10, rpe: 8 }',
+            };
           }
           s.rpe = rpeNum;
         }
         // T#711: per-set type — optional enum (normal|warmup|dropset|failure)
         if (s.type != null) {
           if (typeof s.type !== 'string') {
-            return { ok: false, error: `Exercise ${i + 1} ("${ex.name}"), set ${j + 1}: type must be a string if provided.`, hint: 'type: "warmup" | "normal" | "dropset" | "failure"' };
+            return {
+              ok: false,
+              error: `Exercise ${i + 1} ("${ex.name}"), set ${j + 1}: type must be a string if provided.`,
+              hint: 'type: "warmup" | "normal" | "dropset" | "failure"',
+            };
           }
           const t = s.type.toLowerCase();
           if (t !== 'normal' && t !== 'warmup' && t !== 'dropset' && t !== 'failure') {
-            return { ok: false, error: `Exercise ${i + 1} ("${ex.name}"), set ${j + 1}: type must be one of normal, warmup, dropset, failure.`, hint: 'type: "warmup"' };
+            return {
+              ok: false,
+              error: `Exercise ${i + 1} ("${ex.name}"), set ${j + 1}: type must be one of normal, warmup, dropset, failure.`,
+              hint: 'type: "warmup"',
+            };
           }
           s.type = t;
         }
@@ -950,7 +1203,8 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // POST /api/routine/logs — create log entry
   app.post('/api/routine/logs', async (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     try {
       const data = await c.req.json();
       const { type, logged_at } = data;
@@ -963,31 +1217,53 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         const mealData = typeof data.data === 'string' ? JSON.parse(data.data) : data.data;
         if (mealData.items && Array.isArray(mealData.items)) {
           // T#430: itemized meal — validate each item, auto-sum totals
-          if (mealData.items.length === 0) return c.json({ error: 'At least 1 meal item required' }, 400);
+          if (mealData.items.length === 0)
+            return c.json({ error: 'At least 1 meal item required' }, 400);
           const macroFields = ['calories', 'protein', 'carbs', 'fat'] as const;
           for (let i = 0; i < mealData.items.length; i++) {
             const item = mealData.items[i];
             if (!item.name?.trim()) return c.json({ error: `Item ${i + 1}: name required` }, 400);
-            const missing = macroFields.filter(f => item[f] == null || item[f] === '');
-            if (missing.length > 0) return c.json({ error: `Item ${i + 1} (${item.name}): macros required: ${missing.join(', ')}` }, 400);
+            const missing = macroFields.filter((f) => item[f] == null || item[f] === '');
+            if (missing.length > 0)
+              return c.json(
+                { error: `Item ${i + 1} (${item.name}): macros required: ${missing.join(', ')}` },
+                400,
+              );
             for (const f of macroFields) {
               const v = Number(item[f]);
-              if (isNaN(v) || v < 0) return c.json({ error: `Item ${i + 1} (${item.name}): ${f} must be a non-negative number` }, 400);
+              if (isNaN(v) || v < 0)
+                return c.json(
+                  { error: `Item ${i + 1} (${item.name}): ${f} must be a non-negative number` },
+                  400,
+                );
               item[f] = v;
             }
           }
           // Auto-compute top-level totals from items
           for (const f of macroFields) {
-            mealData[f] = mealData.items.reduce((sum: number, item: any) => sum + (Number(item[f]) || 0), 0);
+            mealData[f] = mealData.items.reduce(
+              (sum: number, item: any) => sum + (Number(item[f]) || 0),
+              0,
+            );
           }
           // Auto-generate description from items if not provided
           if (!mealData.description) {
-            mealData.description = mealData.items.map((item: any) => item.name).slice(0, 3).join(', ') + (mealData.items.length > 3 ? '...' : '');
+            mealData.description =
+              mealData.items
+                .map((item: any) => item.name)
+                .slice(0, 3)
+                .join(', ') + (mealData.items.length > 3 ? '...' : '');
           }
           data.data = mealData;
         } else {
           // T#483: meal items are now mandatory — no more total-only logging
-          return c.json({ error: 'Meal items required. Each meal must include an items array with individual food items and per-item macros (name, calories, protein, carbs, fat).' }, 400);
+          return c.json(
+            {
+              error:
+                'Meal items required. Each meal must include an items array with individual food items and per-item macros (name, calories, protein, carbs, fat).',
+            },
+            400,
+          );
         }
       }
       // Workout validation — enforce structured exercise format (T#521, T#522, T#710)
@@ -1004,9 +1280,11 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       if (logged_at && !logged_at.endsWith('Z') && !logged_at.includes('+')) {
         normalizedLoggedAt = logged_at + 'Z';
       }
-      const result = sqlite.prepare(
-        'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)'
-      ).run(type, normalizedLoggedAt, jsonData, data.source || 'manual', now);
+      const result = sqlite
+        .prepare(
+          'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)',
+        )
+        .run(type, normalizedLoggedAt, jsonData, data.source || 'manual', now);
       const logId = (result as any).lastInsertRowid;
       const log = sqlite.prepare('SELECT * FROM routine_logs WHERE id = ?').get(logId);
 
@@ -1015,12 +1293,12 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         try {
           const workoutData = typeof data.data === 'string' ? JSON.parse(data.data) : data.data;
           const prInsert = sqlite.prepare(
-            'INSERT OR IGNORE INTO personal_records (exercise_name, weight, reps, unit, achieved_at, log_id) VALUES (?, ?, ?, ?, ?, ?)'
+            'INSERT OR IGNORE INTO personal_records (exercise_name, weight, reps, unit, achieved_at, log_id) VALUES (?, ?, ?, ?, ?, ?)',
           );
-          for (const ex of (workoutData.exercises || [])) {
-            const { name } = parseExerciseName(typeof ex === 'string' ? ex : (ex.name || ''));
+          for (const ex of workoutData.exercises || []) {
+            const { name } = parseExerciseName(typeof ex === 'string' ? ex : ex.name || '');
             if (!name) continue;
-            for (const s of (ex.sets || [])) {
+            for (const s of ex.sets || []) {
               const w = parseFloat(s.weight) || 0;
               const r = parseInt(s.reps) || 0;
               if (w > 0 && r > 0) {
@@ -1028,18 +1306,25 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
               }
             }
           }
-        } catch { /* PR update failure is non-critical */ }
+        } catch {
+          /* PR update failure is non-critical */
+        }
       }
 
       return c.json(log, 201);
-    } catch { return c.json({ error: 'Invalid request' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
   });
 
   // PATCH /api/routine/logs/:id — edit log
   app.patch('/api/routine/logs/:id', async (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const id = parseInt(c.req.param('id'), 10);
-    const existing = sqlite.prepare('SELECT * FROM routine_logs WHERE id = ? AND deleted_at IS NULL').get(id);
+    const existing = sqlite
+      .prepare('SELECT * FROM routine_logs WHERE id = ? AND deleted_at IS NULL')
+      .get(id);
     if (!existing) return c.json({ error: 'Log not found' }, 404);
     try {
       const body = await c.req.json();
@@ -1051,15 +1336,28 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         if (existingData === 'meal') {
           const mealData = typeof body.data === 'string' ? JSON.parse(body.data) : body.data;
           if (!mealData.items || !Array.isArray(mealData.items) || mealData.items.length === 0) {
-            return c.json({ error: 'Meal items required. Each meal must include an items array with individual food items and per-item macros.' }, 400);
+            return c.json(
+              {
+                error:
+                  'Meal items required. Each meal must include an items array with individual food items and per-item macros.',
+              },
+              400,
+            );
           }
           if (mealData.items && Array.isArray(mealData.items) && mealData.items.length > 0) {
             const macroFields = ['calories', 'protein', 'carbs', 'fat'] as const;
             for (const f of macroFields) {
-              mealData[f] = mealData.items.reduce((sum: number, item: any) => sum + (Number(item[f]) || 0), 0);
+              mealData[f] = mealData.items.reduce(
+                (sum: number, item: any) => sum + (Number(item[f]) || 0),
+                0,
+              );
             }
             if (!mealData.description) {
-              mealData.description = mealData.items.map((item: any) => item.name).slice(0, 3).join(', ') + (mealData.items.length > 3 ? '...' : '');
+              mealData.description =
+                mealData.items
+                  .map((item: any) => item.name)
+                  .slice(0, 3)
+                  .join(', ') + (mealData.items.length > 3 ? '...' : '');
             }
             body.data = mealData;
           }
@@ -1072,45 +1370,62 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
           if (!result.ok) return c.json({ error: result.error, hint: result.hint }, 400);
           body.data = result.data;
         }
-        updates.push('data = ?'); values.push(typeof body.data === 'string' ? body.data : JSON.stringify(body.data));
+        updates.push('data = ?');
+        values.push(typeof body.data === 'string' ? body.data : JSON.stringify(body.data));
       }
       if (body.logged_at) {
         let normalizedLoggedAt = body.logged_at;
         if (!body.logged_at.endsWith('Z') && !body.logged_at.includes('+')) {
           normalizedLoggedAt = body.logged_at + 'Z';
         }
-        updates.push('logged_at = ?'); values.push(normalizedLoggedAt);
+        updates.push('logged_at = ?');
+        values.push(normalizedLoggedAt);
       }
       if (updates.length === 0) return c.json({ error: 'No fields to update' }, 400);
       values.push(id);
       sqlite.prepare(`UPDATE routine_logs SET ${updates.join(', ')} WHERE id = ?`).run(...values);
       return c.json(sqlite.prepare('SELECT * FROM routine_logs WHERE id = ?').get(id));
-    } catch { return c.json({ error: 'Invalid request' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
   });
 
   // DELETE /api/routine/logs/:id — soft delete
   app.delete('/api/routine/logs/:id', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const id = parseInt(c.req.param('id'), 10);
-    const existing = sqlite.prepare('SELECT * FROM routine_logs WHERE id = ? AND deleted_at IS NULL').get(id);
+    const existing = sqlite
+      .prepare('SELECT * FROM routine_logs WHERE id = ? AND deleted_at IS NULL')
+      .get(id);
     if (!existing) return c.json({ error: 'Log not found' }, 404);
-    sqlite.prepare('UPDATE routine_logs SET deleted_at = ? WHERE id = ?').run(new Date().toISOString(), id);
+    sqlite
+      .prepare('UPDATE routine_logs SET deleted_at = ? WHERE id = ?')
+      .run(new Date().toISOString(), id);
     return c.json({ success: true, id });
   });
 
   // GET /api/routine/logs/deleted — list soft-deleted entries for recovery
   app.get('/api/routine/logs/deleted', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const limit = parseInt(c.req.query('limit') || '50');
-    const rows = sqlite.prepare('SELECT * FROM routine_logs WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC LIMIT ?').all(limit);
+    const rows = sqlite
+      .prepare(
+        'SELECT * FROM routine_logs WHERE deleted_at IS NOT NULL ORDER BY deleted_at DESC LIMIT ?',
+      )
+      .all(limit);
     return c.json({ logs: rows, total: (rows as any[]).length });
   });
 
   // PATCH /api/routine/logs/:id/restore — undelete a soft-deleted log
   app.patch('/api/routine/logs/:id/restore', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const id = parseInt(c.req.param('id'), 10);
-    const existing = sqlite.prepare('SELECT * FROM routine_logs WHERE id = ? AND deleted_at IS NOT NULL').get(id);
+    const existing = sqlite
+      .prepare('SELECT * FROM routine_logs WHERE id = ? AND deleted_at IS NOT NULL')
+      .get(id);
     if (!existing) return c.json({ error: 'Deleted log not found' }, 404);
     sqlite.prepare('UPDATE routine_logs SET deleted_at = NULL WHERE id = ?').run(id);
     return c.json({ success: true, id, restored: true });
@@ -1118,19 +1433,29 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // POST /api/routine/photo/upload — upload progress photo
   app.post('/api/routine/photo/upload', async (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     try {
       let formData: FormData;
-      try { formData = await c.req.formData(); } catch { return c.json({ error: 'No file provided. Send multipart/form-data with a file field.' }, 400); }
+      try {
+        formData = await c.req.formData();
+      } catch {
+        return c.json(
+          { error: 'No file provided. Send multipart/form-data with a file field.' },
+          400,
+        );
+      }
       const file = formData.get('file') as File;
-      const tag = formData.get('tag') as string || '';
-      const notes = formData.get('notes') as string || '';
-      if (!file || !(file instanceof File) || file.size === 0) return c.json({ error: 'No file provided' }, 400);
+      const tag = (formData.get('tag') as string) || '';
+      const notes = (formData.get('notes') as string) || '';
+      if (!file || !(file instanceof File) || file.size === 0)
+        return c.json({ error: 'No file provided' }, 400);
       if (file.size > 10 * 1024 * 1024) return c.json({ error: 'File too large. Max 10MB' }, 400);
 
       const buffer = Buffer.from(await file.arrayBuffer());
       const imageType = detectImageType(buffer);
-      if (!imageType) return c.json({ error: 'Invalid image. Only JPG, PNG, GIF, WebP allowed.' }, 400);
+      if (!imageType)
+        return c.json({ error: 'Invalid image. Only JPG, PNG, GIF, WebP allowed.' }, 400);
 
       // Process with sharp: EXIF rotation + keep date + strip GPS + resize
       let processedBuffer = buffer;
@@ -1148,7 +1473,9 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
             if (dateMatch) {
               captureDate = `${dateMatch[1]}-${dateMatch[2]}-${dateMatch[3]}T${dateMatch[4]}:${dateMatch[5]}:${dateMatch[6]}.000Z`;
             }
-          } catch { /* date extraction failed */ }
+          } catch {
+            /* date extraction failed */
+          }
         }
         processedBuffer = await sharp(buffer)
           .rotate()
@@ -1157,7 +1484,9 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
           .withMetadata({ orientation: undefined })
           .toBuffer();
         ext = '.jpg';
-      } catch { /* sharp not available */ }
+      } catch {
+        /* sharp not available */
+      }
 
       const filename = `${crypto.randomUUID()}${ext}`;
       fs.writeFileSync(path.join(ROUTINE_UPLOADS, filename), processedBuffer);
@@ -1165,29 +1494,51 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       // Create log entry — use EXIF capture date if available, otherwise now
       const now = new Date().toISOString();
       const loggedAt = captureDate || now;
-      const photoData = JSON.stringify({ url: `/api/routine/photo/${filename}`, tag, notes, captureDate: captureDate || undefined });
-      const result = sqlite.prepare(
-        'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)'
-      ).run('photo', loggedAt, photoData, 'manual', now);
-      const log = sqlite.prepare('SELECT * FROM routine_logs WHERE id = ?').get((result as any).lastInsertRowid);
+      const photoData = JSON.stringify({
+        url: `/api/routine/photo/${filename}`,
+        tag,
+        notes,
+        captureDate: captureDate || undefined,
+      });
+      const result = sqlite
+        .prepare(
+          'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)',
+        )
+        .run('photo', loggedAt, photoData, 'manual', now);
+      const log = sqlite
+        .prepare('SELECT * FROM routine_logs WHERE id = ?')
+        .get((result as any).lastInsertRowid);
       return c.json(log, 201);
-    } catch { return c.json({ error: 'Upload failed' }, 500); }
+    } catch {
+      return c.json({ error: 'Upload failed' }, 500);
+    }
   });
 
   // GET /api/routine/photo/:filename — serve routine photo
   app.get('/api/routine/photo/:filename', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge is private to Gorn and Sable' }, 403);
     const filename = c.req.param('filename').replace(/[^a-zA-Z0-9._-]/g, '');
     const filePath = path.join(ROUTINE_UPLOADS, filename);
     if (!fs.existsSync(filePath)) return c.json({ error: 'Not found' }, 404);
     const ext = path.extname(filename).toLowerCase();
-    const mime = ext === '.jpg' || ext === '.jpeg' ? 'image/jpeg' : ext === '.png' ? 'image/png' : ext === '.webp' ? 'image/webp' : 'image/jpeg';
-    return new Response(fs.readFileSync(filePath), { headers: { 'Content-Type': mime, 'Cache-Control': 'public, max-age=86400' } });
+    const mime =
+      ext === '.jpg' || ext === '.jpeg'
+        ? 'image/jpeg'
+        : ext === '.png'
+          ? 'image/png'
+          : ext === '.webp'
+            ? 'image/webp'
+            : 'image/jpeg';
+    return new Response(fs.readFileSync(filePath), {
+      headers: { 'Content-Type': mime, 'Cache-Control': 'public, max-age=86400' },
+    });
   });
 
   // POST /api/routine/import/alpha-progression — import Alpha Progression CSV (T#389)
   app.post('/api/routine/import/alpha-progression', async (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge access denied' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge access denied' }, 403);
 
     try {
       const formData = await c.req.formData();
@@ -1195,7 +1546,10 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       if (!file) return c.json({ error: 'No file provided' }, 400);
 
       const text = await file.text();
-      const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
+      const lines = text
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
 
       const sessions: any[] = [];
       let currentSession: any = null;
@@ -1206,7 +1560,7 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       for (const line of lines) {
         // Session header: "Workout Name";"date";"duration"
         if (line.startsWith('"') && line.includes('";"')) {
-          const parts = line.split('";').map(s => s.replace(/^"|"$/g, ''));
+          const parts = line.split('";').map((s) => s.replace(/^"|"$/g, ''));
           if (parts.length >= 3 && parts[1].match(/\d{4}-\d{2}-\d{2}/)) {
             if (currentSession) {
               if (currentExercise) currentSession.exercises.push(currentExercise);
@@ -1273,9 +1627,11 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
       // Check for existing imports in this date range (dedup)
       const existingDates = new Set<string>();
-      const existingRows = sqlite.prepare(
-        "SELECT logged_at FROM routine_logs WHERE type = 'workout' AND source = 'alpha-progression' AND deleted_at IS NULL"
-      ).all() as any[];
+      const existingRows = sqlite
+        .prepare(
+          "SELECT logged_at FROM routine_logs WHERE type = 'workout' AND source = 'alpha-progression' AND deleted_at IS NULL",
+        )
+        .all() as any[];
       for (const row of existingRows) existingDates.add(row.logged_at);
 
       // Filter out sessions that already exist (by date)
@@ -1292,12 +1648,19 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
           sessions: sessions.length,
           new_sessions: newSessions.length,
           duplicates: duplicateCount,
-          date_range: sessions.length > 0 ? {
-            from: sessions[sessions.length - 1].date,
-            to: sessions[0].date,
-          } : null,
+          date_range:
+            sessions.length > 0
+              ? {
+                  from: sessions[sessions.length - 1].date,
+                  to: sessions[0].date,
+                }
+              : null,
           total_exercises: newSessions.reduce((sum: number, s: any) => sum + s.exercises.length, 0),
-          total_sets: newSessions.reduce((sum: number, s: any) => sum + s.exercises.reduce((esum: number, e: any) => esum + e.sets.length, 0), 0),
+          total_sets: newSessions.reduce(
+            (sum: number, s: any) =>
+              sum + s.exercises.reduce((esum: number, e: any) => esum + e.sets.length, 0),
+            0,
+          ),
           sample: newSessions.slice(0, 3),
         });
       }
@@ -1305,7 +1668,7 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       // Import: insert only new sessions
       const now = new Date().toISOString();
       const insert = sqlite.prepare(
-        'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)'
+        'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)',
       );
       let imported = 0;
       for (const session of newSessions) {
@@ -1322,12 +1685,19 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       return c.json({
         imported,
         duplicates: duplicateCount,
-        date_range: newSessions.length > 0 ? {
-          from: newSessions[newSessions.length - 1].date,
-          to: newSessions[0].date,
-        } : null,
+        date_range:
+          newSessions.length > 0
+            ? {
+                from: newSessions[newSessions.length - 1].date,
+                to: newSessions[0].date,
+              }
+            : null,
         total_exercises: newSessions.reduce((sum: number, s: any) => sum + s.exercises.length, 0),
-        total_sets: newSessions.reduce((sum: number, s: any) => sum + s.exercises.reduce((esum: number, e: any) => esum + e.sets.length, 0), 0),
+        total_sets: newSessions.reduce(
+          (sum: number, s: any) =>
+            sum + s.exercises.reduce((esum: number, e: any) => esum + e.sets.length, 0),
+          0,
+        ),
       });
     } catch (error) {
       return c.json({ error: error instanceof Error ? error.message : 'Import failed' }, 500);
@@ -1336,7 +1706,8 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // POST /api/routine/import/alpha-measurements — import Alpha Progression Measurements CSV (T#392)
   app.post('/api/routine/import/alpha-measurements', async (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge access denied' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge access denied' }, 403);
 
     try {
       const formData = await c.req.formData();
@@ -1344,7 +1715,10 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       if (!file) return c.json({ error: 'No file provided' }, 400);
 
       const text = await file.text();
-      const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
+      const lines = text
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
 
       const entries: { type: string; date: string; value: number; unit: string }[] = [];
       let currentType = '';
@@ -1378,23 +1752,25 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
       // Dedup: check existing entries
       const existingDates = new Map<string, Set<string>>();
-      const existingRows = sqlite.prepare(
-        "SELECT type, logged_at FROM routine_logs WHERE type IN ('weight', 'bodyfat') AND source = 'alpha-progression' AND deleted_at IS NULL"
-      ).all() as any[];
+      const existingRows = sqlite
+        .prepare(
+          "SELECT type, logged_at FROM routine_logs WHERE type IN ('weight', 'bodyfat') AND source = 'alpha-progression' AND deleted_at IS NULL",
+        )
+        .all() as any[];
       for (const row of existingRows) {
         if (!existingDates.has(row.type)) existingDates.set(row.type, new Set());
         existingDates.get(row.type)!.add(row.logged_at);
       }
 
-      const newEntries = entries.filter(e => {
+      const newEntries = entries.filter((e) => {
         const loggedAt = new Date(e.date).toISOString();
         return !existingDates.get(e.type)?.has(loggedAt);
       });
       const duplicateCount = entries.length - newEntries.length;
 
       const preview = c.req.query('preview') === 'true';
-      const bodyfatCount = newEntries.filter(e => e.type === 'bodyfat').length;
-      const weightCount = newEntries.filter(e => e.type === 'weight').length;
+      const bodyfatCount = newEntries.filter((e) => e.type === 'bodyfat').length;
+      const weightCount = newEntries.filter((e) => e.type === 'weight').length;
 
       if (preview) {
         return c.json({
@@ -1403,17 +1779,20 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
           duplicates: duplicateCount,
           bodyfat: bodyfatCount,
           weight: weightCount,
-          date_range: entries.length > 0 ? {
-            from: entries[entries.length - 1].date,
-            to: entries[0].date,
-          } : null,
+          date_range:
+            entries.length > 0
+              ? {
+                  from: entries[entries.length - 1].date,
+                  to: entries[0].date,
+                }
+              : null,
         });
       }
 
       // Import
       const now = new Date().toISOString();
       const insert = sqlite.prepare(
-        'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)'
+        'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)',
       );
       let imported = 0;
       for (const entry of newEntries) {
@@ -1422,11 +1801,22 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
           value: entry.value,
           unit: entry.unit === '%' ? '%' : 'kg',
         });
-        insert.run(entry.type === 'weight' ? 'weight' : 'bodyfat', loggedAt, data, 'alpha-progression', now);
+        insert.run(
+          entry.type === 'weight' ? 'weight' : 'bodyfat',
+          loggedAt,
+          data,
+          'alpha-progression',
+          now,
+        );
         imported++;
       }
 
-      return c.json({ imported, duplicates: duplicateCount, bodyfat: bodyfatCount, weight: weightCount });
+      return c.json({
+        imported,
+        duplicates: duplicateCount,
+        bodyfat: bodyfatCount,
+        weight: weightCount,
+      });
     } catch (error) {
       return c.json({ error: error instanceof Error ? error.message : 'Import failed' }, 500);
     }
@@ -1437,7 +1827,8 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // Query: ?days=7 (default window, max 90).
   // Dedupes on hevy workout id stored in data.hevy_id.
   app.post('/api/routine/hevy/sync', async (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge access denied' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge access denied' }, 403);
 
     const token = process.env.HEVY_API_TOKEN;
     if (!token) return c.json({ error: 'HEVY_API_TOKEN not configured on server' }, 500);
@@ -1453,16 +1844,22 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       const pageSize = 10;
       while (true) {
         const url = `https://api.hevyapp.com/v1/workouts?page=${page}&pageSize=${pageSize}`;
-        const resp = await fetch(url, { headers: { 'api-key': token, 'accept': 'application/json' } });
-        if (!resp.ok) return c.json({ error: `Hevy API ${resp.status}: ${await resp.text()}` }, 502);
-        const body = await resp.json() as any;
+        const resp = await fetch(url, {
+          headers: { 'api-key': token, accept: 'application/json' },
+        });
+        if (!resp.ok)
+          return c.json({ error: `Hevy API ${resp.status}: ${await resp.text()}` }, 502);
+        const body = (await resp.json()) as any;
         const workouts = body.workouts || [];
         if (workouts.length === 0) break;
 
         let hitOld = false;
         for (const w of workouts) {
           const startMs = new Date(w.start_time).getTime();
-          if (startMs < sinceMs) { hitOld = true; continue; }
+          if (startMs < sinceMs) {
+            hitOld = true;
+            continue;
+          }
           fetched.push(w);
         }
         if (hitOld || page >= (body.page_count || 1) || page >= 10) break;
@@ -1471,25 +1868,32 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
       // Existing hevy-source workouts — dedupe set on hevy_id.
       const existingIds = new Set<string>();
-      const existingRows = sqlite.prepare(
-        "SELECT data FROM routine_logs WHERE type = 'workout' AND source = 'hevy' AND deleted_at IS NULL"
-      ).all() as any[];
+      const existingRows = sqlite
+        .prepare(
+          "SELECT data FROM routine_logs WHERE type = 'workout' AND source = 'hevy' AND deleted_at IS NULL",
+        )
+        .all() as any[];
       for (const row of existingRows) {
         try {
           const d = typeof row.data === 'string' ? JSON.parse(row.data) : row.data;
           if (d?.hevy_id) existingIds.add(d.hevy_id);
-        } catch { /* skip malformed */ }
+        } catch {
+          /* skip malformed */
+        }
       }
 
       const insert = sqlite.prepare(
-        'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)'
+        'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)',
       );
       let inserted = 0;
       let skipped = 0;
       const nowIso = new Date().toISOString();
 
       for (const w of fetched) {
-        if (existingIds.has(w.id)) { skipped++; continue; }
+        if (existingIds.has(w.id)) {
+          skipped++;
+          continue;
+        }
 
         // Map Hevy → Forge workout shape.
         const startMs = new Date(w.start_time).getTime();
@@ -1523,7 +1927,9 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
                 if (t === 'normal' || t === 'warmup' || t === 'dropset' || t === 'failure') {
                   set.type = t;
                 } else {
-                  console.warn(`[hevy-sync T#711] dropping unknown set.type="${s.type}" on workout ${w.id} exercise ${idx + 1} set ${sIdx + 1}`);
+                  console.warn(
+                    `[hevy-sync T#711] dropping unknown set.type="${s.type}" on workout ${w.id} exercise ${idx + 1} set ${sIdx + 1}`,
+                  );
                 }
               }
               return set;
@@ -1595,7 +2001,7 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // Parse body
     let workoutId: string;
     try {
-      const body = await c.req.json() as any;
+      const body = (await c.req.json()) as any;
       workoutId = String(body.workoutId || '');
       if (!workoutId) {
         console.warn('[Hevy webhook] missing workoutId in body');
@@ -1616,7 +2022,7 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     console.log(`[Hevy webhook] received workoutId=${workoutId}`);
 
     // Async sync — respond 200 immediately, fetch + insert in background
-    syncSingleHevyWorkout(workoutId).catch(err => {
+    syncSingleHevyWorkout(workoutId).catch((err) => {
       console.error(`[Hevy webhook] async sync failed for ${workoutId}:`, err);
     });
 
@@ -1634,27 +2040,35 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   async function syncSingleHevyWorkout(workoutId: string): Promise<void> {
     const apiToken = process.env.HEVY_API_TOKEN;
     if (!apiToken) {
-      console.error(`[Hevy webhook sync] HEVY_API_TOKEN not configured — cannot fetch ${workoutId}`);
+      console.error(
+        `[Hevy webhook sync] HEVY_API_TOKEN not configured — cannot fetch ${workoutId}`,
+      );
       return;
     }
 
     // Check dedupe first — same workoutId webhook re-fires are no-op
-    const existing = sqlite.prepare(
-      "SELECT id FROM routine_logs WHERE type = 'workout' AND source = 'hevy' AND deleted_at IS NULL AND json_extract(data, '$.hevy_id') = ? LIMIT 1"
-    ).get(workoutId) as any;
+    const existing = sqlite
+      .prepare(
+        "SELECT id FROM routine_logs WHERE type = 'workout' AND source = 'hevy' AND deleted_at IS NULL AND json_extract(data, '$.hevy_id') = ? LIMIT 1",
+      )
+      .get(workoutId) as any;
     if (existing) {
-      console.log(`[Hevy webhook sync] workoutId=${workoutId} already exists as routine_log id=${existing.id}, skipping`);
+      console.log(
+        `[Hevy webhook sync] workoutId=${workoutId} already exists as routine_log id=${existing.id}, skipping`,
+      );
       return;
     }
 
     // Fetch the workout from Hevy
     const url = `https://api.hevyapp.com/v1/workouts/${workoutId}`;
-    const resp = await fetch(url, { headers: { 'api-key': apiToken, 'accept': 'application/json' } });
+    const resp = await fetch(url, { headers: { 'api-key': apiToken, accept: 'application/json' } });
     if (!resp.ok) {
-      console.error(`[Hevy webhook sync] Hevy API ${resp.status} for ${workoutId}: ${await resp.text()}`);
+      console.error(
+        `[Hevy webhook sync] Hevy API ${resp.status} for ${workoutId}: ${await resp.text()}`,
+      );
       return;
     }
-    const w = await resp.json() as any;
+    const w = (await resp.json()) as any;
     // Hevy single-workout endpoint may wrap in { workout: ... } — handle both shapes
     const workout = w.workout || w;
     if (!workout || !workout.id) {
@@ -1689,7 +2103,9 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
             if (t === 'normal' || t === 'warmup' || t === 'dropset' || t === 'failure') {
               set.type = t;
             } else {
-              console.warn(`[hevy-webhook T#711] dropping unknown set.type="${s.type}" on workout ${workout.id} exercise ${idx + 1} set ${sIdx + 1}`);
+              console.warn(
+                `[hevy-webhook T#711] dropping unknown set.type="${s.type}" on workout ${workout.id} exercise ${idx + 1} set ${sIdx + 1}`,
+              );
             }
           }
           return set;
@@ -1711,14 +2127,26 @@ export function registerForgeRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       duration,
       exercises,
       hevy_id: workout.id,
-      notes: typeof workout.description === 'string' && workout.description.trim() ? workout.description : undefined,
+      notes:
+        typeof workout.description === 'string' && workout.description.trim()
+          ? workout.description
+          : undefined,
     };
 
-    sqlite.prepare(
-      'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)'
-    ).run('workout', new Date(workout.start_time).toISOString(), JSON.stringify(data), 'hevy', new Date().toISOString());
+    sqlite
+      .prepare(
+        'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)',
+      )
+      .run(
+        'workout',
+        new Date(workout.start_time).toISOString(),
+        JSON.stringify(data),
+        'hevy',
+        new Date().toISOString(),
+      );
 
-    console.log(`[Hevy webhook sync] inserted workoutId=${workoutId} title="${data.title}" exercises=${exercises.length}`);
+    console.log(
+      `[Hevy webhook sync] inserted workoutId=${workoutId} title="${data.title}" exercises=${exercises.length}`,
+    );
   }
-
 }

--- a/src/forum/handler.ts
+++ b/src/forum/handler.ts
@@ -40,18 +40,22 @@ function getProjectContext_(): string | undefined {
 export function createThread(
   title: string,
   createdBy: string = 'user',
-  project?: string
+  project?: string,
 ): ForumThread {
   const now = Date.now();
 
-  const result = db.insert(forumThreads).values({
-    title,
-    createdBy,
-    status: 'active',
-    project: project || null,
-    createdAt: now,
-    updatedAt: now,
-  }).returning({ id: forumThreads.id }).get();
+  const result = db
+    .insert(forumThreads)
+    .values({
+      title,
+      createdBy,
+      status: 'active',
+      project: project || null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: forumThreads.id })
+    .get();
 
   return {
     id: result.id,
@@ -68,10 +72,7 @@ export function createThread(
  * Get thread by ID
  */
 export function getThread(threadId: number): ForumThread | null {
-  const row = db.select()
-    .from(forumThreads)
-    .where(eq(forumThreads.id, threadId))
-    .get();
+  const row = db.select().from(forumThreads).where(eq(forumThreads.id, threadId)).get();
 
   if (!row) return null;
 
@@ -102,12 +103,9 @@ export function updateThreadStatus(threadId: number, status: ThreadStatus): void
 /**
  * List threads with optional filters
  */
-export function listThreads(options: {
-  status?: ThreadStatus;
-  project?: string;
-  limit?: number;
-  offset?: number;
-} = {}): { threads: ForumThread[]; total: number } {
+export function listThreads(
+  options: { status?: ThreadStatus; project?: string; limit?: number; offset?: number } = {},
+): { threads: ForumThread[]; total: number } {
   const { status, project, limit = 20, offset = 0 } = options;
 
   // Build conditions array
@@ -122,14 +120,16 @@ export function listThreads(options: {
   const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
   // Get count
-  const countResult = db.select({ count: sql<number>`count(*)` })
+  const countResult = db
+    .select({ count: sql<number>`count(*)` })
     .from(forumThreads)
     .where(whereClause)
     .get();
   const total = countResult?.count || 0;
 
   // Get threads
-  const rows = db.select()
+  const rows = db
+    .select()
     .from(forumThreads)
     .where(whereClause)
     .orderBy(desc(forumThreads.updatedAt))
@@ -138,7 +138,7 @@ export function listThreads(options: {
     .all();
 
   return {
-    threads: rows.map(row => ({
+    threads: rows.map((row) => ({
       id: row.id,
       title: row.title,
       createdBy: row.createdBy || 'unknown',
@@ -170,26 +170,27 @@ export function addMessage(
     principlesFound?: number;
     patternsFound?: number;
     searchQuery?: string;
-  } = {}
+  } = {},
 ): ForumMessage {
   const now = Date.now();
 
-  const result = db.insert(forumMessages).values({
-    threadId,
-    role,
-    content,
-    author: options.author || null,
-    principlesFound: options.principlesFound || null,
-    patternsFound: options.patternsFound || null,
-    searchQuery: options.searchQuery || null,
-    createdAt: now,
-  }).returning({ id: forumMessages.id }).get();
+  const result = db
+    .insert(forumMessages)
+    .values({
+      threadId,
+      role,
+      content,
+      author: options.author || null,
+      principlesFound: options.principlesFound || null,
+      patternsFound: options.patternsFound || null,
+      searchQuery: options.searchQuery || null,
+      createdAt: now,
+    })
+    .returning({ id: forumMessages.id })
+    .get();
 
   // Update thread timestamp
-  db.update(forumThreads)
-    .set({ updatedAt: now })
-    .where(eq(forumThreads.id, threadId))
-    .run();
+  db.update(forumThreads).set({ updatedAt: now }).where(eq(forumThreads.id, threadId)).run();
 
   return {
     id: result.id,
@@ -214,14 +215,16 @@ export function getMessages(
   order: 'asc' | 'desc' = 'asc',
 ): { messages: ForumMessage[]; total: number } {
   const notDeleted = sql`deleted_at IS NULL`;
-  const countResult = db.select({ count: sql<number>`count(*)` })
+  const countResult = db
+    .select({ count: sql<number>`count(*)` })
     .from(forumMessages)
     .where(and(eq(forumMessages.threadId, threadId), notDeleted))
     .get();
 
   const total = countResult?.count ?? 0;
 
-  let query = db.select()
+  let query = db
+    .select()
     .from(forumMessages)
     .where(and(eq(forumMessages.threadId, threadId), notDeleted))
     .orderBy(order === 'desc' ? desc(forumMessages.createdAt) : forumMessages.createdAt);
@@ -232,7 +235,7 @@ export function getMessages(
 
   const rows = query.all();
 
-  const messages = rows.map(row => ({
+  const messages = rows.map((row) => ({
     id: row.id,
     threadId: row.threadId,
     role: row.role as MessageRole,
@@ -255,9 +258,7 @@ export function getMessages(
 /**
  * Main entry point: Send message to thread, Oracle auto-responds
  */
-export async function handleThreadMessage(
-  input: OracleThreadInput
-): Promise<OracleThreadOutput> {
+export async function handleThreadMessage(input: OracleThreadInput): Promise<OracleThreadOutput> {
   const { message, threadId, title, role = 'human', model, author: authorOverride } = input;
 
   // Get project context
@@ -310,13 +311,29 @@ export async function handleThreadMessage(
   // T#618: Auto-subscribe author and @mentioned Beasts (only if no existing preference)
   const senderName = author?.split('@')[0]?.toLowerCase() || '';
   if (senderName) {
-    try { autoSubscribe(senderName, thread.id); } catch { /* ignore */ }
+    try {
+      autoSubscribe(senderName, thread.id);
+    } catch {
+      /* ignore */
+    }
   }
   for (const m of mentions) {
-    try { autoSubscribe(m, thread.id); } catch { /* ignore */ }
+    try {
+      autoSubscribe(m, thread.id);
+    } catch {
+      /* ignore */
+    }
   }
 
-  const notified = notifyMentioned(mentions, thread.id, thread.title, author, message, undefined, directMentionSet);
+  const notified = notifyMentioned(
+    mentions,
+    thread.id,
+    thread.title,
+    author,
+    message,
+    undefined,
+    directMentionSet,
+  );
 
   // Notify all thread participants on new posts (not just @mentioned ones)
   // T#618: Participants are filtered by subscription level in notifyMentioned
@@ -325,7 +342,8 @@ export async function handleThreadMessage(
     const registry = getOracleRegistry();
     const alreadyNotified = new Set(notified);
     try {
-      const rows = db.select({ author: forumMessages.author })
+      const rows = db
+        .select({ author: forumMessages.author })
         .from(forumMessages)
         .where(eq(forumMessages.threadId, thread.id))
         .all();
@@ -333,17 +351,36 @@ export async function handleThreadMessage(
       const participants: string[] = [];
       for (const r of rows) {
         const name = r.author?.split('@')[0]?.toLowerCase();
-        if (name && name in registry && name !== 'gorn' && name !== 'human' && name !== 'user' && name !== senderName && !alreadyNotified.has(name) && !seen.has(name)) {
+        if (
+          name &&
+          name in registry &&
+          name !== 'gorn' &&
+          name !== 'human' &&
+          name !== 'user' &&
+          name !== senderName &&
+          !alreadyNotified.has(name) &&
+          !seen.has(name)
+        ) {
           seen.add(name);
           participants.push(name);
         }
       }
       if (participants.length > 0) {
         // These are thread participants, NOT direct mentions — subscription filter applies
-        const extra = notifyMentioned(participants, thread.id, thread.title, author || 'unknown', message, undefined, new Set());
+        const extra = notifyMentioned(
+          participants,
+          thread.id,
+          thread.title,
+          author || 'unknown',
+          message,
+          undefined,
+          new Set(),
+        );
         notified.push(...extra);
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   // Get updated thread status

--- a/src/forum/mentions.ts
+++ b/src/forum/mentions.ts
@@ -14,21 +14,21 @@ import { enqueueNotification } from '../notify.ts';
 // ============================================================================
 
 export interface OracleEntry {
-  tmux: string;       // tmux session name (capitalized)
-  workspace: string;  // workspace path
+  tmux: string; // tmux session name (capitalized)
+  workspace: string; // workspace path
 }
 
 export type OracleRegistry = Record<string, OracleEntry>;
 
 const DEFAULT_REGISTRY: OracleRegistry = {
   zaghnal: { tmux: 'Zaghnal', workspace: '/home/gorn/workspace/gorn-oracle' },
-  karo:    { tmux: 'Karo',    workspace: '/home/gorn/workspace/karo' },
-  gnarl:   { tmux: 'Gnarl',   workspace: '/home/gorn/workspace/gnarl' },
-  bertus:  { tmux: 'Bertus',  workspace: '/home/gorn/workspace/bertus' },
-  mara:    { tmux: 'Mara',    workspace: '/home/gorn/workspace/mara' },
+  karo: { tmux: 'Karo', workspace: '/home/gorn/workspace/karo' },
+  gnarl: { tmux: 'Gnarl', workspace: '/home/gorn/workspace/gnarl' },
+  bertus: { tmux: 'Bertus', workspace: '/home/gorn/workspace/bertus' },
+  mara: { tmux: 'Mara', workspace: '/home/gorn/workspace/mara' },
   leonard: { tmux: 'Leonard', workspace: '/home/gorn/workspace/leonard' },
-  rax:     { tmux: 'Rax',     workspace: '/home/gorn/workspace/rax' },
-  pip:     { tmux: 'Pip',     workspace: '/home/gorn/workspace/pip' },
+  rax: { tmux: 'Rax', workspace: '/home/gorn/workspace/rax' },
+  pip: { tmux: 'Pip', workspace: '/home/gorn/workspace/pip' },
 };
 
 let registryCache: OracleRegistry | null = null;
@@ -42,7 +42,7 @@ const CACHE_TTL_MS = 30_000; // Refresh from DB every 30s
  */
 export function getOracleRegistry(): OracleRegistry {
   const now = Date.now();
-  if (registryCache && (now - registryCacheTime) < CACHE_TTL_MS) return registryCache;
+  if (registryCache && now - registryCacheTime < CACHE_TTL_MS) return registryCache;
 
   // Build from beast_profiles (single source of truth)
   try {
@@ -51,18 +51,19 @@ export function getOracleRegistry(): OracleRegistry {
       const registry: OracleRegistry = {};
       for (const b of beasts) {
         const name = b.name.toLowerCase();
-        const displayName = b.display_name || (name.charAt(0).toUpperCase() + name.slice(1));
+        const displayName = b.display_name || name.charAt(0).toUpperCase() + name.slice(1);
         // Special case: zaghnal's workspace is gorn-oracle (legacy)
-        const workspace = name === 'zaghnal'
-          ? '/home/gorn/workspace/gorn-oracle'
-          : `/home/gorn/workspace/${name}`;
+        const workspace =
+          name === 'zaghnal' ? '/home/gorn/workspace/gorn-oracle' : `/home/gorn/workspace/${name}`;
         registry[name] = { tmux: displayName, workspace };
       }
       registryCache = registry;
       registryCacheTime = now;
       return registry;
     }
-  } catch { /* beast_profiles table may not exist yet */ }
+  } catch {
+    /* beast_profiles table may not exist yet */
+  }
 
   // Fallback to hardcoded defaults
   registryCache = DEFAULT_REGISTRY;
@@ -109,14 +110,22 @@ export function parseMentions(content: string, threadId?: number): string[] {
       // Check if it's a team name (e.g. @real-broker → all team members)
       try {
         const teamName = name.replace(/-/g, ' ');
-        const team = sqlite.prepare('SELECT id FROM teams WHERE LOWER(name) = ? OR LOWER(REPLACE(name, \' \', \'-\')) = ?').get(teamName, name) as any;
+        const team = sqlite
+          .prepare(
+            "SELECT id FROM teams WHERE LOWER(name) = ? OR LOWER(REPLACE(name, ' ', '-')) = ?",
+          )
+          .get(teamName, name) as any;
         if (team) {
-          const members = sqlite.prepare('SELECT beast FROM team_members WHERE team_id = ?').all(team.id) as any[];
+          const members = sqlite
+            .prepare('SELECT beast FROM team_members WHERE team_id = ?')
+            .all(team.id) as any[];
           for (const m of members) {
             if (m.beast in registry) names.add(m.beast);
           }
         }
-      } catch { /* teams table may not exist yet */ }
+      } catch {
+        /* teams table may not exist yet */
+      }
     }
   }
 
@@ -127,16 +136,20 @@ export function parseMentions(content: string, threadId?: number): string[] {
   if (hasHere && threadId) {
     // Get all unique authors who participated in this thread
     try {
-      const rows = sqlite.prepare(
-        'SELECT DISTINCT author FROM forum_messages WHERE thread_id = ? AND author IS NOT NULL'
-      ).all(threadId) as any[];
+      const rows = sqlite
+        .prepare(
+          'SELECT DISTINCT author FROM forum_messages WHERE thread_id = ? AND author IS NOT NULL',
+        )
+        .all(threadId) as any[];
       for (const r of rows) {
         const authorName = r.author?.split('@')[0]?.toLowerCase();
         if (authorName && authorName in registry) {
           names.add(authorName);
         }
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   return [...names];
@@ -154,13 +167,15 @@ export type SubscriptionLevel = 'full' | 'summary' | 'muted';
  */
 export function getSubscriptionLevel(beast: string, threadId: number): SubscriptionLevel {
   try {
-    const row = sqlite.prepare(
-      'SELECT level FROM forum_notification_prefs WHERE beast_name = ? AND thread_id = ?'
-    ).get(beast.toLowerCase(), threadId) as { level: string } | undefined;
+    const row = sqlite
+      .prepare('SELECT level FROM forum_notification_prefs WHERE beast_name = ? AND thread_id = ?')
+      .get(beast.toLowerCase(), threadId) as { level: string } | undefined;
     if (row && (row.level === 'full' || row.level === 'summary' || row.level === 'muted')) {
       return row.level;
     }
-  } catch { /* table may not have level column yet */ }
+  } catch {
+    /* table may not have level column yet */
+  }
   return 'full';
 }
 
@@ -169,14 +184,16 @@ export function getSubscriptionLevel(beast: string, threadId: number): Subscript
  */
 export function setSubscription(beast: string, threadId: number, level: SubscriptionLevel): void {
   const now = Date.now();
-  sqlite.prepare(`
+  sqlite
+    .prepare(`
     INSERT INTO forum_notification_prefs (beast_name, thread_id, muted, level, updated_at)
     VALUES (?, ?, ?, ?, ?)
     ON CONFLICT(beast_name, thread_id) DO UPDATE SET
       level = excluded.level,
       muted = CASE WHEN excluded.level = 'muted' THEN 1 ELSE 0 END,
       updated_at = excluded.updated_at
-  `).run(beast.toLowerCase(), threadId, level === 'muted' ? 1 : 0, level, now);
+  `)
+    .run(beast.toLowerCase(), threadId, level === 'muted' ? 1 : 0, level, now);
 }
 
 /**
@@ -185,41 +202,51 @@ export function setSubscription(beast: string, threadId: number, level: Subscrip
  */
 export function autoSubscribe(beast: string, threadId: number): void {
   const now = Date.now();
-  sqlite.prepare(`
+  sqlite
+    .prepare(`
     INSERT INTO forum_notification_prefs (beast_name, thread_id, muted, level, updated_at)
     VALUES (?, ?, 0, 'full', ?)
     ON CONFLICT(beast_name, thread_id) DO NOTHING
-  `).run(beast.toLowerCase(), threadId, now);
+  `)
+    .run(beast.toLowerCase(), threadId, now);
 }
 
 /**
  * Get all subscriptions for a Beast.
  */
-export function getSubscriptions(beast: string): Array<{ thread_id: number; level: SubscriptionLevel }> {
+export function getSubscriptions(
+  beast: string,
+): Array<{ thread_id: number; level: SubscriptionLevel }> {
   try {
-    const rows = sqlite.prepare(
-      'SELECT thread_id, level FROM forum_notification_prefs WHERE beast_name = ?'
-    ).all(beast.toLowerCase()) as any[];
-    return rows.map(r => ({
+    const rows = sqlite
+      .prepare('SELECT thread_id, level FROM forum_notification_prefs WHERE beast_name = ?')
+      .all(beast.toLowerCase()) as any[];
+    return rows.map((r) => ({
       thread_id: r.thread_id,
-      level: (r.level === 'full' || r.level === 'summary' || r.level === 'muted') ? r.level : 'full',
+      level: r.level === 'full' || r.level === 'summary' || r.level === 'muted' ? r.level : 'full',
     }));
-  } catch { return []; }
+  } catch {
+    return [];
+  }
 }
 
 /**
  * Get all subscribers for a thread (T#621).
  */
-export function getThreadSubscribers(threadId: number): Array<{ beast_name: string; level: SubscriptionLevel }> {
+export function getThreadSubscribers(
+  threadId: number,
+): Array<{ beast_name: string; level: SubscriptionLevel }> {
   try {
-    const rows = sqlite.prepare(
-      'SELECT beast_name, level FROM forum_notification_prefs WHERE thread_id = ?'
-    ).all(threadId) as any[];
-    return rows.map(r => ({
+    const rows = sqlite
+      .prepare('SELECT beast_name, level FROM forum_notification_prefs WHERE thread_id = ?')
+      .all(threadId) as any[];
+    return rows.map((r) => ({
       beast_name: r.beast_name,
-      level: (r.level === 'full' || r.level === 'summary' || r.level === 'muted') ? r.level : 'full',
+      level: r.level === 'full' || r.level === 'summary' || r.level === 'muted' ? r.level : 'full',
     }));
-  } catch { return []; }
+  } catch {
+    return [];
+  }
 }
 
 // ============================================================================
@@ -231,11 +258,7 @@ export function getThreadSubscribers(threadId: number): Array<{ beast_name: stri
  * Strips newlines, escapes quotes, truncates.
  */
 function sanitizeForTmux(text: string, maxLen: number = 200): string {
-  return text
-    .replace(/\n/g, ' ')
-    .replace(/"/g, "'")
-    .replace(/\\/g, '\\\\')
-    .slice(0, maxLen);
+  return text.replace(/\n/g, ' ').replace(/"/g, "'").replace(/\\/g, '\\\\').slice(0, maxLen);
 }
 
 /**

--- a/src/forum/responder.ts
+++ b/src/forum/responder.ts
@@ -22,27 +22,50 @@ function getOracles(): Record<string, { workspace: string; memoryDir: string }> 
       const map: Record<string, { workspace: string; memoryDir: string }> = {};
       for (const b of beasts) {
         const name = b.name.toLowerCase();
-        const workspace = name === 'zaghnal'
-          ? '/home/gorn/workspace/gorn-oracle'
-          : `/home/gorn/workspace/${name}`;
-        const memoryDir = name === 'zaghnal'
-          ? '/home/gorn/.claude/projects/-home-gorn-workspace-gorn-oracle/memory'
-          : `/home/gorn/.claude/projects/-home-gorn-workspace-${name}/memory`;
+        const workspace =
+          name === 'zaghnal' ? '/home/gorn/workspace/gorn-oracle' : `/home/gorn/workspace/${name}`;
+        const memoryDir =
+          name === 'zaghnal'
+            ? '/home/gorn/.claude/projects/-home-gorn-workspace-gorn-oracle/memory'
+            : `/home/gorn/.claude/projects/-home-gorn-workspace-${name}/memory`;
         map[name] = { workspace, memoryDir };
       }
       return map;
     }
-  } catch { /* beast_profiles may not exist */ }
+  } catch {
+    /* beast_profiles may not exist */
+  }
 
   // Fallback
   return {
-    karo:    { workspace: '/home/gorn/workspace/karo',        memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-karo/memory' },
-    zaghnal: { workspace: '/home/gorn/workspace/gorn-oracle', memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-gorn-oracle/memory' },
-    gnarl:   { workspace: '/home/gorn/workspace/gnarl',       memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-gnarl/memory' },
-    bertus:  { workspace: '/home/gorn/workspace/bertus',      memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-bertus/memory' },
-    leonard: { workspace: '/home/gorn/workspace/leonard',     memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-leonard/memory' },
-    mara:    { workspace: '/home/gorn/workspace/mara',        memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-mara/memory' },
-    rax:     { workspace: '/home/gorn/workspace/rax',         memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-rax/memory' },
+    karo: {
+      workspace: '/home/gorn/workspace/karo',
+      memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-karo/memory',
+    },
+    zaghnal: {
+      workspace: '/home/gorn/workspace/gorn-oracle',
+      memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-gorn-oracle/memory',
+    },
+    gnarl: {
+      workspace: '/home/gorn/workspace/gnarl',
+      memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-gnarl/memory',
+    },
+    bertus: {
+      workspace: '/home/gorn/workspace/bertus',
+      memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-bertus/memory',
+    },
+    leonard: {
+      workspace: '/home/gorn/workspace/leonard',
+      memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-leonard/memory',
+    },
+    mara: {
+      workspace: '/home/gorn/workspace/mara',
+      memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-mara/memory',
+    },
+    rax: {
+      workspace: '/home/gorn/workspace/rax',
+      memoryDir: '/home/gorn/.claude/projects/-home-gorn-workspace-rax/memory',
+    },
   };
 }
 
@@ -65,7 +88,7 @@ function findTmuxPane(oracle: string): string | null {
     // List all tmux panes with their PID, command, and path
     const output = execSync(
       `tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index} #{pane_pid} #{pane_current_command} #{pane_current_path}" 2>/dev/null || true`,
-      { encoding: 'utf-8', timeout: 5000 }
+      { encoding: 'utf-8', timeout: 5000 },
     ).trim();
 
     if (!output) return null;
@@ -85,14 +108,18 @@ function findTmuxPane(oracle: string): string | null {
 
       // Indirect match: pane is bash/zsh but has a claude child process
       try {
-        const children = execSync(
-          `pgrep -P ${panePid} -a 2>/dev/null || true`,
-          { encoding: 'utf-8', timeout: 3000 }
-        ).trim();
+        const children = execSync(`pgrep -P ${panePid} -a 2>/dev/null || true`, {
+          encoding: 'utf-8',
+          timeout: 3000,
+        }).trim();
         if (children.includes('claude')) return pane;
-      } catch { /* skip */ }
+      } catch {
+        /* skip */
+      }
     }
-  } catch { /* skip */ }
+  } catch {
+    /* skip */
+  }
 
   return null;
 }
@@ -101,7 +128,14 @@ function findTmuxPane(oracle: string): string | null {
  * Inject a message into a live Claude Code session via tmux send-keys.
  * The message becomes user input in the session.
  */
-function sendToLiveSession(pane: string, oracle: string, threadId: number, title: string, senderName: string, message: string): boolean {
+function sendToLiveSession(
+  pane: string,
+  oracle: string,
+  threadId: number,
+  title: string,
+  senderName: string,
+  message: string,
+): boolean {
   const preview = message.length > 300 ? message.slice(0, 300) + '...' : message;
 
   // Craft the injected prompt — the Oracle will process this as a user message
@@ -114,7 +148,10 @@ function sendToLiveSession(pane: string, oracle: string, threadId: number, title
     }
     return success;
   } catch (err) {
-    console.error(`[notify] Failed to queue for ${oracle}:`, err instanceof Error ? err.message : err);
+    console.error(
+      `[notify] Failed to queue for ${oracle}:`,
+      err instanceof Error ? err.message : err,
+    );
     return false;
   }
 }
@@ -156,18 +193,26 @@ function extractOracleFromAuthor(author: string): string | null {
 /**
  * Build prompt context from thread messages.
  */
-function buildPrompt(oracle: string, title: string, messages: ForumMessage[], turnNumber: number): string {
+function buildPrompt(
+  oracle: string,
+  title: string,
+  messages: ForumMessage[],
+  turnNumber: number,
+): string {
   const recentMessages = messages.slice(-15); // Last 15 messages for context
-  const context = recentMessages.map(m => {
-    const author = m.author || m.role;
-    return `[${author}]: ${m.content}`;
-  }).join('\n\n');
+  const context = recentMessages
+    .map((m) => {
+      const author = m.author || m.role;
+      return `[${author}]: ${m.content}`;
+    })
+    .join('\n\n');
 
-  const turnGuidance = turnNumber >= MAX_TURNS - 2
-    ? '\n\nThis conversation has been going for a while. Wrap up with a clear conclusion or action items.'
-    : turnNumber >= 3
-      ? '\n\nIf the conversation has reached a natural conclusion (agreement, action items decided, question answered), end with "[RESOLVED]" on its own line. Otherwise continue naturally.'
-      : '';
+  const turnGuidance =
+    turnNumber >= MAX_TURNS - 2
+      ? '\n\nThis conversation has been going for a while. Wrap up with a clear conclusion or action items.'
+      : turnNumber >= 3
+        ? '\n\nIf the conversation has reached a natural conclusion (agreement, action items decided, question answered), end with "[RESOLVED]" on its own line. Otherwise continue naturally.'
+        : '';
 
   return `You are responding to a message in the Oracle forum thread "${title}".
 
@@ -191,10 +236,12 @@ function invokeOracle(oracle: string, prompt: string): Promise<string> {
     const claudePath = '/home/gorn/.local/bin/claude';
     const args = [
       '-p',
-      '--model', 'sonnet',
+      '--model',
+      'sonnet',
       '--no-session-persistence',
-      '--max-budget-usd', '0.50',
-      prompt
+      '--max-budget-usd',
+      '0.50',
+      prompt,
     ];
 
     const child = spawn(claudePath, args, {
@@ -207,8 +254,12 @@ function invokeOracle(oracle: string, prompt: string): Promise<string> {
     let stdout = '';
     let stderr = '';
 
-    child.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
-    child.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+    child.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+    child.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
 
     child.on('close', (code) => {
       if (code === 0 && stdout.trim()) {
@@ -246,7 +297,7 @@ function cleanResponse(response: string): string {
 async function saveConversationMemory(
   threadId: number,
   title: string,
-  messages: ForumMessage[]
+  messages: ForumMessage[],
 ): Promise<void> {
   // Find all participating oracles
   const participants = new Set<string>();
@@ -259,13 +310,18 @@ async function saveConversationMemory(
 
   const now = new Date();
   const dateStr = now.toISOString().slice(0, 10);
-  const slug = title.replace(/[^a-z0-9]+/gi, '-').toLowerCase().slice(0, 40);
+  const slug = title
+    .replace(/[^a-z0-9]+/gi, '-')
+    .toLowerCase()
+    .slice(0, 40);
 
   // Build conversation transcript
-  const transcript = messages.map(m => {
-    const author = m.author || m.role;
-    return `**${author}**: ${m.content}`;
-  }).join('\n\n---\n\n');
+  const transcript = messages
+    .map((m) => {
+      const author = m.author || m.role;
+      return `**${author}**: ${m.content}`;
+    })
+    .join('\n\n---\n\n');
 
   const participantNames = [...participants].join(', ');
 
@@ -302,10 +358,16 @@ Output ONLY the bullet point summary, nothing else.`;
     if (!existsSync(psiFilepath)) {
       mkdirSync(learningsDir, { recursive: true });
       try {
-        writeFileSync(psiFilepath, `---\ndate: ${dateStr}\nsource: forum-thread:${threadId}\ntitle: "${title}"\nparticipants: [${[...participants].map(p => `"${p}"`).join(', ')}]\ntags: [forum, auto-responder]\n---\n\n# Forum: ${title}\n\n## Summary\n\n${summary}\n\n## Full Conversation\n\n${transcript}\n`);
+        writeFileSync(
+          psiFilepath,
+          `---\ndate: ${dateStr}\nsource: forum-thread:${threadId}\ntitle: "${title}"\nparticipants: [${[...participants].map((p) => `"${p}"`).join(', ')}]\ntags: [forum, auto-responder]\n---\n\n# Forum: ${title}\n\n## Summary\n\n${summary}\n\n## Full Conversation\n\n${transcript}\n`,
+        );
         console.log(`[memory] Saved to ${oracle} ψ: ${psiFilename}`);
       } catch (err) {
-        console.error(`[memory] Failed ψ save for ${oracle}:`, err instanceof Error ? err.message : err);
+        console.error(
+          `[memory] Failed ψ save for ${oracle}:`,
+          err instanceof Error ? err.message : err,
+        );
       }
     }
 
@@ -350,7 +412,10 @@ ${summary}
 
       console.log(`[memory] Updated ${oracle} MEMORY.md index`);
     } catch (err) {
-      console.error(`[memory] Failed persistent save for ${oracle}:`, err instanceof Error ? err.message : err);
+      console.error(
+        `[memory] Failed persistent save for ${oracle}:`,
+        err instanceof Error ? err.message : err,
+      );
     }
   }
 }
@@ -416,7 +481,9 @@ async function runConversation(threadId: number, title: string): Promise<void> {
         author: `${nextResponder}@auto-responder`,
       });
 
-      console.log(`${tag} Turn ${turn}: ${nextResponder} posted (${cleanedResponse.length} chars)${done ? ' [RESOLVED]' : ''}`);
+      console.log(
+        `${tag} Turn ${turn}: ${nextResponder} posted (${cleanedResponse.length} chars)${done ? ' [RESOLVED]' : ''}`,
+      );
 
       if (done) {
         updateThreadStatus(threadId, 'answered');
@@ -428,10 +495,12 @@ async function runConversation(threadId: number, title: string): Promise<void> {
       }
 
       // Brief pause between turns
-      await new Promise(r => setTimeout(r, TURN_DELAY_MS));
-
+      await new Promise((r) => setTimeout(r, TURN_DELAY_MS));
     } catch (err) {
-      console.error(`${tag} Turn ${turn}: ${nextResponder} failed:`, err instanceof Error ? err.message : err);
+      console.error(
+        `${tag} Turn ${turn}: ${nextResponder} failed:`,
+        err instanceof Error ? err.message : err,
+      );
       break;
     } finally {
       activeDispatch = null;
@@ -534,23 +603,36 @@ export function maybeAutoRespond(threadId: number, title: string): void {
     const senderName = lastMessage.author || lastMessage.role;
 
     // Inject directly into the live session — the real Oracle handles it
-    const sent = sendToLiveSession(pane, nextResponder, threadId, title, senderName, lastMessage.content);
+    const sent = sendToLiveSession(
+      pane,
+      nextResponder,
+      threadId,
+      title,
+      senderName,
+      lastMessage.content,
+    );
     if (sent) {
-      console.log(`[responder] Injected into ${nextResponder}'s live session (${pane}) — real Oracle will handle it`);
+      console.log(
+        `[responder] Injected into ${nextResponder}'s live session (${pane}) — real Oracle will handle it`,
+      );
       return;
     }
     // If tmux injection failed, fall through to auto-responder
-    console.log(`[responder] tmux injection failed for ${nextResponder} — falling back to auto-responder`);
+    console.log(
+      `[responder] tmux injection failed for ${nextResponder} — falling back to auto-responder`,
+    );
   }
 
   // No live session — auto-respond immediately
   activeConversations.add(threadId);
-  console.log(`[responder] No live session for ${nextResponder} — auto-responding in thread #${threadId} ("${title}")`);
+  console.log(
+    `[responder] No live session for ${nextResponder} — auto-responding in thread #${threadId} ("${title}")`,
+  );
   queue.push({ threadId, oracle: targetOracle, title });
 
   // Start processing if not already running
   if (!activeDispatch) {
-    processQueue().catch(err => {
+    processQueue().catch((err) => {
       console.error('[responder] Queue processing error:', err);
       activeConversations.delete(threadId);
     });

--- a/src/forum/routes.ts
+++ b/src/forum/routes.ts
@@ -2,7 +2,11 @@ import type { Context } from 'hono';
 import type { OpenAPIHono } from '@hono/zod-openapi';
 import type { Database } from 'bun:sqlite';
 import type { Role } from '../server/rbac.ts';
-import { checkGuestPostRate, checkGuestContentLength, scanForInjection } from '../server/guest-safety.ts';
+import {
+  checkGuestPostRate,
+  checkGuestContentLength,
+  scanForInjection,
+} from '../server/guest-safety.ts';
 import { logSecurityEvent } from '../server/security-logger.ts';
 import { searchIndexUpsert } from '../search/routes.ts';
 import { handleThreadMessage, getFullThread, updateThreadStatus } from './handler.ts';
@@ -23,8 +27,19 @@ interface ForumHelpers {
   getSupportedEmoji: () => Set<string>;
 }
 
-export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: ForumHelpers): void {
-  const { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast, withRetry, getSupportedEmoji } = helpers;
+export function registerForumRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: ForumHelpers,
+): void {
+  const {
+    hasSessionAuth,
+    requireBeastIdentity,
+    isTrustedRequest,
+    wsBroadcast,
+    withRetry,
+    getSupportedEmoji,
+  } = helpers;
   const sqlite: Database = sqliteDb;
   let SUPPORTED_EMOJI: Set<string> = getSupportedEmoji();
 
@@ -38,20 +53,31 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       // T#718 — derive beast from auth, reject body.beast mismatch
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       if (body.beast && body.beast.toLowerCase() !== caller) {
-        return c.json({ error: 'Identity spoof blocked. body.beast must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Identity spoof blocked. body.beast must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const beast = caller;
       const now = Date.now();
-      sqlite.prepare(`
+      sqlite
+        .prepare(`
         INSERT INTO forum_read_status (beast_name, thread_id, last_read_message_id, updated_at)
         VALUES (?, ?, ?, ?)
         ON CONFLICT(beast_name, thread_id) DO UPDATE SET
           last_read_message_id = MAX(last_read_message_id, excluded.last_read_message_id),
           updated_at = excluded.updated_at
-      `).run(beast, threadId, messageId, now);
+      `)
+        .run(beast, threadId, messageId, now);
       return c.json({ success: true });
     } catch (error) {
       return c.json({ error: error instanceof Error ? error.message : 'Unknown error' }, 500);
@@ -60,7 +86,8 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   app.get('/api/forum/unread/:beast', (c) => {
     const beast = c.req.param('beast');
-    const rows = sqlite.prepare(`
+    const rows = sqlite
+      .prepare(`
       SELECT t.id as thread_id, t.title,
              COUNT(m.id) as total_messages,
              COALESCE(r.last_read_message_id, 0) as last_read,
@@ -73,11 +100,12 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       GROUP BY t.id
       HAVING unread_count > 0
       ORDER BY unread_count DESC
-    `).all(beast, beast) as any[];
+    `)
+      .all(beast, beast) as any[];
 
     return c.json({
       beast,
-      threads: rows.map(r => ({
+      threads: rows.map((r) => ({
         thread_id: r.thread_id,
         title: r.title,
         unread_count: r.unread_count,
@@ -88,15 +116,18 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   app.get('/api/forum/file/:filename', (c) => {
     const filename = c.req.param('filename');
-    if (filename.includes('..') || filename.includes('/')) return c.json({ error: 'Invalid filename' }, 400);
+    if (filename.includes('..') || filename.includes('/'))
+      return c.json({ error: 'Invalid filename' }, 400);
     return c.redirect(`/api/f/${filename}`, 301);
   });
 
   app.get('/api/message/:id/attachments', (c) => {
     const messageId = parseInt(c.req.param('id'), 10);
-    const rows = sqlite.prepare('SELECT * FROM forum_attachments WHERE message_id = ? ORDER BY created_at').all(messageId) as any[];
+    const rows = sqlite
+      .prepare('SELECT * FROM forum_attachments WHERE message_id = ? ORDER BY created_at')
+      .all(messageId) as any[];
     return c.json({
-      attachments: rows.map(r => ({
+      attachments: rows.map((r) => ({
         id: r.id,
         filename: r.filename,
         original_name: r.original_name,
@@ -115,10 +146,19 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       // T#718 — derive beast from auth
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       if (body.beast && body.beast.toLowerCase() !== caller) {
-        return c.json({ error: 'Identity spoof blocked. body.beast must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Identity spoof blocked. body.beast must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const beast = caller;
       const muted = body.muted !== false;
@@ -133,16 +173,19 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   app.get('/api/forum/muted/:beast', (c) => {
     const beast = c.req.param('beast').toLowerCase();
-    const rows = sqlite.prepare(
-      'SELECT thread_id FROM forum_notification_prefs WHERE beast_name = ? AND (muted = 1 OR level = ?)'
-    ).all(beast, 'muted') as any[];
-    return c.json({ beast, muted_threads: rows.map(r => r.thread_id) });
+    const rows = sqlite
+      .prepare(
+        'SELECT thread_id FROM forum_notification_prefs WHERE beast_name = ? AND (muted = 1 OR level = ?)',
+      )
+      .all(beast, 'muted') as any[];
+    return c.json({ beast, muted_threads: rows.map((r) => r.thread_id) });
   });
 
   app.post('/api/forum/subscribe', async (c) => {
     try {
       const body = await c.req.json();
-      if (!body.beast || !body.threadId) return c.json({ error: 'beast and threadId required' }, 400);
+      if (!body.beast || !body.threadId)
+        return c.json({ error: 'beast and threadId required' }, 400);
       const level = body.level || 'full';
       if (!['full', 'summary', 'muted'].includes(level)) {
         return c.json({ error: 'level must be full, summary, or muted' }, 400);
@@ -175,10 +218,12 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const subs = getThreadSubscribers(threadId);
 
     // Enrich with beast profile data
-    const subscribers = subs.map(s => {
-      const profile = sqlite.prepare(
-        'SELECT display_name, animal, avatar_url, theme_color FROM beast_profiles WHERE name = ?'
-      ).get(s.beast_name) as any;
+    const subscribers = subs.map((s) => {
+      const profile = sqlite
+        .prepare(
+          'SELECT display_name, animal, avatar_url, theme_color FROM beast_profiles WHERE name = ?',
+        )
+        .get(s.beast_name) as any;
       return {
         name: s.beast_name,
         display_name: profile?.display_name || s.beast_name,
@@ -204,8 +249,14 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       }
       // Block internal/private hostnames
       const hostname = parsed.hostname.toLowerCase();
-      if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' ||
-          hostname === '0.0.0.0' || hostname.endsWith('.local') || hostname.endsWith('.internal')) {
+      if (
+        hostname === 'localhost' ||
+        hostname === '127.0.0.1' ||
+        hostname === '::1' ||
+        hostname === '0.0.0.0' ||
+        hostname.endsWith('.local') ||
+        hostname.endsWith('.internal')
+      ) {
         return c.json({ error: 'Internal URLs not allowed' }, 400);
       }
       // Resolve DNS and block private IP ranges
@@ -214,14 +265,19 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         const ips = await resolve4(hostname);
         for (const ip of ips) {
           const parts = ip.split('.').map(Number);
-          if (parts[0] === 10 || parts[0] === 127 ||
-              (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
-              (parts[0] === 192 && parts[1] === 168) ||
-              (parts[0] === 169 && parts[1] === 254)) {
+          if (
+            parts[0] === 10 ||
+            parts[0] === 127 ||
+            (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+            (parts[0] === 192 && parts[1] === 168) ||
+            (parts[0] === 169 && parts[1] === 254)
+          ) {
             return c.json({ error: 'Internal URLs not allowed' }, 400);
           }
         }
-      } catch { /* DNS resolution failed — let fetch handle it */ }
+      } catch {
+        /* DNS resolution failed — let fetch handle it */
+      }
     } catch {
       return c.json({ error: 'Invalid URL' }, 400);
     }
@@ -236,11 +292,18 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
       // Extract basic meta tags
       const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
-      const descMatch = html.match(/<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["']/i)
-        || html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*name=["']description["']/i);
-      const ogTitleMatch = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i);
-      const ogDescMatch = html.match(/<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']+)["']/i);
-      const ogImageMatch = html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i);
+      const descMatch =
+        html.match(/<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["']/i) ||
+        html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*name=["']description["']/i);
+      const ogTitleMatch = html.match(
+        /<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i,
+      );
+      const ogDescMatch = html.match(
+        /<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']+)["']/i,
+      );
+      const ogImageMatch = html.match(
+        /<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i,
+      );
 
       return c.json({
         url,
@@ -255,17 +318,19 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   app.get('/api/forum/activity', (c) => {
     const limit = parseInt(c.req.query('limit') || '30');
-    const rows = sqlite.prepare(`
+    const rows = sqlite
+      .prepare(`
       SELECT m.id, m.thread_id, m.role, m.content, m.author, m.created_at,
              t.title as thread_title, t.category
       FROM forum_messages m
       JOIN forum_threads t ON m.thread_id = t.id
       ORDER BY m.created_at DESC
       LIMIT ?
-    `).all(limit) as any[];
+    `)
+      .all(limit) as any[];
 
     return c.json({
-      activity: rows.map(r => ({
+      activity: rows.map((r) => ({
         message_id: r.id,
         thread_id: r.thread_id,
         thread_title: r.thread_title,
@@ -282,7 +347,8 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   app.get('/api/forum/mentions/:beast', (c) => {
     const beast = c.req.param('beast').toLowerCase();
     const limit = parseInt(c.req.query('limit') || '30');
-    const rows = sqlite.prepare(`
+    const rows = sqlite
+      .prepare(`
       SELECT m.id, m.thread_id, m.content, m.author, m.created_at,
              t.title as thread_title
       FROM forum_messages m
@@ -290,11 +356,12 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       WHERE LOWER(m.content) LIKE ?
       ORDER BY m.created_at DESC
       LIMIT ?
-    `).all(`%@${beast}%`, limit) as any[];
+    `)
+      .all(`%@${beast}%`, limit) as any[];
 
     return c.json({
       beast,
-      mentions: rows.map(r => ({
+      mentions: rows.map((r) => ({
         message_id: r.id,
         thread_id: r.thread_id,
         thread_title: r.thread_title,
@@ -320,23 +387,33 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       JOIN forum_threads t ON m.thread_id = t.id
       WHERE m.content LIKE ?`;
     const msgParams: any[] = [`%${q}%`];
-    if (author) { msgQuery += ' AND LOWER(m.author) LIKE ?'; msgParams.push(`%${author.toLowerCase()}%`); }
-    if (category) { msgQuery += ' AND t.category = ?'; msgParams.push(category); }
+    if (author) {
+      msgQuery += ' AND LOWER(m.author) LIKE ?';
+      msgParams.push(`%${author.toLowerCase()}%`);
+    }
+    if (category) {
+      msgQuery += ' AND t.category = ?';
+      msgParams.push(category);
+    }
     msgQuery += ' ORDER BY m.created_at DESC LIMIT ?';
     msgParams.push(limit);
     const messages = sqlite.prepare(msgQuery).all(...msgParams) as any[];
 
     // Search threads by title (with optional category filter)
-    let threadQuery = 'SELECT id, title, status, category, created_at FROM forum_threads WHERE title LIKE ?';
+    let threadQuery =
+      'SELECT id, title, status, category, created_at FROM forum_threads WHERE title LIKE ?';
     const threadParams: any[] = [`%${q}%`];
-    if (category) { threadQuery += ' AND category = ?'; threadParams.push(category); }
+    if (category) {
+      threadQuery += ' AND category = ?';
+      threadParams.push(category);
+    }
     threadQuery += ' ORDER BY updated_at DESC LIMIT ?';
     threadParams.push(limit);
     const threads = sqlite.prepare(threadQuery).all(...threadParams) as any[];
 
     return c.json({
       query: q,
-      messages: messages.map(m => ({
+      messages: messages.map((m) => ({
         id: m.id,
         thread_id: m.thread_id,
         thread_title: m.thread_title,
@@ -345,7 +422,7 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         author: m.author,
         created_at: new Date(m.created_at).toISOString(),
       })),
-      threads: threads.map(t => ({
+      threads: threads.map((t) => ({
         id: t.id,
         title: t.title,
         status: t.status,
@@ -364,32 +441,53 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const offset = parseInt(c.req.query('offset') || '0');
     const role = (c.get as any)('role') as Role | undefined;
 
-    let query = 'SELECT *, (SELECT COUNT(*) FROM forum_messages WHERE thread_id = forum_threads.id) as msg_count FROM forum_threads WHERE deleted_at IS NULL';
+    let query =
+      'SELECT *, (SELECT COUNT(*) FROM forum_messages WHERE thread_id = forum_threads.id) as msg_count FROM forum_threads WHERE deleted_at IS NULL';
     const params: any[] = [];
-    if (status) { query += ' AND status = ?'; params.push(status); }
-    if (category) { query += ' AND category = ?'; params.push(category); }
+    if (status) {
+      query += ' AND status = ?';
+      params.push(status);
+    }
+    if (category) {
+      query += ' AND category = ?';
+      params.push(category);
+    }
     // Guests only see public threads; owner can filter by visibility
-    if (role === 'guest') { query += " AND visibility = 'public'"; }
-    else if (visibility === 'public' || visibility === 'internal') { query += ' AND visibility = ?'; params.push(visibility); }
+    if (role === 'guest') {
+      query += " AND visibility = 'public'";
+    } else if (visibility === 'public' || visibility === 'internal') {
+      query += ' AND visibility = ?';
+      params.push(visibility);
+    }
     query += ' ORDER BY COALESCE(pinned, 0) DESC, updated_at DESC LIMIT ? OFFSET ?';
     params.push(limit, offset);
 
     const rows = sqlite.prepare(query).all(...params) as any[];
     let countQuery = 'SELECT COUNT(*) as total FROM forum_threads WHERE deleted_at IS NULL';
     const countParams: any[] = [];
-    if (status) { countQuery += ' AND status = ?'; countParams.push(status); }
-    if (category) { countQuery += ' AND category = ?'; countParams.push(category); }
-    if (role === 'guest') { countQuery += " AND visibility = 'public'"; }
-    else if (visibility === 'public' || visibility === 'internal') { countQuery += ' AND visibility = ?'; countParams.push(visibility); }
+    if (status) {
+      countQuery += ' AND status = ?';
+      countParams.push(status);
+    }
+    if (category) {
+      countQuery += ' AND category = ?';
+      countParams.push(category);
+    }
+    if (role === 'guest') {
+      countQuery += " AND visibility = 'public'";
+    } else if (visibility === 'public' || visibility === 'internal') {
+      countQuery += ' AND visibility = ?';
+      countParams.push(visibility);
+    }
     const total = (sqlite.prepare(countQuery).get(...countParams) as any)?.total || 0;
 
     return c.json({
-      threads: rows.map(t => ({
+      threads: rows.map((t) => ({
         id: t.id,
         title: t.title,
         status: t.status || 'active',
         category: t.category || 'discussion',
-        pinned: !!(t.pinned),
+        pinned: !!t.pinned,
         message_count: t.msg_count || 0,
         created_at: new Date(t.created_at).toISOString(),
         created_by: t.created_by || null,
@@ -416,7 +514,9 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         if (!data.thread_id) {
           return c.json({ error: 'Guests cannot create new threads' }, 403);
         }
-        const threadRow = sqlite.prepare('SELECT visibility FROM forum_threads WHERE id = ?').get(data.thread_id) as any;
+        const threadRow = sqlite
+          .prepare('SELECT visibility FROM forum_threads WHERE id = ?')
+          .get(data.thread_id) as any;
         if (!threadRow || threadRow.visibility !== 'public') {
           return c.json({ error: 'Guests can only post in public threads' }, 403);
         }
@@ -454,49 +554,84 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         // T#718 — Beast/owner path: derive author from auth, reject client-asserted mismatch
         const caller = requireBeastIdentity(c);
         if (!caller) {
-          return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+          return c.json(
+            {
+              error: 'Beast identity required — bearer-token or owner session',
+              requiresAuth: true,
+            },
+            401,
+          );
         }
         if (data.author && data.author.toLowerCase() !== caller) {
-          return c.json({ error: 'Author impersonation blocked. body.author must match authenticated caller or be omitted.' }, 403);
+          return c.json(
+            {
+              error:
+                'Author impersonation blocked. body.author must match authenticated caller or be omitted.',
+            },
+            403,
+          );
         }
         data.author = caller;
       }
 
       // Block posting to deleted threads
       if (data.thread_id) {
-        const threadCheck = sqlite.prepare('SELECT deleted_at FROM forum_threads WHERE id = ?').get(data.thread_id) as any;
+        const threadCheck = sqlite
+          .prepare('SELECT deleted_at FROM forum_threads WHERE id = ?')
+          .get(data.thread_id) as any;
         if (threadCheck?.deleted_at) {
           return c.json({ error: 'Cannot post to a deleted thread' }, 410);
         }
       }
 
-      const result = await withRetry(() => handleThreadMessage({
-        message: data.message,
-        threadId: data.thread_id,
-        title: data.title,
-        role: data.role || 'human',
-        author: data.author,
-      }));
+      const result = await withRetry(() =>
+        handleThreadMessage({
+          message: data.message,
+          threadId: data.thread_id,
+          title: data.title,
+          role: data.role || 'human',
+          author: data.author,
+        }),
+      );
       // Set visibility on new thread creation if specified
       if (!data.thread_id && result.threadId && data.visibility) {
         const vis = data.visibility === 'public' ? 'public' : 'internal';
-        sqlite.prepare('UPDATE forum_threads SET visibility = ? WHERE id = ?').run(vis, result.threadId);
+        sqlite
+          .prepare('UPDATE forum_threads SET visibility = ? WHERE id = ?')
+          .run(vis, result.threadId);
       }
       // Store reply_to_id and author_role if applicable
       if (result.messageId) {
         if (data.reply_to_id) {
-          sqlite.prepare('UPDATE forum_messages SET reply_to_id = ? WHERE id = ?')
+          sqlite
+            .prepare('UPDATE forum_messages SET reply_to_id = ? WHERE id = ?')
             .run(data.reply_to_id, result.messageId);
         }
         // Set author_role for prompt injection defense (Spec #32, T#557)
-        const authorRole = role === 'guest' ? 'guest' : (role === 'owner' ? 'owner' : 'beast');
-        sqlite.prepare('UPDATE forum_messages SET author_role = ? WHERE id = ?')
+        const authorRole = role === 'guest' ? 'guest' : role === 'owner' ? 'owner' : 'beast';
+        sqlite
+          .prepare('UPDATE forum_messages SET author_role = ? WHERE id = ?')
           .run(authorRole, result.messageId);
       }
       // Index forum message for search (T#347)
       if (result.messageId && result.threadId) {
-        const threadTitle = data.title || (sqlite.prepare('SELECT title FROM forum_threads WHERE id = ?').get(result.threadId) as any)?.title || '';
-        searchIndexUpsert('forum', result.messageId, threadTitle, data.message, data.author, new Date().toISOString(), `/forum?thread=${result.threadId}`);
+        const threadTitle =
+          data.title ||
+          (
+            sqlite
+              .prepare('SELECT title FROM forum_threads WHERE id = ?')
+              .get(result.threadId) as any
+          )?.title ||
+          '';
+        searchIndexUpsert(
+          'forum',
+          result.messageId,
+          threadTitle,
+          data.message,
+          data.author,
+          new Date().toISOString(),
+          `/forum?thread=${result.threadId}`,
+        );
       }
       // Push WebSocket event
       wsBroadcast('new_message', {
@@ -513,9 +648,12 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         notified: result.notified,
       });
     } catch (error) {
-      return c.json({
-        error: error instanceof Error ? error.message : 'Unknown error'
-      }, 500);
+      return c.json(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        500,
+      );
     }
   });
 
@@ -540,7 +678,9 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // Guests can only view public threads
     const role = (c.get as any)('role') as Role | undefined;
     if (role === 'guest') {
-      const threadRow = sqlite.prepare('SELECT visibility FROM forum_threads WHERE id = ?').get(threadId) as any;
+      const threadRow = sqlite
+        .prepare('SELECT visibility FROM forum_threads WHERE id = ?')
+        .get(threadId) as any;
       if (!threadRow || threadRow.visibility !== 'public') {
         return c.json({ error: 'Thread not found' }, 404);
       }
@@ -552,20 +692,28 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         title: threadData.thread.title,
         status: threadData.thread.status,
         created_at: new Date(threadData.thread.createdAt).toISOString(),
-        issue_url: threadData.thread.issueUrl
+        issue_url: threadData.thread.issueUrl,
       },
-      messages: threadData.messages.map(m => {
+      messages: threadData.messages.map((m) => {
         // Get reply_to_id from raw SQL (not in Drizzle schema)
-        const raw = sqlite.prepare('SELECT reply_to_id FROM forum_messages WHERE id = ?').get(m.id) as any;
+        const raw = sqlite
+          .prepare('SELECT reply_to_id FROM forum_messages WHERE id = ?')
+          .get(m.id) as any;
         // Get reactions for this message
-        const reactionRows = sqlite.prepare(
-          'SELECT emoji, GROUP_CONCAT(beast_name) as beasts, COUNT(*) as count FROM forum_reactions WHERE message_id = ? GROUP BY emoji'
-        ).all(m.id) as any[];
+        const reactionRows = sqlite
+          .prepare(
+            'SELECT emoji, GROUP_CONCAT(beast_name) as beasts, COUNT(*) as count FROM forum_reactions WHERE message_id = ? GROUP BY emoji',
+          )
+          .all(m.id) as any[];
         // Resolve guest avatar URL from guest_accounts (T#602)
         let authorAvatarUrl: string | null = null;
         if (m.author?.startsWith('[Guest]')) {
           const guestName = m.author.replace('[Guest] ', '').replace('[Guest]', '').trim();
-          const guest = sqlite.prepare('SELECT avatar_url FROM guest_accounts WHERE LOWER(display_name) = ? OR LOWER(username) = ?').get(guestName.toLowerCase(), guestName.toLowerCase()) as any;
+          const guest = sqlite
+            .prepare(
+              'SELECT avatar_url FROM guest_accounts WHERE LOWER(display_name) = ? OR LOWER(username) = ?',
+            )
+            .get(guestName.toLowerCase(), guestName.toLowerCase()) as any;
           authorAvatarUrl = guest?.avatar_url || null;
         }
         return {
@@ -578,7 +726,11 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
           principles_found: m.principlesFound,
           patterns_found: m.patternsFound,
           created_at: new Date(m.createdAt).toISOString(),
-          reactions: reactionRows.map(r => ({ emoji: r.emoji, beasts: r.beasts.split(','), count: r.count })),
+          reactions: reactionRows.map((r) => ({
+            emoji: r.emoji,
+            beasts: r.beasts.split(','),
+            count: r.count,
+          })),
         };
       }),
       total: threadData.total,
@@ -595,14 +747,25 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       // T#718 — derive beast from auth, reject client-asserted mismatch
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       if (body.beast && body.beast.toLowerCase() !== caller) {
-        return c.json({ error: 'Identity spoof blocked. body.beast must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Identity spoof blocked. body.beast must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
 
       // Get current content
-      const current = sqlite.prepare('SELECT content, author FROM forum_messages WHERE id = ?').get(messageId) as any;
+      const current = sqlite
+        .prepare('SELECT content, author FROM forum_messages WHERE id = ?')
+        .get(messageId) as any;
       if (!current) return c.json({ error: 'Message not found' }, 404);
 
       // Restrict edits to original author only (or Gorn)
@@ -614,16 +777,23 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
       // Save original to edit history (Nothing is Deleted)
       const now = Date.now();
-      sqlite.prepare(`
+      sqlite
+        .prepare(`
         INSERT INTO forum_message_edits (message_id, original_content, edited_by, created_at)
         VALUES (?, ?, ?, ?)
-      `).run(messageId, current.content, caller, now);
+      `)
+        .run(messageId, current.content, caller, now);
 
       // Update message
-      sqlite.prepare('UPDATE forum_messages SET content = ?, edited_at = ? WHERE id = ?')
+      sqlite
+        .prepare('UPDATE forum_messages SET content = ?, edited_at = ? WHERE id = ?')
         .run(body.content, now, messageId);
 
-      return c.json({ success: true, message_id: messageId, edited_at: new Date(now).toISOString() });
+      return c.json({
+        success: true,
+        message_id: messageId,
+        edited_at: new Date(now).toISOString(),
+      });
     } catch (error) {
       return c.json({ error: error instanceof Error ? error.message : 'Unknown error' }, 500);
     }
@@ -641,43 +811,61 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       return c.json({ error: 'Only Gorn can delete forum messages' }, 403);
     }
 
-    const msg = sqlite.prepare('SELECT id, thread_id, author, content, deleted_at FROM forum_messages WHERE id = ?').get(messageId) as any;
+    const msg = sqlite
+      .prepare('SELECT id, thread_id, author, content, deleted_at FROM forum_messages WHERE id = ?')
+      .get(messageId) as any;
     if (!msg) return c.json({ error: 'Message not found' }, 404);
     if (msg.deleted_at) return c.json({ error: 'Message already deleted' }, 400);
 
     // Soft delete — Nothing is Deleted principle
     const now = new Date().toISOString();
     try {
-      sqlite.prepare('UPDATE forum_messages SET deleted_at = ?, deleted_by = ? WHERE id = ?')
+      sqlite
+        .prepare('UPDATE forum_messages SET deleted_at = ?, deleted_by = ? WHERE id = ?')
         .run(now, 'gorn', messageId);
     } catch (error) {
       return c.json({ error: 'Database error during deletion' }, 500);
     }
 
     // Audit trail
-    const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+    const ip =
+      c.req.header('x-real-ip') ||
+      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+      'local';
     logSecurityEvent({
       eventType: 'message_delete',
       severity: 'warning',
       actor: 'gorn',
       actorType: 'owner',
       target: `message:${messageId}`,
-      details: { thread_id: msg.thread_id, author: msg.author, content_preview: msg.content?.slice(0, 100) },
+      details: {
+        thread_id: msg.thread_id,
+        author: msg.author,
+        content_preview: msg.content?.slice(0, 100),
+      },
       ipSource: ip,
       requestId: (c.get as any)('requestId'),
     });
 
-    return c.json({ deleted: messageId, thread_id: msg.thread_id, deleted_at: now, deleted_by: 'gorn', soft: true });
+    return c.json({
+      deleted: messageId,
+      thread_id: msg.thread_id,
+      deleted_at: now,
+      deleted_by: 'gorn',
+      soft: true,
+    });
   });
 
   app.get('/api/message/:id/history', (c) => {
     const messageId = parseInt(c.req.param('id'), 10);
-    const rows = sqlite.prepare(
-      'SELECT id, original_content, edited_by, created_at FROM forum_message_edits WHERE message_id = ? ORDER BY created_at DESC'
-    ).all(messageId) as any[];
+    const rows = sqlite
+      .prepare(
+        'SELECT id, original_content, edited_by, created_at FROM forum_message_edits WHERE message_id = ? ORDER BY created_at DESC',
+      )
+      .all(messageId) as any[];
     return c.json({
       message_id: messageId,
-      edits: rows.map(r => ({
+      edits: rows.map((r) => ({
         id: r.id,
         original_content: r.original_content,
         edited_by: r.edited_by,
@@ -688,7 +876,9 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   });
 
   app.openapi(emojiListRoute, (c) => {
-    const rows = sqlite.prepare('SELECT emoji, added_by, created_at FROM emoji_whitelist ORDER BY created_at').all() as any[];
+    const rows = sqlite
+      .prepare('SELECT emoji, added_by, created_at FROM emoji_whitelist ORDER BY created_at')
+      .all() as any[];
     return c.json({ emoji: rows, total: rows.length }, 200);
   });
 
@@ -701,7 +891,11 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const beast = data.beast || data.added_by || (hasSessionAuth(c) ? 'gorn' : '');
     if (!beast && !isTrustedRequest(c)) return c.json({ error: 'beast required' }, 400);
     const now = Date.now();
-    sqlite.prepare('INSERT OR IGNORE INTO emoji_whitelist (emoji, added_by, created_at) VALUES (?, ?, ?)').run(data.emoji, beast, now);
+    sqlite
+      .prepare(
+        'INSERT OR IGNORE INTO emoji_whitelist (emoji, added_by, created_at) VALUES (?, ?, ?)',
+      )
+      .run(data.emoji, beast, now);
     SUPPORTED_EMOJI = getSupportedEmoji();
     return c.json({ added: data.emoji, by: beast, total: SUPPORTED_EMOJI.size }, 200);
   }) as any);
@@ -735,9 +929,13 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         body.beast = `[Guest] ${guestUsername}`;
 
         // Thread visibility check — guests can only react to messages in public threads
-        const msg = sqlite.prepare('SELECT thread_id FROM forum_messages WHERE id = ?').get(messageId) as any;
+        const msg = sqlite
+          .prepare('SELECT thread_id FROM forum_messages WHERE id = ?')
+          .get(messageId) as any;
         if (msg) {
-          const thread = sqlite.prepare('SELECT visibility FROM forum_threads WHERE id = ?').get(msg.thread_id) as any;
+          const thread = sqlite
+            .prepare('SELECT visibility FROM forum_threads WHERE id = ?')
+            .get(msg.thread_id) as any;
           if (thread && thread.visibility && thread.visibility !== 'public') {
             return c.json({ error: 'Guests cannot react to messages in private threads' }, 403);
           }
@@ -746,43 +944,76 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         // T#718 — Beast/owner path: derive from auth, reject client-asserted mismatch
         const caller = requireBeastIdentity(c);
         if (!caller) {
-          return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+          return c.json(
+            {
+              error: 'Beast identity required — bearer-token or owner session',
+              requiresAuth: true,
+            },
+            401,
+          );
         }
         if (body.beast && body.beast.toLowerCase() !== caller) {
-          return c.json({ error: 'Identity spoof blocked. body.beast must match authenticated caller or be omitted.' }, 403);
+          return c.json(
+            {
+              error:
+                'Identity spoof blocked. body.beast must match authenticated caller or be omitted.',
+            },
+            403,
+          );
         }
         body.beast = caller;
       }
       if (!SUPPORTED_EMOJI.has(body.emoji)) {
-        return c.json({ error: `Unsupported emoji. Supported: ${[...SUPPORTED_EMOJI].join(' ')}` }, 400);
+        return c.json(
+          { error: `Unsupported emoji. Supported: ${[...SUPPORTED_EMOJI].join(' ')}` },
+          400,
+        );
       }
       const now = Date.now();
-      sqlite.prepare(`
+      sqlite
+        .prepare(`
         INSERT OR IGNORE INTO forum_reactions (message_id, beast_name, emoji, created_at)
         VALUES (?, ?, ?, ?)
-      `).run(messageId, body.beast.toLowerCase(), body.emoji, now);
-      wsBroadcast('reaction', { message_id: messageId, beast: body.beast, emoji: body.emoji, action: 'add' });
+      `)
+        .run(messageId, body.beast.toLowerCase(), body.emoji, now);
+      wsBroadcast('reaction', {
+        message_id: messageId,
+        beast: body.beast,
+        emoji: body.emoji,
+        action: 'add',
+      });
 
       // Notify the message author about the reaction
       try {
-        const msg = sqlite.prepare('SELECT author, thread_id FROM forum_messages WHERE id = ?').get(messageId) as any;
+        const msg = sqlite
+          .prepare('SELECT author, thread_id FROM forum_messages WHERE id = ?')
+          .get(messageId) as any;
         if (msg?.author) {
           const msgAuthor = msg.author.split('@')[0].toLowerCase();
           const reactor = body.beast.toLowerCase();
           // Don't notify yourself
-          if (msgAuthor !== reactor && msgAuthor !== 'gorn' && msgAuthor !== 'human' && msgAuthor !== 'user') {
-            const thread = sqlite.prepare('SELECT title FROM forum_threads WHERE id = ?').get(msg.thread_id) as any;
+          if (
+            msgAuthor !== reactor &&
+            msgAuthor !== 'gorn' &&
+            msgAuthor !== 'human' &&
+            msgAuthor !== 'user'
+          ) {
+            const thread = sqlite
+              .prepare('SELECT title FROM forum_threads WHERE id = ?')
+              .get(msg.thread_id) as any;
             const { notifyMentioned } = await import('./mentions.ts');
             notifyMentioned(
               [msgAuthor],
               msg.thread_id,
               thread?.title || 'thread',
               reactor,
-              `${body.emoji} reacted to your message`
+              `${body.emoji} reacted to your message`,
             );
           }
         }
-      } catch { /* notification failure is non-critical */ }
+      } catch {
+        /* notification failure is non-critical */
+      }
 
       return c.json({ success: true, message_id: messageId, emoji: body.emoji });
     } catch (error) {
@@ -808,16 +1039,36 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         // T#718 — Beast/owner path: derive from auth
         const caller = requireBeastIdentity(c);
         if (!caller) {
-          return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+          return c.json(
+            {
+              error: 'Beast identity required — bearer-token or owner session',
+              requiresAuth: true,
+            },
+            401,
+          );
         }
         if (body.beast && body.beast.toLowerCase() !== caller) {
-          return c.json({ error: 'Identity spoof blocked. body.beast must match authenticated caller or be omitted.' }, 403);
+          return c.json(
+            {
+              error:
+                'Identity spoof blocked. body.beast must match authenticated caller or be omitted.',
+            },
+            403,
+          );
         }
         body.beast = caller;
       }
-      sqlite.prepare('DELETE FROM forum_reactions WHERE message_id = ? AND beast_name = ? AND emoji = ?')
+      sqlite
+        .prepare(
+          'DELETE FROM forum_reactions WHERE message_id = ? AND beast_name = ? AND emoji = ?',
+        )
         .run(messageId, body.beast.toLowerCase(), body.emoji);
-      wsBroadcast('reaction', { message_id: messageId, beast: body.beast, emoji: body.emoji, action: 'remove' });
+      wsBroadcast('reaction', {
+        message_id: messageId,
+        beast: body.beast,
+        emoji: body.emoji,
+        action: 'remove',
+      });
       return c.json({ success: true });
     } catch (error) {
       return c.json({ error: error instanceof Error ? error.message : 'Unknown error' }, 500);
@@ -826,12 +1077,14 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   app.get('/api/message/:id/reactions', (c) => {
     const messageId = parseInt(c.req.param('id'), 10);
-    const rows = sqlite.prepare(
-      'SELECT emoji, GROUP_CONCAT(beast_name) as beasts, COUNT(*) as count FROM forum_reactions WHERE message_id = ? GROUP BY emoji'
-    ).all(messageId) as any[];
+    const rows = sqlite
+      .prepare(
+        'SELECT emoji, GROUP_CONCAT(beast_name) as beasts, COUNT(*) as count FROM forum_reactions WHERE message_id = ? GROUP BY emoji',
+      )
+      .all(messageId) as any[];
     return c.json({
       message_id: messageId,
-      reactions: rows.map(r => ({ emoji: r.emoji, beasts: r.beasts.split(','), count: r.count })),
+      reactions: rows.map((r) => ({ emoji: r.emoji, beasts: r.beasts.split(','), count: r.count })),
     });
   });
 
@@ -843,7 +1096,9 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       if (!data.category || !allowed.includes(data.category)) {
         return c.json({ error: `Invalid category. Allowed: ${allowed.join(', ')}` }, 400);
       }
-      sqlite.prepare('UPDATE forum_threads SET category = ? WHERE id = ?').run(data.category, threadId);
+      sqlite
+        .prepare('UPDATE forum_threads SET category = ? WHERE id = ?')
+        .run(data.category, threadId);
       return c.json({ success: true, thread_id: threadId, category: data.category });
     } catch (e) {
       return c.json({ error: 'Invalid JSON' }, 400);
@@ -859,7 +1114,9 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       if (locked) {
         sqlite.prepare('UPDATE forum_threads SET status = ? WHERE id = ?').run('locked', threadId);
       } else {
-        sqlite.prepare("UPDATE forum_threads SET status = ? WHERE id = ? AND status = 'locked'").run('active', threadId);
+        sqlite
+          .prepare("UPDATE forum_threads SET status = ? WHERE id = ? AND status = 'locked'")
+          .run('active', threadId);
       }
       return c.json({ success: true, thread_id: threadId, locked: !!locked });
     } catch (e) {
@@ -899,7 +1156,9 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       if (!title) return c.json({ error: 'title required (after sanitization)' }, 400);
       sqlite.prepare('UPDATE forum_threads SET title = ? WHERE id = ?').run(title, threadId);
       return c.json({ success: true, thread_id: threadId, title });
-    } catch { return c.json({ error: 'Invalid JSON' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid JSON' }, 400);
+    }
   });
 
   app.patch('/api/thread/:id/visibility', async (c) => {
@@ -912,19 +1171,35 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       if (data.visibility !== 'public' && data.visibility !== 'internal') {
         return c.json({ error: "visibility must be 'public' or 'internal'" }, 400);
       }
-      sqlite.prepare('UPDATE forum_threads SET visibility = ? WHERE id = ?').run(data.visibility, threadId);
+      sqlite
+        .prepare('UPDATE forum_threads SET visibility = ? WHERE id = ?')
+        .run(data.visibility, threadId);
 
       // T#629: Notify all Beasts when a thread becomes public
       if (data.visibility === 'public') {
         try {
-          const thread = sqlite.prepare('SELECT title, created_by FROM forum_threads WHERE id = ?').get(threadId) as any;
+          const thread = sqlite
+            .prepare('SELECT title, created_by FROM forum_threads WHERE id = ?')
+            .get(threadId) as any;
           if (thread) {
             const { getOracleRegistry, notifyMentioned } = await import('./mentions.ts');
             const registry = getOracleRegistry();
-            const allBeasts = Object.keys(registry).filter(name => name !== 'gorn' && name !== (thread.created_by || '').toLowerCase());
-            notifyMentioned(allBeasts, threadId, thread.title, thread.created_by || 'unknown', `New public thread: ${thread.title}`, undefined, new Set(allBeasts));
+            const allBeasts = Object.keys(registry).filter(
+              (name) => name !== 'gorn' && name !== (thread.created_by || '').toLowerCase(),
+            );
+            notifyMentioned(
+              allBeasts,
+              threadId,
+              thread.title,
+              thread.created_by || 'unknown',
+              `New public thread: ${thread.title}`,
+              undefined,
+              new Set(allBeasts),
+            );
           }
-        } catch { /* best effort */ }
+        } catch {
+          /* best effort */
+        }
       }
 
       return c.json({ success: true, thread_id: threadId, visibility: data.visibility });
@@ -958,9 +1233,11 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       return c.json({ error: 'Only the thread creator or Gorn can delete a thread' }, 403);
     }
     // Soft delete — set deleted_at timestamp (Nothing is Deleted)
-    sqlite.prepare("UPDATE forum_threads SET deleted_at = datetime('now'), status = 'deleted' WHERE id = ?").run(id);
+    sqlite
+      .prepare(
+        "UPDATE forum_threads SET deleted_at = datetime('now'), status = 'deleted' WHERE id = ?",
+      )
+      .run(id);
     return c.json({ deleted: id, title: existing.title, soft: true });
   });
-
-
 }

--- a/src/forum/types.ts
+++ b/src/forum/types.ts
@@ -17,12 +17,12 @@ export interface ForumThread {
   title: string;
   createdBy: string;
   status: ThreadStatus;
-  issueUrl?: string;      // GitHub mirror (optional)
+  issueUrl?: string; // GitHub mirror (optional)
   issueNumber?: number;
-  project?: string;       // Which project context
+  project?: string; // Which project context
   createdAt: number;
   updatedAt: number;
-  syncedAt?: number;      // Last GitHub sync
+  syncedAt?: number; // Last GitHub sync
 }
 
 export interface ForumMessage {
@@ -30,7 +30,7 @@ export interface ForumMessage {
   threadId: number;
   role: MessageRole;
   content: string;
-  author?: string;        // GitHub username or "oracle"
+  author?: string; // GitHub username or "oracle"
 
   // Oracle response metadata
   principlesFound?: number;
@@ -38,7 +38,7 @@ export interface ForumMessage {
   searchQuery?: string;
 
   // GitHub mirror
-  commentId?: number;     // GitHub comment ID if synced
+  commentId?: number; // GitHub comment ID if synced
 
   createdAt: number;
 }
@@ -61,7 +61,7 @@ export function parseIssueUrl(url: string): ParsedIssueUrl | null {
     owner: match[1],
     repo: match[2],
     issueNumber: parseInt(match[3], 10),
-    url
+    url,
   };
 }
 
@@ -76,11 +76,11 @@ export function buildIssueUrl(owner: string, repo: string, issueNumber: number):
 // Start new thread or add to existing
 export interface OracleThreadInput {
   message: string;
-  threadId?: number;      // If continuing existing thread
-  title?: string;         // For new threads
-  role?: MessageRole;     // Default: 'human'
-  model?: string;         // e.g., 'opus', 'sonnet' for Claude calls
-  author?: string;        // Override author (e.g., 'karo' from HTTP callers)
+  threadId?: number; // If continuing existing thread
+  title?: string; // For new threads
+  role?: MessageRole; // Default: 'human'
+  model?: string; // e.g., 'opus', 'sonnet' for Claude calls
+  author?: string; // Override author (e.g., 'karo' from HTTP callers)
 }
 
 export interface OracleThreadOutput {
@@ -99,7 +99,7 @@ export interface OracleThreadOutput {
 // Sync thread to GitHub Issue
 export interface OracleSyncInput {
   threadId: number;
-  createIssue?: boolean;  // Create new issue if not exists
+  createIssue?: boolean; // Create new issue if not exists
 }
 
 export interface OracleSyncOutput {
@@ -134,8 +134,8 @@ export interface OracleListThreadsOutput {
 
 export interface ForumConfig {
   defaultRepo: string;
-  autoAnswer: boolean;      // Oracle auto-responds to questions
-  autoSync: boolean;        // Auto-sync to GitHub
+  autoAnswer: boolean; // Oracle auto-responds to questions
+  autoSync: boolean; // Auto-sync to GitHub
   labels: {
     question: string;
     answered: string;
@@ -146,10 +146,10 @@ export interface ForumConfig {
 export const DEFAULT_FORUM_CONFIG: ForumConfig = {
   defaultRepo: process.env.ORACLE_FORUM_REPO || 'laris-co/Nat-s-Agents',
   autoAnswer: true,
-  autoSync: false,  // Manual sync by default
+  autoSync: false, // Manual sync by default
   labels: {
     question: 'oracle-thread',
     answered: 'oracle-answered',
-    pending: 'oracle-pending'
-  }
+    pending: 'oracle-pending',
+  },
 };

--- a/src/governance/routes.ts
+++ b/src/governance/routes.ts
@@ -19,7 +19,11 @@ function decorateRule(rule: any) {
   if (rule.type === 'decree' && rule.approval_status === 'rejected') {
     return { ...rule, status: 'rejected' };
   }
-  if (rule.type === 'decree' && rule.status === 'active' && (rule.approval_status === 'approved' || rule.approval_status === null)) {
+  if (
+    rule.type === 'decree' &&
+    rule.status === 'active' &&
+    (rule.approval_status === 'approved' || rule.approval_status === null)
+  ) {
     const enforcementLevel = (rule.enforcement || 'must').toLowerCase();
     const keyword = enforcementLevel === 'should' ? 'IMPORTANT: SHOULD' : 'IMPORTANT: MUST';
     return { ...rule, enforcement_text: `${keyword} — ${rule.title}` };
@@ -27,8 +31,13 @@ function decorateRule(rule: any) {
   return rule;
 }
 
-export function registerGovernanceRoutes(app: OpenAPIHono, sqlite: Database, helpers: GovernanceHelpers) {
-  const { hasSessionAuth, requireBeastIdentity, addMessage, sendDm, withRetry, wsBroadcast } = helpers;
+export function registerGovernanceRoutes(
+  app: OpenAPIHono,
+  sqlite: Database,
+  helpers: GovernanceHelpers,
+) {
+  const { hasSessionAuth, requireBeastIdentity, addMessage, sendDm, withRetry, wsBroadcast } =
+    helpers;
 
   // GET /api/rules — list rules
   app.get('/api/rules', (c) => {
@@ -38,9 +47,17 @@ export function registerGovernanceRoutes(app: OpenAPIHono, sqlite: Database, hel
     const includePending = c.req.query('include_pending') === 'true';
     let query = 'SELECT * FROM rules WHERE status = ?';
     const params: any[] = [status];
-    if (!includePending) { query += " AND (approval_status IS NULL OR approval_status = 'approved')"; }
-    if (type) { query += ' AND type = ?'; params.push(type); }
-    if (scope) { query += ' AND scope = ?'; params.push(scope); }
+    if (!includePending) {
+      query += " AND (approval_status IS NULL OR approval_status = 'approved')";
+    }
+    if (type) {
+      query += ' AND type = ?';
+      params.push(type);
+    }
+    if (scope) {
+      query += ' AND scope = ?';
+      params.push(scope);
+    }
     query += " ORDER BY CASE type WHEN 'decree' THEN 0 WHEN 'norm' THEN 1 END, created_at DESC";
     const rules = (sqlite.prepare(query).all(...params) as any[]).map(decorateRule);
     return c.json({ rules, total: rules.length });
@@ -48,13 +65,25 @@ export function registerGovernanceRoutes(app: OpenAPIHono, sqlite: Database, hel
 
   // GET /api/rules/decrees — active approved decrees only
   app.get('/api/rules/decrees', (c) => {
-    const rules = (sqlite.prepare("SELECT * FROM rules WHERE type = 'decree' AND status = 'active' AND (approval_status IS NULL OR approval_status = 'approved') ORDER BY created_at DESC").all() as any[]).map(decorateRule);
+    const rules = (
+      sqlite
+        .prepare(
+          "SELECT * FROM rules WHERE type = 'decree' AND status = 'active' AND (approval_status IS NULL OR approval_status = 'approved') ORDER BY created_at DESC",
+        )
+        .all() as any[]
+    ).map(decorateRule);
     return c.json({ rules, total: rules.length });
   });
 
   // GET /api/rules/pending — pending decrees awaiting Gorn approval
   app.get('/api/rules/pending', (c) => {
-    const rules = (sqlite.prepare("SELECT * FROM rules WHERE type = 'decree' AND status = 'active' AND approval_status = 'pending' ORDER BY created_at DESC").all() as any[]).map(decorateRule);
+    const rules = (
+      sqlite
+        .prepare(
+          "SELECT * FROM rules WHERE type = 'decree' AND status = 'active' AND approval_status = 'pending' ORDER BY created_at DESC",
+        )
+        .all() as any[]
+    ).map(decorateRule);
     return c.json({ rules, total: rules.length });
   });
 
@@ -65,17 +94,29 @@ export function registerGovernanceRoutes(app: OpenAPIHono, sqlite: Database, hel
     const rule = sqlite.prepare('SELECT * FROM rules WHERE id = ?').get(id) as any;
     if (!rule) return c.json({ error: 'Rule not found' }, 404);
     if (rule.type !== 'decree') return c.json({ error: 'Only decrees need approval' }, 400);
-    if (rule.approval_status !== 'pending') return c.json({ error: 'Only pending decrees can be approved' }, 400);
+    if (rule.approval_status !== 'pending')
+      return c.json({ error: 'Only pending decrees can be approved' }, 400);
     const now = new Date().toISOString();
-    sqlite.prepare('UPDATE rules SET approval_status = ?, approved_by = ?, approved_at = ?, updated_at = ? WHERE id = ?')
+    sqlite
+      .prepare(
+        'UPDATE rules SET approval_status = ?, approved_by = ?, approved_at = ?, updated_at = ? WHERE id = ?',
+      )
       .run('approved', 'gorn', now, now, id);
     const author = rule.author?.toLowerCase();
     if (author && author !== 'gorn') {
       const msg = `Decree #${id} "${rule.title}" has been **approved** by Gorn.`;
       if (rule.source_thread_id) {
-        try { addMessage(rule.source_thread_id, 'claude', msg, { author: 'system' }); } catch { /* non-critical */ }
+        try {
+          addMessage(rule.source_thread_id, 'claude', msg, { author: 'system' });
+        } catch {
+          /* non-critical */
+        }
       }
-      try { await withRetry(() => sendDm('system', author, msg)); } catch { /* non-critical */ }
+      try {
+        await withRetry(() => sendDm('system', author, msg));
+      } catch {
+        /* non-critical */
+      }
       wsBroadcast('decree_approved', { id, title: rule.title, author });
     }
     return c.json(decorateRule(sqlite.prepare('SELECT * FROM rules WHERE id = ?').get(id)));
@@ -88,31 +129,51 @@ export function registerGovernanceRoutes(app: OpenAPIHono, sqlite: Database, hel
     const rule = sqlite.prepare('SELECT * FROM rules WHERE id = ?').get(id) as any;
     if (!rule) return c.json({ error: 'Rule not found' }, 404);
     if (rule.type !== 'decree') return c.json({ error: 'Only decrees can be rejected' }, 400);
-    if (rule.approval_status !== 'pending') return c.json({ error: 'Only pending decrees can be rejected' }, 400);
+    if (rule.approval_status !== 'pending')
+      return c.json({ error: 'Only pending decrees can be rejected' }, 400);
     try {
       const data = await c.req.json();
       const reason = data.reason || '';
       const now = new Date().toISOString();
-      sqlite.prepare('UPDATE rules SET approval_status = ?, rejection_reason = ?, updated_at = ? WHERE id = ?')
+      sqlite
+        .prepare(
+          'UPDATE rules SET approval_status = ?, rejection_reason = ?, updated_at = ? WHERE id = ?',
+        )
         .run('rejected', reason, now, id);
       const author = rule.author?.toLowerCase();
       if (author && author !== 'gorn') {
         const msg = `Decree #${id} "${rule.title}" has been **rejected** by Gorn.${reason ? ` Reason: ${reason}` : ''}`;
         if (rule.source_thread_id) {
-          try { addMessage(rule.source_thread_id, 'claude', msg, { author: 'system' }); } catch { /* non-critical */ }
+          try {
+            addMessage(rule.source_thread_id, 'claude', msg, { author: 'system' });
+          } catch {
+            /* non-critical */
+          }
         }
-        try { await withRetry(() => sendDm('system', author, msg)); } catch { /* non-critical */ }
+        try {
+          await withRetry(() => sendDm('system', author, msg));
+        } catch {
+          /* non-critical */
+        }
         wsBroadcast('decree_rejected', { id, title: rule.title, author, reason });
       }
       return c.json(decorateRule(sqlite.prepare('SELECT * FROM rules WHERE id = ?').get(id)));
-    } catch { return c.json({ error: 'Invalid request' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
   });
 
   // GET /api/rules/markdown — all active rules as plain markdown (T#426)
   app.get('/api/rules/markdown', (c) => {
-    const rules = (sqlite.prepare("SELECT * FROM rules WHERE status = 'active' AND (approval_status IS NULL OR approval_status = 'approved') ORDER BY CASE type WHEN 'decree' THEN 0 WHEN 'norm' THEN 1 END, created_at DESC").all() as any[]).map(decorateRule);
-    const decrees = rules.filter(r => r.type === 'decree');
-    const norms = rules.filter(r => r.type === 'norm');
+    const rules = (
+      sqlite
+        .prepare(
+          "SELECT * FROM rules WHERE status = 'active' AND (approval_status IS NULL OR approval_status = 'approved') ORDER BY CASE type WHEN 'decree' THEN 0 WHEN 'norm' THEN 1 END, created_at DESC",
+        )
+        .all() as any[]
+    ).map(decorateRule);
+    const decrees = rules.filter((r) => r.type === 'decree');
+    const norms = rules.filter((r) => r.type === 'norm');
     let md = '';
     if (decrees.length) {
       md += '## Decrees\n\n';
@@ -128,7 +189,11 @@ export function registerGovernanceRoutes(app: OpenAPIHono, sqlite: Database, hel
 
   // GET /api/rules/norms — active norms only
   app.get('/api/rules/norms', (c) => {
-    const rules = sqlite.prepare("SELECT * FROM rules WHERE type = 'norm' AND status = 'active' ORDER BY created_at DESC").all();
+    const rules = sqlite
+      .prepare(
+        "SELECT * FROM rules WHERE type = 'norm' AND status = 'active' ORDER BY created_at DESC",
+      )
+      .all();
     return c.json({ rules, total: (rules as any[]).length });
   });
 
@@ -145,30 +210,61 @@ export function registerGovernanceRoutes(app: OpenAPIHono, sqlite: Database, hel
     try {
       const data = await c.req.json();
       const { type, title, content, scope, source_thread_id } = data;
-      if (!type || !title || !content) return c.json({ error: 'type, title, content required' }, 400);
-      if (!['decree', 'norm'].includes(type)) return c.json({ error: 'type must be decree or norm' }, 400);
+      if (!type || !title || !content)
+        return c.json({ error: 'type, title, content required' }, 400);
+      if (!['decree', 'norm'].includes(type))
+        return c.json({ error: 'type must be decree or norm' }, 400);
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       if (data.author && data.author.toLowerCase() !== caller) {
-        return c.json({ error: 'Author impersonation blocked. body.author must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Author impersonation blocked. body.author must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const author = caller;
       if (type === 'decree' && !['leonard', 'gorn'].includes(author)) {
         return c.json({ error: 'Only Leonard and Gorn can create decrees' }, 403);
       }
       const enforcement = type === 'decree' ? 'mandatory' : 'recommended';
-      const approvalStatus = type === 'decree' && author !== 'gorn' ? 'pending' : (type === 'decree' ? 'approved' : null);
+      const approvalStatus =
+        type === 'decree' && author !== 'gorn' ? 'pending' : type === 'decree' ? 'approved' : null;
       const approvedBy = type === 'decree' && author === 'gorn' ? 'gorn' : null;
       const approvedAt = type === 'decree' && author === 'gorn' ? new Date().toISOString() : null;
       const now = new Date().toISOString();
-      const result = sqlite.prepare(
-        'INSERT INTO rules (type, title, content, author, enforcement, scope, source_thread_id, approval_status, approved_by, approved_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-      ).run(type, title, content, author, enforcement, scope || 'all', source_thread_id || null, approvalStatus, approvedBy, approvedAt, now, now);
-      const rule = sqlite.prepare('SELECT * FROM rules WHERE id = ?').get((result as any).lastInsertRowid);
+      const result = sqlite
+        .prepare(
+          'INSERT INTO rules (type, title, content, author, enforcement, scope, source_thread_id, approval_status, approved_by, approved_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        )
+        .run(
+          type,
+          title,
+          content,
+          author,
+          enforcement,
+          scope || 'all',
+          source_thread_id || null,
+          approvalStatus,
+          approvedBy,
+          approvedAt,
+          now,
+          now,
+        );
+      const rule = sqlite
+        .prepare('SELECT * FROM rules WHERE id = ?')
+        .get((result as any).lastInsertRowid);
       return c.json(decorateRule(rule), 201);
-    } catch { return c.json({ error: 'Invalid request' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
   });
 
   // PATCH /api/rules/:id — update rule
@@ -180,30 +276,56 @@ export function registerGovernanceRoutes(app: OpenAPIHono, sqlite: Database, hel
       const data = await c.req.json();
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       const claimed = (data.author || data.beast || c.req.query('as') || '').toLowerCase();
       if (claimed && claimed !== caller) {
-        return c.json({ error: 'Identity spoof blocked. body.author/beast or ?as= must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Identity spoof blocked. body.author/beast or ?as= must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const requester = caller;
       if (rule.type === 'decree' && !['leonard', 'gorn'].includes(requester)) {
         return c.json({ error: 'Only Leonard and Gorn can edit decrees' }, 403);
       }
-      if (rule.type === 'norm' && requester !== rule.author && requester !== 'leonard' && requester !== 'gorn') {
+      if (
+        rule.type === 'norm' &&
+        requester !== rule.author &&
+        requester !== 'leonard' &&
+        requester !== 'gorn'
+      ) {
         return c.json({ error: 'Only the author or Leonard can edit norms' }, 403);
       }
       const updates: string[] = [];
       const values: any[] = [];
-      if (data.title) { updates.push('title = ?'); values.push(data.title); }
-      if (data.content) { updates.push('content = ?'); values.push(data.content); }
-      if (data.scope) { updates.push('scope = ?'); values.push(data.scope); }
+      if (data.title) {
+        updates.push('title = ?');
+        values.push(data.title);
+      }
+      if (data.content) {
+        updates.push('content = ?');
+        values.push(data.content);
+      }
+      if (data.scope) {
+        updates.push('scope = ?');
+        values.push(data.scope);
+      }
       if (updates.length === 0) return c.json({ error: 'No fields to update' }, 400);
-      updates.push('updated_at = ?'); values.push(new Date().toISOString());
+      updates.push('updated_at = ?');
+      values.push(new Date().toISOString());
       values.push(id);
       sqlite.prepare(`UPDATE rules SET ${updates.join(', ')} WHERE id = ?`).run(...values);
       return c.json(decorateRule(sqlite.prepare('SELECT * FROM rules WHERE id = ?').get(id)));
-    } catch { return c.json({ error: 'Invalid request' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
   });
 
   // PATCH /api/rules/:id/archive — archive rule
@@ -216,23 +338,42 @@ export function registerGovernanceRoutes(app: OpenAPIHono, sqlite: Database, hel
       const data = await c.req.json();
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       const claimed = (data.author || data.beast || c.req.query('as') || '').toLowerCase();
       if (claimed && claimed !== caller) {
-        return c.json({ error: 'Identity spoof blocked. body.author/beast or ?as= must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Identity spoof blocked. body.author/beast or ?as= must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const requester = caller;
       if (rule.type === 'decree' && !['leonard', 'gorn'].includes(requester)) {
         return c.json({ error: 'Only Leonard and Gorn can archive decrees' }, 403);
       }
-      if (rule.type === 'norm' && requester !== rule.author && requester !== 'leonard' && requester !== 'gorn') {
+      if (
+        rule.type === 'norm' &&
+        requester !== rule.author &&
+        requester !== 'leonard' &&
+        requester !== 'gorn'
+      ) {
         return c.json({ error: 'Only the author or Leonard can archive norms' }, 403);
       }
       const now = new Date().toISOString();
-      sqlite.prepare('UPDATE rules SET status = ?, archived_at = ?, archived_by = ?, updated_at = ? WHERE id = ?')
+      sqlite
+        .prepare(
+          'UPDATE rules SET status = ?, archived_at = ?, archived_by = ?, updated_at = ? WHERE id = ?',
+        )
         .run('archived', now, requester, now, id);
       return c.json(decorateRule(sqlite.prepare('SELECT * FROM rules WHERE id = ?').get(id)));
-    } catch { return c.json({ error: 'Invalid request' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
   });
 }

--- a/src/guest/routes.ts
+++ b/src/guest/routes.ts
@@ -5,20 +5,38 @@ import * as path from 'path';
 import { getFullThread, handleThreadMessage } from '../forum/handler.ts';
 import { sendDm, getMessages as getDmMessages } from '../dm/handler.ts';
 import { getBeastProfile } from '../db/index.ts';
-import { getGuestByUsername, changeGuestPassword, updateGuestProfile } from '../server/guest-accounts.ts';
-import { checkGuestPostRate, checkGuestDmRate, checkGuestContentLength, scanForInjection } from '../server/guest-safety.ts';
+import {
+  getGuestByUsername,
+  changeGuestPassword,
+  updateGuestProfile,
+} from '../server/guest-accounts.ts';
+import {
+  checkGuestPostRate,
+  checkGuestDmRate,
+  checkGuestContentLength,
+  scanForInjection,
+} from '../server/guest-safety.ts';
 import { logSecurityEvent } from '../server/security-logger.ts';
 
 interface GuestHelpers {
   wsBroadcast: (event: string, data: any) => void;
   withRetry: <T>(fn: () => T | Promise<T>, maxRetries?: number, delayMs?: number) => Promise<T>;
-  getTmuxStatus: () => { tmuxStatus: Map<string, string>; contextPctMap: Map<string, number | null> };
+  getTmuxStatus: () => {
+    tmuxStatus: Map<string, string>;
+    contextPctMap: Map<string, number | null>;
+  };
   normalizeAvatarUrl: (url: string | null) => string | null;
   uploadsDir: string;
 }
 
 export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers: GuestHelpers) {
-  const { wsBroadcast, withRetry, getTmuxStatus, normalizeAvatarUrl, uploadsDir: UPLOADS_DIR } = helpers;
+  const {
+    wsBroadcast,
+    withRetry,
+    getTmuxStatus,
+    normalizeAvatarUrl,
+    uploadsDir: UPLOADS_DIR,
+  } = helpers;
 
   // Password change rate limiting: max 5 attempts per guest per 15 minutes
   const passwordChangeAttempts = new Map<string, { count: number; firstAttempt: number }>();
@@ -27,7 +45,9 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // Resolve guest display name from username
   function getGuestDisplayName(username: string): string {
-    const guest = sqlite.query('SELECT display_name FROM guest_accounts WHERE username = ?').get(username) as any;
+    const guest = sqlite
+      .query('SELECT display_name FROM guest_accounts WHERE username = ?')
+      .get(username) as any;
     return guest?.display_name || username;
   }
 
@@ -35,40 +55,56 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
   app.get('/api/guest/dashboard', (c) => {
     const guestUsername = (c.get as any)('guestUsername') as string | undefined;
 
-    const publicThreads = sqlite.prepare(
-      "SELECT id, title, status, created_at, (SELECT COUNT(*) FROM forum_messages WHERE thread_id = forum_threads.id) as msg_count FROM forum_threads WHERE visibility = 'public' ORDER BY updated_at DESC LIMIT 10"
-    ).all() as any[];
+    const publicThreads = sqlite
+      .prepare(
+        "SELECT id, title, status, created_at, (SELECT COUNT(*) FROM forum_messages WHERE thread_id = forum_threads.id) as msg_count FROM forum_threads WHERE visibility = 'public' ORDER BY updated_at DESC LIMIT 10",
+      )
+      .all() as any[];
 
-    const beasts = sqlite.prepare(
-      "SELECT name, display_name, animal, role, bio, theme_color FROM beast_profiles ORDER BY name"
-    ).all() as any[];
+    const beasts = sqlite
+      .prepare(
+        'SELECT name, display_name, animal, role, bio, theme_color FROM beast_profiles ORDER BY name',
+      )
+      .all() as any[];
 
     let dmSummary: any[] = [];
     let dmUnreadTotal = 0;
     if (guestUsername) {
       const guestDisplayName = getGuestDisplayName(guestUsername);
       const guestTag = `[Guest] ${guestDisplayName}`;
-      const convos = sqlite.prepare(
-        "SELECT c.id, CASE WHEN participant1 = ? THEN participant2 ELSE participant1 END as other, (SELECT content FROM dm_messages WHERE conversation_id = c.id ORDER BY created_at DESC LIMIT 1) as last_message, (SELECT created_at FROM dm_messages WHERE conversation_id = c.id ORDER BY created_at DESC LIMIT 1) as last_at FROM dm_conversations c WHERE participant1 = ? OR participant2 = ? ORDER BY last_at DESC LIMIT 10"
-      ).all(guestTag, guestTag, guestTag) as any[];
+      const convos = sqlite
+        .prepare(
+          'SELECT c.id, CASE WHEN participant1 = ? THEN participant2 ELSE participant1 END as other, (SELECT content FROM dm_messages WHERE conversation_id = c.id ORDER BY created_at DESC LIMIT 1) as last_message, (SELECT created_at FROM dm_messages WHERE conversation_id = c.id ORDER BY created_at DESC LIMIT 1) as last_at FROM dm_conversations c WHERE participant1 = ? OR participant2 = ? ORDER BY last_at DESC LIMIT 10',
+        )
+        .all(guestTag, guestTag, guestTag) as any[];
       for (const conv of convos) {
-        const unread = (sqlite.prepare(
-          "SELECT COUNT(*) as c FROM dm_messages WHERE conversation_id = ? AND LOWER(sender) != ? AND read_at IS NULL"
-        ).get(conv.id, guestTag.toLowerCase()) as any)?.c || 0;
-        dmSummary.push({ other: conv.other, last_message: conv.last_message, last_at: conv.last_at, unread });
+        const unread =
+          (
+            sqlite
+              .prepare(
+                'SELECT COUNT(*) as c FROM dm_messages WHERE conversation_id = ? AND LOWER(sender) != ? AND read_at IS NULL',
+              )
+              .get(conv.id, guestTag.toLowerCase()) as any
+          )?.c || 0;
+        dmSummary.push({
+          other: conv.other,
+          last_message: conv.last_message,
+          last_at: conv.last_at,
+          unread,
+        });
         dmUnreadTotal += unread;
       }
     }
 
     return c.json({
-      publicThreads: publicThreads.map(t => ({
+      publicThreads: publicThreads.map((t) => ({
         id: t.id,
         title: t.title,
         status: t.status,
         message_count: t.msg_count || 0,
         created_at: new Date(t.created_at).toISOString(),
       })),
-      pack: beasts.map(b => ({
+      pack: beasts.map((b) => ({
         name: b.name,
         displayName: b.display_name,
         animal: b.animal,
@@ -86,19 +122,28 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const limit = parseInt(c.req.query('limit') || '50');
     const offset = parseInt(c.req.query('offset') || '0');
 
-    const rows = sqlite.prepare(
-      "SELECT *, (SELECT COUNT(*) FROM forum_messages WHERE thread_id = forum_threads.id) as msg_count FROM forum_threads WHERE visibility = 'public' AND deleted_at IS NULL ORDER BY COALESCE(pinned, 0) DESC, updated_at DESC LIMIT ? OFFSET ?"
-    ).all(limit, offset) as any[];
+    const rows = sqlite
+      .prepare(
+        "SELECT *, (SELECT COUNT(*) FROM forum_messages WHERE thread_id = forum_threads.id) as msg_count FROM forum_threads WHERE visibility = 'public' AND deleted_at IS NULL ORDER BY COALESCE(pinned, 0) DESC, updated_at DESC LIMIT ? OFFSET ?",
+      )
+      .all(limit, offset) as any[];
 
-    const total = (sqlite.prepare("SELECT COUNT(*) as total FROM forum_threads WHERE visibility = 'public' AND deleted_at IS NULL").get() as any)?.total || 0;
+    const total =
+      (
+        sqlite
+          .prepare(
+            "SELECT COUNT(*) as total FROM forum_threads WHERE visibility = 'public' AND deleted_at IS NULL",
+          )
+          .get() as any
+      )?.total || 0;
 
     return c.json({
-      threads: rows.map(t => ({
+      threads: rows.map((t) => ({
         id: t.id,
         title: t.title,
         status: t.status || 'active',
         category: t.category || 'discussion',
-        pinned: !!(t.pinned),
+        pinned: !!t.pinned,
         message_count: t.msg_count || 0,
         created_at: new Date(t.created_at).toISOString(),
         visibility: 'public',
@@ -112,7 +157,9 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const threadId = parseInt(c.req.param('id'), 10);
     if (isNaN(threadId)) return c.json({ error: 'Invalid thread ID' }, 400);
 
-    const threadRow = sqlite.prepare('SELECT * FROM forum_threads WHERE id = ? AND visibility = ?').get(threadId, 'public') as any;
+    const threadRow = sqlite
+      .prepare('SELECT * FROM forum_threads WHERE id = ? AND visibility = ?')
+      .get(threadId, 'public') as any;
     if (!threadRow) return c.json({ error: 'Thread not found' }, 404);
 
     const rawLimit = c.req.query('limit');
@@ -132,15 +179,23 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
         status: threadData.thread.status,
         created_at: new Date(threadData.thread.createdAt).toISOString(),
       },
-      messages: threadData.messages.map(m => {
-        const raw = sqlite.prepare('SELECT reply_to_id FROM forum_messages WHERE id = ?').get(m.id) as any;
-        const reactionRows = sqlite.prepare(
-          'SELECT emoji, GROUP_CONCAT(beast_name) as beasts, COUNT(*) as count FROM forum_reactions WHERE message_id = ? GROUP BY emoji'
-        ).all(m.id) as any[];
+      messages: threadData.messages.map((m) => {
+        const raw = sqlite
+          .prepare('SELECT reply_to_id FROM forum_messages WHERE id = ?')
+          .get(m.id) as any;
+        const reactionRows = sqlite
+          .prepare(
+            'SELECT emoji, GROUP_CONCAT(beast_name) as beasts, COUNT(*) as count FROM forum_reactions WHERE message_id = ? GROUP BY emoji',
+          )
+          .all(m.id) as any[];
         let authorAvatarUrl: string | null = null;
         if (m.author?.startsWith('[Guest]')) {
           const guestName = m.author.replace('[Guest] ', '').replace('[Guest]', '').trim();
-          const guest = sqlite.prepare('SELECT avatar_url FROM guest_accounts WHERE LOWER(display_name) = ? OR LOWER(username) = ?').get(guestName.toLowerCase(), guestName.toLowerCase()) as any;
+          const guest = sqlite
+            .prepare(
+              'SELECT avatar_url FROM guest_accounts WHERE LOWER(display_name) = ? OR LOWER(username) = ?',
+            )
+            .get(guestName.toLowerCase(), guestName.toLowerCase()) as any;
           authorAvatarUrl = guest?.avatar_url || null;
         }
         return {
@@ -153,7 +208,11 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
           principles_found: m.principlesFound,
           patterns_found: m.patternsFound,
           created_at: new Date(m.createdAt).toISOString(),
-          reactions: reactionRows.map(r => ({ emoji: r.emoji, beasts: r.beasts.split(','), count: r.count })),
+          reactions: reactionRows.map((r) => ({
+            emoji: r.emoji,
+            beasts: r.beasts.split(','),
+            count: r.count,
+          })),
         };
       }),
       total: threadData.total,
@@ -165,7 +224,9 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const threadId = parseInt(c.req.param('id'), 10);
     if (isNaN(threadId)) return c.json({ error: 'Invalid thread ID' }, 400);
 
-    const threadRow = sqlite.prepare('SELECT visibility FROM forum_threads WHERE id = ?').get(threadId) as any;
+    const threadRow = sqlite
+      .prepare('SELECT visibility FROM forum_threads WHERE id = ?')
+      .get(threadId) as any;
     if (!threadRow || threadRow.visibility !== 'public') {
       return c.json({ error: 'Thread not found' }, 404);
     }
@@ -196,17 +257,23 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
     const guestDisplayName = getGuestDisplayName(guestUsername);
     const author = `[Guest] ${guestDisplayName}`;
-    const result = await withRetry(() => handleThreadMessage({
-      message: data.message,
-      threadId,
-      role: 'human',
-      author,
-    }));
+    const result = await withRetry(() =>
+      handleThreadMessage({
+        message: data.message,
+        threadId,
+        role: 'human',
+        author,
+      }),
+    );
 
     if (result.messageId) {
-      sqlite.prepare('UPDATE forum_messages SET author_role = ? WHERE id = ?').run('guest', result.messageId);
+      sqlite
+        .prepare('UPDATE forum_messages SET author_role = ? WHERE id = ?')
+        .run('guest', result.messageId);
       if (data.reply_to_id) {
-        sqlite.prepare('UPDATE forum_messages SET reply_to_id = ? WHERE id = ?').run(data.reply_to_id, result.messageId);
+        sqlite
+          .prepare('UPDATE forum_messages SET reply_to_id = ? WHERE id = ?')
+          .run(data.reply_to_id, result.messageId);
       }
     }
 
@@ -235,7 +302,10 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
         actor: guestUsername,
         actorType: 'guest',
         target: '/api/guest/thread',
-        details: { patterns: scan.patterns, content_preview: (data.title + ': ' + data.message).slice(0, 200) },
+        details: {
+          patterns: scan.patterns,
+          content_preview: (data.title + ': ' + data.message).slice(0, 200),
+        },
         ipSource: c.req.header('x-real-ip') || 'local',
         requestId: (c.get as any)('requestId'),
       });
@@ -243,46 +313,69 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
     const guestDisplayName = getGuestDisplayName(guestUsername);
     const author = `[Guest] ${guestDisplayName}`;
-    const result = await withRetry(() => handleThreadMessage({
-      message: data.message,
-      title: data.title,
-      role: 'human',
-      author,
-    }));
+    const result = await withRetry(() =>
+      handleThreadMessage({
+        message: data.message,
+        title: data.title,
+        role: 'human',
+        author,
+      }),
+    );
 
     if (result.threadId) {
-      sqlite.prepare('UPDATE forum_threads SET visibility = ? WHERE id = ?').run('public', result.threadId);
+      sqlite
+        .prepare('UPDATE forum_threads SET visibility = ? WHERE id = ?')
+        .run('public', result.threadId);
 
       if (!data.thread_id) {
         try {
           const { getOracleRegistry, notifyMentioned } = await import('../forum/mentions.ts');
           const registry = getOracleRegistry();
           const threadTitle = data.title || data.message?.slice(0, 50) || 'New thread';
-          const allBeasts = Object.keys(registry).filter(name => name !== 'gorn');
-          notifyMentioned(allBeasts, result.threadId, threadTitle, author, `New public thread from guest: ${threadTitle}`, undefined, new Set(allBeasts));
-        } catch { /* best effort */ }
+          const allBeasts = Object.keys(registry).filter((name) => name !== 'gorn');
+          notifyMentioned(
+            allBeasts,
+            result.threadId,
+            threadTitle,
+            author,
+            `New public thread from guest: ${threadTitle}`,
+            undefined,
+            new Set(allBeasts),
+          );
+        } catch {
+          /* best effort */
+        }
       }
     }
     if (result.messageId) {
-      sqlite.prepare('UPDATE forum_messages SET author_role = ? WHERE id = ?').run('guest', result.messageId);
+      sqlite
+        .prepare('UPDATE forum_messages SET author_role = ? WHERE id = ?')
+        .run('guest', result.messageId);
     }
 
-    wsBroadcast('new_message', { thread_id: result.threadId, message_id: result.messageId, author });
+    wsBroadcast('new_message', {
+      thread_id: result.threadId,
+      message_id: result.messageId,
+      author,
+    });
     return c.json({ thread_id: result.threadId, message_id: result.messageId }, 201);
   });
 
   // Guest pack — Beast profiles (T#559)
   app.get('/api/guest/pack', (c) => {
-    const beasts = sqlite.prepare(
-      "SELECT name, display_name, animal, role, bio, theme_color, avatar_url, interests, sex, birthdate FROM beast_profiles ORDER BY name"
-    ).all() as any[];
+    const beasts = sqlite
+      .prepare(
+        'SELECT name, display_name, animal, role, bio, theme_color, avatar_url, interests, sex, birthdate FROM beast_profiles ORDER BY name',
+      )
+      .all() as any[];
 
     const { tmuxStatus } = getTmuxStatus();
 
     return c.json({
-      beasts: beasts.map(b => {
+      beasts: beasts.map((b) => {
         const sessionName = b.name.charAt(0).toUpperCase() + b.name.slice(1);
-        const rawStatus = tmuxStatus.get(sessionName.toLowerCase()) || tmuxStatus.get(b.name) || 'offline';
+        const rawStatus =
+          tmuxStatus.get(sessionName.toLowerCase()) || tmuxStatus.get(b.name) || 'offline';
         return {
           name: b.name,
           displayName: b.display_name,
@@ -310,12 +403,18 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const guestDisplayName = getGuestDisplayName(guestUsername);
     const guestTag = `[Guest] ${guestDisplayName}`;
 
-    if (fromParam !== guestTag && toParam !== guestTag && fromParam !== guestUsername && toParam !== guestUsername) {
+    if (
+      fromParam !== guestTag &&
+      toParam !== guestTag &&
+      fromParam !== guestUsername &&
+      toParam !== guestUsername
+    ) {
       return c.json({ error: 'Access denied' }, 403);
     }
 
-    const from = (fromParam === guestUsername || fromParam === guestDisplayName) ? guestTag : fromParam;
-    const to = (toParam === guestUsername || toParam === guestDisplayName) ? guestTag : toParam;
+    const from =
+      fromParam === guestUsername || fromParam === guestDisplayName ? guestTag : fromParam;
+    const to = toParam === guestUsername || toParam === guestDisplayName ? guestTag : toParam;
 
     const limit = parseInt(c.req.query('limit') || '50');
     const offset = parseInt(c.req.query('offset') || '0');
@@ -329,8 +428,8 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
     return c.json({
       conversation_id: data.conversationId,
-      participants: data.participants.map(p => normalizeGuestSender(p)),
-      messages: data.messages.map(m => ({
+      participants: data.participants.map((p) => normalizeGuestSender(p)),
+      messages: data.messages.map((m) => ({
         id: m.id,
         sender: normalizeGuestSender(m.sender),
         message: m.content,
@@ -350,7 +449,10 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const recipientBeast = getBeastProfile(data.to);
     const isOwner = data.to.toLowerCase() === 'gorn';
     if (!recipientBeast && !isOwner) {
-      return c.json({ error: `Recipient "${data.to}" not found. Must be a valid beast name.` }, 404);
+      return c.json(
+        { error: `Recipient "${data.to}" not found. Must be a valid beast name.` },
+        404,
+      );
     }
 
     const rateCheck = checkGuestDmRate(guestUsername);
@@ -375,12 +477,18 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
     const guestDisplayName = getGuestDisplayName(guestUsername);
     const guestTag = `[Guest] ${guestDisplayName}`;
-    const result = await withRetry(() => sendDm(guestTag, data.to, data.message, `[Guest] ${guestUsername}`));
+    const result = await withRetry(() =>
+      sendDm(guestTag, data.to, data.message, `[Guest] ${guestUsername}`),
+    );
 
     if (result.messageId) {
       try {
-        sqlite.prepare('UPDATE dm_messages SET author_role = ? WHERE id = ?').run('guest', result.messageId);
-      } catch { /* column may not exist */ }
+        sqlite
+          .prepare('UPDATE dm_messages SET author_role = ? WHERE id = ?')
+          .run('guest', result.messageId);
+      } catch {
+        /* column may not exist */
+      }
     }
 
     wsBroadcast('new_dm', { conversation_id: result.conversationId });
@@ -401,7 +509,9 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       if (now - attempts.firstAttempt > PASSWORD_CHANGE_RATE_WINDOW_MS) {
         passwordChangeAttempts.delete(guestUsername);
       } else if (attempts.count >= PASSWORD_CHANGE_RATE_LIMIT) {
-        const retryAfter = Math.ceil((attempts.firstAttempt + PASSWORD_CHANGE_RATE_WINDOW_MS - now) / 1000);
+        const retryAfter = Math.ceil(
+          (attempts.firstAttempt + PASSWORD_CHANGE_RATE_WINDOW_MS - now) / 1000,
+        );
         logSecurityEvent({
           eventType: 'rate_limited',
           severity: 'warning',
@@ -409,10 +519,18 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
           actorType: 'guest',
           target: '/api/guest/change-password',
           details: { attempts: attempts.count, window_ms: PASSWORD_CHANGE_RATE_WINDOW_MS },
-          ipSource: c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || '127.0.0.1',
+          ipSource:
+            c.req.header('x-real-ip') ||
+            c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+            '127.0.0.1',
           requestId: (c.get as any)('requestId'),
         });
-        return c.json({ error: `Too many password change attempts. Try again in ${Math.ceil(retryAfter / 60)} minutes.` }, 429);
+        return c.json(
+          {
+            error: `Too many password change attempts. Try again in ${Math.ceil(retryAfter / 60)} minutes.`,
+          },
+          429,
+        );
       }
     }
 
@@ -421,7 +539,12 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       return c.json({ error: 'current_password and new_password required' }, 400);
     }
 
-    const result = await changeGuestPassword(sqlite, guest, body.current_password, body.new_password);
+    const result = await changeGuestPassword(
+      sqlite,
+      guest,
+      body.current_password,
+      body.new_password,
+    );
     if (!result.success) {
       const existing = passwordChangeAttempts.get(guestUsername);
       if (existing) {
@@ -450,7 +573,9 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       if (now - attempts.firstAttempt > PASSWORD_CHANGE_RATE_WINDOW_MS) {
         passwordChangeAttempts.delete(guestUsername);
       } else if (attempts.count >= PASSWORD_CHANGE_RATE_LIMIT) {
-        const retryAfter = Math.ceil((attempts.firstAttempt + PASSWORD_CHANGE_RATE_WINDOW_MS - now) / 1000);
+        const retryAfter = Math.ceil(
+          (attempts.firstAttempt + PASSWORD_CHANGE_RATE_WINDOW_MS - now) / 1000,
+        );
         logSecurityEvent({
           eventType: 'rate_limited',
           severity: 'warning',
@@ -458,10 +583,18 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
           actorType: 'guest',
           target: '/api/guest/reset-password',
           details: { attempts: attempts.count, window_ms: PASSWORD_CHANGE_RATE_WINDOW_MS },
-          ipSource: c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || '127.0.0.1',
+          ipSource:
+            c.req.header('x-real-ip') ||
+            c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+            '127.0.0.1',
           requestId: (c.get as any)('requestId'),
         });
-        return c.json({ error: `Too many password change attempts. Try again in ${Math.ceil(retryAfter / 60)} minutes.` }, 429);
+        return c.json(
+          {
+            error: `Too many password change attempts. Try again in ${Math.ceil(retryAfter / 60)} minutes.`,
+          },
+          429,
+        );
       }
     }
 
@@ -470,10 +603,19 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       return c.json({ error: 'current_password and new_password required' }, 400);
     }
 
-    const result = await changeGuestPassword(sqlite, guest, body.current_password, body.new_password);
+    const result = await changeGuestPassword(
+      sqlite,
+      guest,
+      body.current_password,
+      body.new_password,
+    );
     if (!result.success) {
       const existing = passwordChangeAttempts.get(guestUsername);
-      if (existing) { existing.count++; } else { passwordChangeAttempts.set(guestUsername, { count: 1, firstAttempt: now }); }
+      if (existing) {
+        existing.count++;
+      } else {
+        passwordChangeAttempts.set(guestUsername, { count: 1, firstAttempt: now });
+      }
       return c.json({ error: result.error }, 400);
     }
 
@@ -515,8 +657,26 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     }
     if (body.display_name !== undefined) {
       const RESERVED_NAMES = new Set([
-        'karo','rax','mara','leonard','bertus','gnarl','zaghnal','pip','nyx','dex',
-        'flint','quill','snap','vigil','talon','sable','gorn','admin','administrator','system',
+        'karo',
+        'rax',
+        'mara',
+        'leonard',
+        'bertus',
+        'gnarl',
+        'zaghnal',
+        'pip',
+        'nyx',
+        'dex',
+        'flint',
+        'quill',
+        'snap',
+        'vigil',
+        'talon',
+        'sable',
+        'gorn',
+        'admin',
+        'administrator',
+        'system',
       ]);
       if (RESERVED_NAMES.has(body.display_name.toLowerCase().trim())) {
         return c.json({ error: 'That display name is reserved' }, 400);
@@ -569,10 +729,17 @@ export function registerGuestRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
     const buffer = await file.arrayBuffer();
     const bytes = new Uint8Array(buffer);
-    const isJpeg = bytes[0] === 0xFF && bytes[1] === 0xD8 && bytes[2] === 0xFF;
-    const isPng = bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4E && bytes[3] === 0x47;
-    const isWebp = bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46
-      && bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50;
+    const isJpeg = bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+    const isPng = bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47;
+    const isWebp =
+      bytes[0] === 0x52 &&
+      bytes[1] === 0x49 &&
+      bytes[2] === 0x46 &&
+      bytes[3] === 0x46 &&
+      bytes[8] === 0x57 &&
+      bytes[9] === 0x45 &&
+      bytes[10] === 0x42 &&
+      bytes[11] === 0x50;
     if (!isJpeg && !isPng && !isWebp) {
       return c.json({ error: 'File content does not match an allowed image type' }, 400);
     }

--- a/src/inbox/routes.ts
+++ b/src/inbox/routes.ts
@@ -26,13 +26,16 @@ export function registerInboxRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       const timeStr = `${String(now.getHours()).padStart(2, '0')}-${String(now.getMinutes()).padStart(2, '0')}`;
 
       // Generate slug
-      const slug = data.slug || data.content
-        .substring(0, 50)
-        .toLowerCase()
-        .replace(/[^a-z0-9\s-]/g, '')
-        .replace(/\s+/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '') || 'handoff';
+      const slug =
+        data.slug ||
+        data.content
+          .substring(0, 50)
+          .toLowerCase()
+          .replace(/[^a-z0-9\s-]/g, '')
+          .replace(/\s+/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-|-$/g, '') ||
+        'handoff';
 
       const filename = `${dateStr}_${timeStr}_${slug}.md`;
       const dirPath = path.join(REPO_ROOT, 'ψ/inbox/handoff');
@@ -47,9 +50,14 @@ export function registerInboxRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       let restedBeast: string | null = null;
       const asParam = c.req.query('as')?.toLowerCase();
       if (asParam && isTrustedRequest(c)) {
-        const beastRow = sqlite.prepare('SELECT name FROM beast_profiles WHERE name = ?').get(asParam) as any;
+        const beastRow = sqlite
+          .prepare('SELECT name FROM beast_profiles WHERE name = ?')
+          .get(asParam) as any;
         if (beastRow) {
-          sqlite.prepare("UPDATE beast_profiles SET rest_status = 'rest', updated_at = ? WHERE name = ?")
+          sqlite
+            .prepare(
+              "UPDATE beast_profiles SET rest_status = 'rest', updated_at = ? WHERE name = ?",
+            )
             .run(Date.now(), asParam);
           restedBeast = asParam;
           console.log(`[Handoff] ${asParam} → rest_status=rest`);
@@ -57,18 +65,24 @@ export function registerInboxRoutes(app: OpenAPIHono, sqlite: Database, helpers:
         }
       }
 
-      return c.json({
-        success: true,
-        file: `ψ/inbox/handoff/${filename}`,
-        rested_beast: restedBeast,
-        message: restedBeast
-          ? `Handoff written. ${restedBeast} → rest_status=rest. Schedules paused until /wake.`
-          : 'Handoff written.'
-      }, 201);
+      return c.json(
+        {
+          success: true,
+          file: `ψ/inbox/handoff/${filename}`,
+          rested_beast: restedBeast,
+          message: restedBeast
+            ? `Handoff written. ${restedBeast} → rest_status=rest. Schedules paused until /wake.`
+            : 'Handoff written.',
+        },
+        201,
+      );
     } catch (error) {
-      return c.json({
-        error: error instanceof Error ? error.message : 'Unknown error'
-      }, 500);
+      return c.json(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        500,
+      );
     }
   });
 
@@ -78,13 +92,20 @@ export function registerInboxRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const type = c.req.query('type') || 'all';
 
     const inboxDir = path.join(REPO_ROOT, 'ψ/inbox');
-    const results: Array<{ filename: string; path: string; created: string; preview: string; type: string }> = [];
+    const results: Array<{
+      filename: string;
+      path: string;
+      created: string;
+      preview: string;
+      type: string;
+    }> = [];
 
     if (type === 'all' || type === 'handoff') {
       const handoffDir = path.join(inboxDir, 'handoff');
       if (fs.existsSync(handoffDir)) {
-        const files = fs.readdirSync(handoffDir)
-          .filter(f => f.endsWith('.md'))
+        const files = fs
+          .readdirSync(handoffDir)
+          .filter((f) => f.endsWith('.md'))
           .sort()
           .reverse();
 
@@ -123,15 +144,18 @@ export function registerInboxRoutes(app: OpenAPIHono, sqlite: Database, helpers:
         data.pattern,
         data.source,
         data.concepts,
-        data.origin,   // 'mother' | 'arthur' | 'volt' | 'human' (null = universal)
-        data.project,  // ghq-style project path (null = universal)
-        data.cwd       // Auto-detect project from cwd
+        data.origin, // 'mother' | 'arthur' | 'volt' | 'human' (null = universal)
+        data.project, // ghq-style project path (null = universal)
+        data.cwd, // Auto-detect project from cwd
       );
       return c.json(result);
     } catch (error) {
-      return c.json({
-        error: error instanceof Error ? error.message : 'Unknown error'
-      }, 500);
+      return c.json(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        500,
+      );
     }
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,7 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
 import * as schema from './db/schema.ts';
@@ -24,23 +21,44 @@ import { logMcpToolCall } from './mcp-audit.ts';
 // Tool handlers (all extracted to src/tools/)
 import type { ToolContext } from './tools/types.ts';
 import {
-  searchToolDef, handleSearch,
-  learnToolDef, handleLearn,
-  reflectToolDef, handleReflect,
-  listToolDef, handleList,
-  statsToolDef, handleStats,
-  conceptsToolDef, handleConcepts,
-  supersedeToolDef, handleSupersede,
-  handoffToolDef, handleHandoff,
-  inboxToolDef, handleInbox,
-  verifyToolDef, handleVerify,
-  scheduleAddToolDef, handleScheduleAdd,
-  scheduleListToolDef, handleScheduleList,
-  readToolDef, handleRead,
+  searchToolDef,
+  handleSearch,
+  learnToolDef,
+  handleLearn,
+  reflectToolDef,
+  handleReflect,
+  listToolDef,
+  handleList,
+  statsToolDef,
+  handleStats,
+  conceptsToolDef,
+  handleConcepts,
+  supersedeToolDef,
+  handleSupersede,
+  handoffToolDef,
+  handleHandoff,
+  inboxToolDef,
+  handleInbox,
+  verifyToolDef,
+  handleVerify,
+  scheduleAddToolDef,
+  handleScheduleAdd,
+  scheduleListToolDef,
+  handleScheduleList,
+  readToolDef,
+  handleRead,
   forumToolDefs,
-  handleThread, handleThreads, handleThreadRead, handleThreadUpdate,
+  handleThread,
+  handleThreads,
+  handleThreadRead,
+  handleThreadUpdate,
   traceToolDefs,
-  handleTrace, handleTraceList, handleTraceGet, handleTraceLink, handleTraceUnlink, handleTraceChain,
+  handleTrace,
+  handleTraceList,
+  handleTraceGet,
+  handleTraceLink,
+  handleTraceUnlink,
+  handleTraceChain,
 } from './tools/index.ts';
 
 import type {
@@ -63,11 +81,7 @@ import type {
   OracleThreadUpdateInput,
 } from './tools/index.ts';
 
-import type {
-  CreateTraceInput,
-  ListTracesInput,
-  GetTraceInput,
-} from './trace/types.ts';
+import type { CreateTraceInput, ListTracesInput, GetTraceInput } from './trace/types.ts';
 
 // Write tools that should be disabled in read-only mode
 const WRITE_TOOLS = [
@@ -103,11 +117,13 @@ class OracleMCPServer {
       dataPath: path.join(homeDir, '.chromadb'),
     });
 
-    const pkg = JSON.parse(fs.readFileSync(path.join(import.meta.dirname || __dirname, '..', 'package.json'), 'utf-8'));
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(import.meta.dirname || __dirname, '..', 'package.json'), 'utf-8'),
+    );
     this.version = pkg.version;
     this.server = new Server(
       { name: 'oracle-nightly', version: this.version },
-      { capabilities: { tools: {} } }
+      { capabilities: { tools: {} } },
     );
 
     const oracleDataDir = process.env.ORACLE_DATA_DIR || path.join(homeDir, '.oracle');
@@ -138,14 +154,19 @@ class OracleMCPServer {
       const stats = await this.vectorStore.getStats();
       if (stats.count > 0) {
         this.vectorStatus = 'connected';
-        console.error(`[VectorDB:${this.vectorStore.name}] ✓ oracle_knowledge: ${stats.count} documents`);
+        console.error(
+          `[VectorDB:${this.vectorStore.name}] ✓ oracle_knowledge: ${stats.count} documents`,
+        );
       } else {
         this.vectorStatus = 'connected';
         console.error(`[VectorDB:${this.vectorStore.name}] ✓ Connected but collection empty`);
       }
     } catch (e) {
       this.vectorStatus = 'unavailable';
-      console.error(`[VectorDB:${this.vectorStore.name}] ✗ Cannot connect:`, e instanceof Error ? e.message : String(e));
+      console.error(
+        `[VectorDB:${this.vectorStore.name}] ✗ Cannot connect:`,
+        e instanceof Error ? e.message : String(e),
+      );
     }
   }
 
@@ -175,7 +196,7 @@ class OracleMCPServer {
         {
           name: '____IMPORTANT',
           description: `ORACLE WORKFLOW GUIDE (v${this.version}):\n\n1. SEARCH & DISCOVER\n   oracle_search(query) → Find knowledge by keywords/vectors\n   oracle_read(file/id) → Read full document content\n   oracle_list() → Browse all documents\n   oracle_concepts() → See topic coverage\n\n2. REFLECT\n   oracle_reflect() → Random wisdom for alignment\n\n3. LEARN & REMEMBER\n   oracle_learn(pattern) → Add new patterns/learnings\n   oracle_thread(message) → Multi-turn discussions\n   ⚠️ BEFORE adding: search for similar topics first!\n   If updating old info → use oracle_supersede(oldId, newId)\n\n4. TRACE & DISTILL\n   oracle_trace(query) → Log discovery sessions with dig points\n   oracle_trace_list() → Find past traces\n   oracle_trace_get(id) → Explore dig points (files, commits, issues)\n   oracle_trace_link(prevId, nextId) → Chain related traces together\n   oracle_trace_chain(id) → View the full linked chain\n\n5. HANDOFF & INBOX\n   oracle_handoff(content) → Save session context for next session\n   oracle_inbox() → List pending handoffs\n\n6. SCHEDULE (shared across all Oracles)\n   oracle_schedule_add(date, event) → Add appointment to shared schedule\n   oracle_schedule_list(filter?) → View upcoming events\n   Schedule lives at ~/.oracle/ψ/inbox/schedule.md (per-human, not per-project)\n\n7. SUPERSEDE (when info changes)\n   oracle_supersede(oldId, newId, reason) → Mark old doc as outdated\n   "Nothing is Deleted" — old preserved, just marked superseded\n\n7. VERIFY (health check)\n   oracle_verify(check?) → Compare ψ/ files vs DB index\n   check=true (default): read-only report\n   check=false: also flag orphaned entries\n\nPhilosophy: "Nothing is Deleted" — All interactions logged.`,
-          inputSchema: { type: 'object', properties: {} }
+          inputSchema: { type: 'object', properties: {} },
         },
         // Core tools (from src/tools/)
         searchToolDef,
@@ -199,7 +220,7 @@ class OracleMCPServer {
       ];
 
       const tools = this.readOnly
-        ? allTools.filter(t => !WRITE_TOOLS.includes(t.name))
+        ? allTools.filter((t) => !WRITE_TOOLS.includes(t.name))
         : allTools;
 
       return { tools };
@@ -212,13 +233,21 @@ class OracleMCPServer {
       const startTime = Date.now();
 
       if (this.readOnly && WRITE_TOOLS.includes(request.params.name)) {
-        logMcpToolCall(this.repoRoot, request.params.name, request.params.arguments as Record<string, unknown>, 'read_only_blocked', Date.now() - startTime);
+        logMcpToolCall(
+          this.repoRoot,
+          request.params.name,
+          request.params.arguments as Record<string, unknown>,
+          'read_only_blocked',
+          Date.now() - startTime,
+        );
         return {
-          content: [{
-            type: 'text',
-            text: `Error: Tool "${request.params.name}" is disabled in read-only mode. This Oracle instance is configured for read-only access.`
-          }],
-          isError: true
+          content: [
+            {
+              type: 'text',
+              text: `Error: Tool "${request.params.name}" is disabled in read-only mode. This Oracle instance is configured for read-only access.`,
+            },
+          ],
+          isError: true,
         };
       }
 
@@ -229,70 +258,154 @@ class OracleMCPServer {
         switch (request.params.name) {
           // Core tools (delegated to src/tools/)
           case 'oracle_search':
-            result = await handleSearch(ctx, request.params.arguments as unknown as OracleSearchInput); break;
+            result = await handleSearch(
+              ctx,
+              request.params.arguments as unknown as OracleSearchInput,
+            );
+            break;
           case 'oracle_read':
-            result = await handleRead(ctx, request.params.arguments as unknown as OracleReadInput); break;
+            result = await handleRead(ctx, request.params.arguments as unknown as OracleReadInput);
+            break;
           case 'oracle_reflect':
-            result = await handleReflect(ctx, request.params.arguments as unknown as OracleReflectInput); break;
+            result = await handleReflect(
+              ctx,
+              request.params.arguments as unknown as OracleReflectInput,
+            );
+            break;
           case 'oracle_learn':
-            result = await handleLearn(ctx, request.params.arguments as unknown as OracleLearnInput); break;
+            result = await handleLearn(
+              ctx,
+              request.params.arguments as unknown as OracleLearnInput,
+            );
+            break;
           case 'oracle_list':
-            result = await handleList(ctx, request.params.arguments as unknown as OracleListInput); break;
+            result = await handleList(ctx, request.params.arguments as unknown as OracleListInput);
+            break;
           case 'oracle_stats':
-            result = await handleStats(ctx, request.params.arguments as unknown as OracleStatsInput); break;
+            result = await handleStats(
+              ctx,
+              request.params.arguments as unknown as OracleStatsInput,
+            );
+            break;
           case 'oracle_concepts':
-            result = await handleConcepts(ctx, request.params.arguments as unknown as OracleConceptsInput); break;
+            result = await handleConcepts(
+              ctx,
+              request.params.arguments as unknown as OracleConceptsInput,
+            );
+            break;
           case 'oracle_supersede':
-            result = await handleSupersede(ctx, request.params.arguments as unknown as OracleSupersededInput); break;
+            result = await handleSupersede(
+              ctx,
+              request.params.arguments as unknown as OracleSupersededInput,
+            );
+            break;
           case 'oracle_handoff':
-            result = await handleHandoff(ctx, request.params.arguments as unknown as OracleHandoffInput); break;
+            result = await handleHandoff(
+              ctx,
+              request.params.arguments as unknown as OracleHandoffInput,
+            );
+            break;
           case 'oracle_inbox':
-            result = await handleInbox(ctx, request.params.arguments as unknown as OracleInboxInput); break;
+            result = await handleInbox(
+              ctx,
+              request.params.arguments as unknown as OracleInboxInput,
+            );
+            break;
           case 'oracle_verify':
-            result = await handleVerify(ctx, request.params.arguments as unknown as OracleVerifyInput); break;
+            result = await handleVerify(
+              ctx,
+              request.params.arguments as unknown as OracleVerifyInput,
+            );
+            break;
           case 'oracle_schedule_add':
-            result = await handleScheduleAdd(ctx, request.params.arguments as unknown as OracleScheduleAddInput); break;
+            result = await handleScheduleAdd(
+              ctx,
+              request.params.arguments as unknown as OracleScheduleAddInput,
+            );
+            break;
           case 'oracle_schedule_list':
-            result = await handleScheduleList(ctx, request.params.arguments as unknown as OracleScheduleListInput); break;
+            result = await handleScheduleList(
+              ctx,
+              request.params.arguments as unknown as OracleScheduleListInput,
+            );
+            break;
 
           // Forum tools (delegated to src/tools/forum.ts)
           case 'oracle_thread':
-            result = await handleThread(request.params.arguments as unknown as OracleThreadInput); break;
+            result = await handleThread(request.params.arguments as unknown as OracleThreadInput);
+            break;
           case 'oracle_threads':
-            result = await handleThreads(request.params.arguments as unknown as OracleThreadsInput); break;
+            result = await handleThreads(request.params.arguments as unknown as OracleThreadsInput);
+            break;
           case 'oracle_thread_read':
-            result = await handleThreadRead(request.params.arguments as unknown as OracleThreadReadInput); break;
+            result = await handleThreadRead(
+              request.params.arguments as unknown as OracleThreadReadInput,
+            );
+            break;
           case 'oracle_thread_update':
-            result = await handleThreadUpdate(request.params.arguments as unknown as OracleThreadUpdateInput); break;
+            result = await handleThreadUpdate(
+              request.params.arguments as unknown as OracleThreadUpdateInput,
+            );
+            break;
 
           // Trace tools (delegated to src/tools/trace.ts)
           case 'oracle_trace':
-            result = await handleTrace(request.params.arguments as unknown as CreateTraceInput); break;
+            result = await handleTrace(request.params.arguments as unknown as CreateTraceInput);
+            break;
           case 'oracle_trace_list':
-            result = await handleTraceList(request.params.arguments as unknown as ListTracesInput); break;
+            result = await handleTraceList(request.params.arguments as unknown as ListTracesInput);
+            break;
           case 'oracle_trace_get':
-            result = await handleTraceGet(request.params.arguments as unknown as GetTraceInput); break;
+            result = await handleTraceGet(request.params.arguments as unknown as GetTraceInput);
+            break;
           case 'oracle_trace_link':
-            result = await handleTraceLink(request.params.arguments as unknown as { prevTraceId: string; nextTraceId: string }); break;
+            result = await handleTraceLink(
+              request.params.arguments as unknown as { prevTraceId: string; nextTraceId: string },
+            );
+            break;
           case 'oracle_trace_unlink':
-            result = await handleTraceUnlink(request.params.arguments as unknown as { traceId: string; direction: 'prev' | 'next' }); break;
+            result = await handleTraceUnlink(
+              request.params.arguments as unknown as {
+                traceId: string;
+                direction: 'prev' | 'next';
+              },
+            );
+            break;
           case 'oracle_trace_chain':
-            result = await handleTraceChain(request.params.arguments as unknown as { traceId: string }); break;
+            result = await handleTraceChain(
+              request.params.arguments as unknown as { traceId: string },
+            );
+            break;
 
           default:
             throw new Error(`Unknown tool: ${request.params.name}`);
         }
-        logMcpToolCall(this.repoRoot, request.params.name, request.params.arguments as Record<string, unknown>, 'success', Date.now() - startTime);
+        logMcpToolCall(
+          this.repoRoot,
+          request.params.name,
+          request.params.arguments as Record<string, unknown>,
+          'success',
+          Date.now() - startTime,
+        );
         return result;
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error);
-        logMcpToolCall(this.repoRoot, request.params.name, request.params.arguments as Record<string, unknown>, 'error', Date.now() - startTime, errMsg);
+        logMcpToolCall(
+          this.repoRoot,
+          request.params.name,
+          request.params.arguments as Record<string, unknown>,
+          'error',
+          Date.now() - startTime,
+          errMsg,
+        );
         return {
-          content: [{
-            type: 'text',
-            text: `Error: ${errMsg}`
-          }],
-          isError: true
+          content: [
+            {
+              type: 'text',
+              text: `Error: ${errMsg}`,
+            },
+          ],
+          isError: true,
         };
       }
     });

--- a/src/indexer-preservation.test.ts
+++ b/src/indexer-preservation.test.ts
@@ -85,7 +85,8 @@ beforeEach(() => {
 // ============================================================================
 
 function simulateSmartDeletion(project: string | null): string[] {
-  const docsToDelete = db.select({ id: oracleDocuments.id })
+  const docsToDelete = db
+    .select({ id: oracleDocuments.id })
     .from(oracleDocuments)
     .where(
       and(
@@ -94,17 +95,15 @@ function simulateSmartDeletion(project: string | null): string[] {
           ? or(eq(oracleDocuments.project, project), isNull(oracleDocuments.project))
           : isNull(oracleDocuments.project),
         // Only delete indexer-created OR legacy (null) docs
-        or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy))
-      )
+        or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy)),
+      ),
     )
     .all();
 
-  const idsToDelete = docsToDelete.map(d => d.id);
+  const idsToDelete = docsToDelete.map((d) => d.id);
 
   if (idsToDelete.length > 0) {
-    db.delete(oracleDocuments)
-      .where(inArray(oracleDocuments.id, idsToDelete))
-      .run();
+    db.delete(oracleDocuments).where(inArray(oracleDocuments.id, idsToDelete)).run();
 
     // Delete from FTS
     const placeholders = idsToDelete.map(() => '?').join(',');
@@ -137,9 +136,11 @@ function insertTestDoc(doc: {
     })
     .run();
 
-  sqlite.prepare(`
+  sqlite
+    .prepare(`
     INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)
-  `).run(doc.id, doc.content || 'Test content', '');
+  `)
+    .run(doc.id, doc.content || 'Test content', '');
 }
 
 // ============================================================================
@@ -170,14 +171,20 @@ describe('Indexer Preservation - oracle_learn documents', () => {
     const deleted = simulateSmartDeletion('github.com/current/repo');
 
     // Verify oracle_learn doc is preserved
-    const preserved = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'test-oracle-learn-1')).get();
+    const preserved = db
+      .select()
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.id, 'test-oracle-learn-1'))
+      .get();
     expect(preserved).toBeDefined();
     expect(preserved?.createdBy).toBe('oracle_learn');
 
     // Verify indexer doc was deleted
-    const notPreserved = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'test-indexer-1')).get();
+    const notPreserved = db
+      .select()
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.id, 'test-indexer-1'))
+      .get();
     expect(notPreserved).toBeUndefined();
 
     expect(deleted).toContain('test-indexer-1');
@@ -206,10 +213,16 @@ describe('Indexer Preservation - oracle_learn documents', () => {
     simulateSmartDeletion('github.com/team/repo-a');
 
     // Both oracle_learn docs should be preserved
-    const docA = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'learn-repo-a')).get();
-    const docB = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'learn-repo-b')).get();
+    const docA = db
+      .select()
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.id, 'learn-repo-a'))
+      .get();
+    const docB = db
+      .select()
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.id, 'learn-repo-b'))
+      .get();
 
     expect(docA).toBeDefined();
     expect(docB).toBeDefined();
@@ -240,13 +253,19 @@ describe('Indexer Preservation - project isolation', () => {
     const deleted = simulateSmartDeletion('github.com/current/repo');
 
     // Other repo's doc should be preserved
-    const otherDoc = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'other-repo-doc')).get();
+    const otherDoc = db
+      .select()
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.id, 'other-repo-doc'))
+      .get();
     expect(otherDoc).toBeDefined();
 
     // Current repo's doc should be deleted
-    const currentDoc = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'current-repo-doc')).get();
+    const currentDoc = db
+      .select()
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.id, 'current-repo-doc'))
+      .get();
     expect(currentDoc).toBeUndefined();
 
     expect(deleted).toContain('current-repo-doc');
@@ -294,8 +313,11 @@ describe('Indexer Preservation - project isolation', () => {
     const deleted = simulateSmartDeletion('github.com/any/repo');
 
     // Universal oracle_learn should be preserved
-    const doc = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'universal-learn-doc')).get();
+    const doc = db
+      .select()
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.id, 'universal-learn-doc'))
+      .get();
     expect(doc).toBeDefined();
     expect(deleted).not.toContain('universal-learn-doc');
   });
@@ -316,8 +338,7 @@ describe('Indexer Preservation - legacy docs (null createdBy)', () => {
     const deleted = simulateSmartDeletion('github.com/current/repo');
 
     // Legacy doc should be deleted (treated as indexer doc)
-    const doc = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'legacy-doc')).get();
+    const doc = db.select().from(oracleDocuments).where(eq(oracleDocuments.id, 'legacy-doc')).get();
     expect(doc).toBeUndefined();
     expect(deleted).toContain('legacy-doc');
   });
@@ -336,18 +357,14 @@ describe('Indexer Preservation - FTS sync', () => {
     });
 
     // Verify FTS entry exists
-    const ftsBefore = sqlite.prepare(
-      'SELECT id FROM oracle_fts WHERE id = ?'
-    ).get('fts-test-doc');
+    const ftsBefore = sqlite.prepare('SELECT id FROM oracle_fts WHERE id = ?').get('fts-test-doc');
     expect(ftsBefore).toBeDefined();
 
     // Simulate indexer run
     simulateSmartDeletion('github.com/current/repo');
 
     // Verify FTS entry is also deleted
-    const ftsAfter = sqlite.prepare(
-      'SELECT id FROM oracle_fts WHERE id = ?'
-    ).get('fts-test-doc');
+    const ftsAfter = sqlite.prepare('SELECT id FROM oracle_fts WHERE id = ?').get('fts-test-doc');
     expect(ftsAfter).toBeFalsy(); // null or undefined
   });
 
@@ -366,9 +383,9 @@ describe('Indexer Preservation - FTS sync', () => {
     simulateSmartDeletion('github.com/current/repo');
 
     // FTS entry should still exist
-    const fts = sqlite.prepare(
-      'SELECT content FROM oracle_fts WHERE id = ?'
-    ).get('fts-preserved-doc') as { content: string } | undefined;
+    const fts = sqlite
+      .prepare('SELECT content FROM oracle_fts WHERE id = ?')
+      .get('fts-preserved-doc') as { content: string } | undefined;
     expect(fts).toBeDefined();
     expect(fts?.content).toBe('This content should remain searchable');
   });
@@ -453,7 +470,7 @@ describe('Indexer Preservation - edge cases', () => {
 
     // Verify remaining docs
     const remaining = db.select({ id: oracleDocuments.id }).from(oracleDocuments).all();
-    const remainingIds = remaining.map(d => d.id);
+    const remainingIds = remaining.map((d) => d.id);
     expect(remainingIds).toContain('oracle-learn-doc');
     expect(remainingIds).toContain('manual-doc');
   });

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -30,12 +30,12 @@ import { getVaultPsiRoot } from './vault/handler.ts';
 import type { OracleDocument, OracleMetadata, IndexerConfig } from './types.ts';
 
 export class OracleIndexer {
-  private sqlite: Database;  // Raw bun:sqlite for FTS and schema operations
-  private db: BunSQLiteDatabase<typeof schema>;  // Drizzle for type-safe queries
+  private sqlite: Database; // Raw bun:sqlite for FTS and schema operations
+  private db: BunSQLiteDatabase<typeof schema>; // Drizzle for type-safe queries
   private vectorClient: VectorStoreAdapter | null = null;
   private config: IndexerConfig;
   private project: string | null;
-  private seenContentHashes: Set<string> = new Set();  // Content dedup across projects
+  private seenContentHashes: Set<string> = new Set(); // Content dedup across projects
 
   constructor(config: IndexerConfig) {
     this.config = config;
@@ -49,7 +49,12 @@ export class OracleIndexer {
   /**
    * Update indexing status for tray app
    */
-  private setIndexingStatus(isIndexing: boolean, current: number = 0, total: number = 0, error?: string): void {
+  private setIndexingStatus(
+    isIndexing: boolean,
+    current: number = 0,
+    total: number = 0,
+    error?: string,
+  ): void {
     // Ensure repo_root column exists (migration)
     try {
       this.sqlite.exec('ALTER TABLE indexing_status ADD COLUMN repo_root TEXT');
@@ -57,7 +62,8 @@ export class OracleIndexer {
       // Column already exists
     }
 
-    this.sqlite.prepare(`
+    this.sqlite
+      .prepare(`
       UPDATE indexing_status SET
         is_indexing = ?,
         progress_current = ?,
@@ -67,17 +73,18 @@ export class OracleIndexer {
         error = ?,
         repo_root = ?
       WHERE id = 1
-    `).run(
-      isIndexing ? 1 : 0,
-      current,
-      total,
-      isIndexing ? 1 : 0,
-      Date.now(),
-      isIndexing ? 1 : 0,
-      Date.now(),
-      error || null,
-      this.config.repoRoot
-    );
+    `)
+      .run(
+        isIndexing ? 1 : 0,
+        current,
+        total,
+        isIndexing ? 1 : 0,
+        Date.now(),
+        isIndexing ? 1 : 0,
+        Date.now(),
+        error || null,
+        this.config.repoRoot,
+      );
   }
 
   /**
@@ -106,11 +113,13 @@ export class OracleIndexer {
     // Query all documents for export
     let docs: any[] = [];
     try {
-      docs = this.sqlite.prepare(`
+      docs = this.sqlite
+        .prepare(`
         SELECT d.id, d.type, d.source_file, d.concepts, d.project, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
-      `).all() as any[];
+      `)
+        .all() as any[];
     } catch (e) {
       console.warn(`⚠️ Query failed: ${e instanceof Error ? e.message : e}`);
       return;
@@ -121,10 +130,10 @@ export class OracleIndexer {
       const exportData = {
         exported_at: new Date().toISOString(),
         count: docs.length,
-        documents: docs.map(d => ({
+        documents: docs.map((d) => ({
           ...d,
-          concepts: JSON.parse(d.concepts || '[]')
-        }))
+          concepts: JSON.parse(d.concepts || '[]'),
+        })),
       };
       fs.writeFileSync(jsonPath, JSON.stringify(exportData, null, 2));
       console.log(`📄 JSON export: ${jsonPath} (${docs.length} docs)`);
@@ -142,10 +151,10 @@ export class OracleIndexer {
       };
 
       const header = 'id,type,source_file,concepts,project,content';
-      const rows = docs.map(d =>
+      const rows = docs.map((d) =>
         [d.id, d.type, d.source_file, d.concepts, d.project || '', d.content]
-          .map(v => escapeCSV(String(v || '')))
-          .join(',')
+          .map((v) => escapeCSV(String(v || '')))
+          .join(','),
       );
 
       fs.writeFileSync(csvPath, [header, ...rows].join('\n'));
@@ -172,23 +181,20 @@ export class OracleIndexer {
 
     // Smart deletion: delete indexer-created docs whose source file no longer exists on disk.
     // Safe for multi-project vault: only removes docs with missing files, preserves oracle_learn docs.
-    const allIndexerDocs = this.db.select({ id: oracleDocuments.id, sourceFile: oracleDocuments.sourceFile })
+    const allIndexerDocs = this.db
+      .select({ id: oracleDocuments.id, sourceFile: oracleDocuments.sourceFile })
       .from(oracleDocuments)
-      .where(
-        or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy))
-      )
+      .where(or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy)))
       .all();
 
     const idsToDelete = allIndexerDocs
-      .filter(d => !fs.existsSync(path.join(this.config.repoRoot, d.sourceFile)))
-      .map(d => d.id);
+      .filter((d) => !fs.existsSync(path.join(this.config.repoRoot, d.sourceFile)))
+      .map((d) => d.id);
     console.log(`Smart delete: ${idsToDelete.length} stale docs (preserving oracle_learn)`);
 
     if (idsToDelete.length > 0) {
       // Delete from oracle_documents (Drizzle)
-      this.db.delete(oracleDocuments)
-        .where(inArray(oracleDocuments.id, idsToDelete))
-        .run();
+      this.db.delete(oracleDocuments).where(inArray(oracleDocuments.id, idsToDelete)).run();
 
       // Delete from FTS (raw SQL required for FTS5)
       const BATCH_SIZE = 500;
@@ -209,16 +215,19 @@ export class OracleIndexer {
       await this.vectorClient.ensureCollection();
       console.log(`Vector store (${this.vectorClient.name}) connected`);
     } catch (e) {
-      console.log('Vector store not available, using SQLite-only mode:', e instanceof Error ? e.message : e);
+      console.log(
+        'Vector store not available, using SQLite-only mode:',
+        e instanceof Error ? e.message : e,
+      );
       this.vectorClient = null;
     }
 
     const documents: OracleDocument[] = [];
 
     // Index each source type
-    documents.push(...await this.indexResonance());
-    documents.push(...await this.indexLearnings());
-    documents.push(...await this.indexRetrospectives());
+    documents.push(...(await this.indexResonance()));
+    documents.push(...(await this.indexLearnings()));
+    documents.push(...(await this.indexRetrospectives()));
 
     // Store in SQLite + Chroma
     await this.storeDocuments(documents);
@@ -274,7 +283,9 @@ export class OracleIndexer {
       totalFiles += files.length;
     }
 
-    console.log(`Indexed ${documents.length} resonance documents from ${totalFiles} files (skipped ${skippedDupes} duplicate files)`);
+    console.log(
+      `Indexed ${documents.length} resonance documents from ${totalFiles} files (skipped ${skippedDupes} duplicate files)`,
+    );
     return documents;
   }
 
@@ -283,7 +294,11 @@ export class OracleIndexer {
    * Following claude-mem's pattern of splitting by sections
    * Now reads frontmatter tags and inherits them to all chunks
    */
-  private parseResonanceFile(filename: string, content: string, sourceFileOverride?: string): OracleDocument[] {
+  private parseResonanceFile(
+    filename: string,
+    content: string,
+    sourceFileOverride?: string,
+  ): OracleDocument[] {
     const documents: OracleDocument[] = [];
     const sourceFile = sourceFileOverride || `ψ/memory/resonance/${filename}`;
     const now = Date.now();
@@ -292,11 +307,11 @@ export class OracleIndexer {
     const fileTags = this.parseFrontmatterTags(content);
 
     // Infer project from path
-    const fileProject = this.parseFrontmatterProject(content)
-      || this.inferProjectFromPath(sourceFile);
+    const fileProject =
+      this.parseFrontmatterProject(content) || this.inferProjectFromPath(sourceFile);
 
     // Split by ### headers (principles, sections)
-    const sections = content.split(/^###\s+/m).filter(s => s.trim());
+    const sections = content.split(/^###\s+/m).filter((s) => s.trim());
 
     sections.forEach((section, index) => {
       const lines = section.split('\n');
@@ -316,7 +331,7 @@ export class OracleIndexer {
         concepts: this.mergeConceptsWithTags(extractedConcepts, fileTags),
         created_at: now,
         updated_at: now,
-        project: fileProject || undefined
+        project: fileProject || undefined,
       });
 
       // Split bullet points into sub-documents (granular pattern)
@@ -333,7 +348,7 @@ export class OracleIndexer {
             concepts: this.mergeConceptsWithTags(bulletConcepts, fileTags),
             created_at: now,
             updated_at: now,
-            project: fileProject || undefined
+            project: fileProject || undefined,
           });
         });
       }
@@ -388,7 +403,9 @@ export class OracleIndexer {
       totalFiles += files.length;
     }
 
-    console.log(`Indexed ${documents.length} learning documents from ${totalFiles} files (skipped ${skippedDupes} duplicate files)`);
+    console.log(
+      `Indexed ${documents.length} learning documents from ${totalFiles} files (skipped ${skippedDupes} duplicate files)`,
+    );
     return documents;
   }
 
@@ -432,7 +449,7 @@ export class OracleIndexer {
   private inferProjectFromPath(relativePath: string): string | null {
     // Project-first layout: github.com/org/repo/ψ/...
     const projectFirst = relativePath.match(
-      /^(github\.com|gitlab\.com|bitbucket\.org)\/([^/]+\/[^/]+)\/ψ\//
+      /^(github\.com|gitlab\.com|bitbucket\.org)\/([^/]+\/[^/]+)\/ψ\//,
     );
     if (projectFirst) {
       return `${projectFirst[1]}/${projectFirst[2]}`.toLowerCase();
@@ -440,7 +457,7 @@ export class OracleIndexer {
 
     // Legacy layout: ψ/memory/{category}/github.com/org/repo/...
     const legacy = relativePath.match(
-      /^ψ\/(?:memory\/(?:learnings|retrospectives)|inbox\/handoff)\/(github\.com|gitlab\.com|bitbucket\.org)\/([^/]+\/[^/]+)\//
+      /^ψ\/(?:memory\/(?:learnings|retrospectives)|inbox\/handoff)\/(github\.com|gitlab\.com|bitbucket\.org)\/([^/]+\/[^/]+)\//,
     );
     if (legacy) {
       return `${legacy[1]}/${legacy[2]}`.toLowerCase();
@@ -457,22 +474,26 @@ export class OracleIndexer {
    * @param content - markdown content
    * @param sourceFileOverride - if provided, use as sourceFile instead of generating from filename
    */
-  private parseLearningFile(filename: string, content: string, sourceFileOverride?: string): OracleDocument[] {
+  private parseLearningFile(
+    filename: string,
+    content: string,
+    sourceFileOverride?: string,
+  ): OracleDocument[] {
     const documents: OracleDocument[] = [];
     const sourceFile = sourceFileOverride || `ψ/memory/learnings/${filename}`;
     const now = Date.now();
 
     // Extract file-level tags and project from frontmatter
     const fileTags = this.parseFrontmatterTags(content);
-    const fileProject = this.parseFrontmatterProject(content)
-      || this.inferProjectFromPath(sourceFile);
+    const fileProject =
+      this.parseFrontmatterProject(content) || this.inferProjectFromPath(sourceFile);
 
     // Extract title from frontmatter or filename
     const titleMatch = content.match(/^title:\s*(.+)$/m);
     const title = titleMatch ? titleMatch[1] : filename.replace('.md', '');
 
     // Split by ## headers (patterns)
-    const sections = content.split(/^##\s+/m).filter(s => s.trim());
+    const sections = content.split(/^##\s+/m).filter((s) => s.trim());
 
     sections.forEach((section, index) => {
       const lines = section.split('\n');
@@ -491,7 +512,7 @@ export class OracleIndexer {
         concepts: this.mergeConceptsWithTags(extractedConcepts, fileTags),
         created_at: now,
         updated_at: now,
-        project: fileProject || undefined
+        project: fileProject || undefined,
       });
     });
 
@@ -506,7 +527,7 @@ export class OracleIndexer {
         concepts: this.mergeConceptsWithTags(extractedConcepts, fileTags),
         created_at: now,
         updated_at: now,
-        project: fileProject || undefined
+        project: fileProject || undefined,
       });
     }
 
@@ -555,7 +576,9 @@ export class OracleIndexer {
       totalFiles += files.length;
     }
 
-    console.log(`Indexed ${documents.length} retrospective documents from ${totalFiles} files (skipped ${skippedDupes} duplicate files)`);
+    console.log(
+      `Indexed ${documents.length} retrospective documents from ${totalFiles} files (skipped ${skippedDupes} duplicate files)`,
+    );
     return documents;
   }
 
@@ -593,11 +616,11 @@ export class OracleIndexer {
     const fileTags = this.parseFrontmatterTags(content);
 
     // Infer project from frontmatter or path
-    const fileProject = this.parseFrontmatterProject(content)
-      || this.inferProjectFromPath(relativePath);
+    const fileProject =
+      this.parseFrontmatterProject(content) || this.inferProjectFromPath(relativePath);
 
     // Extract key sections (AI Diary, What I Learned, etc.)
-    const sections = content.split(/^##\s+/m).filter(s => s.trim());
+    const sections = content.split(/^##\s+/m).filter((s) => s.trim());
 
     sections.forEach((section, index) => {
       const lines = section.split('\n');
@@ -618,7 +641,7 @@ export class OracleIndexer {
         concepts: this.mergeConceptsWithTags(extractedConcepts, fileTags),
         created_at: now,
         updated_at: now,
-        project: fileProject || undefined
+        project: fileProject || undefined,
       });
     });
 
@@ -641,8 +664,8 @@ export class OracleIndexer {
 
     return tagsMatch[1]
       .split(',')
-      .map(t => t.trim().toLowerCase())
-      .filter(t => t.length > 0);
+      .map((t) => t.trim().toLowerCase())
+      .filter((t) => t.length > 0);
   }
 
   /**
@@ -661,8 +684,10 @@ export class OracleIndexer {
     if (projectMatch) {
       const project = projectMatch[1].trim();
       // Handle quoted values
-      if ((project.startsWith('"') && project.endsWith('"')) ||
-          (project.startsWith("'") && project.endsWith("'"))) {
+      if (
+        (project.startsWith('"') && project.endsWith('"')) ||
+        (project.startsWith("'") && project.endsWith("'"))
+      ) {
         return project.slice(1, -1);
       }
       return project || null;
@@ -701,13 +726,47 @@ export class OracleIndexer {
 
     // Common Oracle concepts (expanded list)
     const keywords = [
-      'trust', 'pattern', 'mirror', 'append', 'history', 'context',
-      'delete', 'behavior', 'intention', 'decision', 'human', 'external',
-      'brain', 'command', 'oracle', 'timestamp', 'immutable', 'preserve',
+      'trust',
+      'pattern',
+      'mirror',
+      'append',
+      'history',
+      'context',
+      'delete',
+      'behavior',
+      'intention',
+      'decision',
+      'human',
+      'external',
+      'brain',
+      'command',
+      'oracle',
+      'timestamp',
+      'immutable',
+      'preserve',
       // Additional keywords for better coverage
-      'learn', 'memory', 'session', 'workflow', 'api', 'mcp', 'claude',
-      'git', 'code', 'file', 'config', 'test', 'debug', 'error', 'fix',
-      'feature', 'refactor', 'style', 'docs', 'plan', 'task', 'issue'
+      'learn',
+      'memory',
+      'session',
+      'workflow',
+      'api',
+      'mcp',
+      'claude',
+      'git',
+      'code',
+      'file',
+      'config',
+      'test',
+      'debug',
+      'error',
+      'fix',
+      'feature',
+      'refactor',
+      'style',
+      'docs',
+      'plan',
+      'task',
+      'issue',
     ];
 
     for (const keyword of keywords) {
@@ -752,7 +811,8 @@ export class OracleIndexer {
         const docProject = (doc.project || this.project)?.toLowerCase();
 
         // Drizzle upsert with createdBy: 'indexer'
-        this.db.insert(oracleDocuments)
+        this.db
+          .insert(oracleDocuments)
           .values({
             id: doc.id,
             type: doc.type,
@@ -762,7 +822,7 @@ export class OracleIndexer {
             updatedAt: doc.updated_at,
             indexedAt: now,
             project: docProject,
-            createdBy: 'indexer',  // Mark as indexer-created
+            createdBy: 'indexer', // Mark as indexer-created
           })
           .onConflictDoUpdate({
             target: oracleDocuments.id,
@@ -774,16 +834,12 @@ export class OracleIndexer {
               indexedAt: now,
               project: docProject,
               // Don't update createdBy - preserve original
-            }
+            },
           })
           .run();
 
         // SQLite FTS (raw SQL required for FTS5)
-        insertFts.run(
-          doc.id,
-          doc.content,
-          doc.concepts.join(' ')
-        );
+        insertFts.run(doc.id, doc.content, doc.concepts.join(' '));
 
         // Chroma vector (metadata must be primitives, not arrays)
         ids.push(doc.id);
@@ -791,7 +847,7 @@ export class OracleIndexer {
         metadatas.push({
           type: doc.type,
           source_file: doc.source_file,
-          concepts: doc.concepts.join(',')  // Convert array to string for ChromaDB
+          concepts: doc.concepts.join(','), // Convert array to string for ChromaDB
         });
       }
       this.sqlite.exec('COMMIT');
@@ -818,17 +874,21 @@ export class OracleIndexer {
         const vectorDocs = batchIds.map((id, idx) => ({
           id,
           document: batchContents[idx],
-          metadata: batchMetadatas[idx]
+          metadata: batchMetadatas[idx],
         }));
         await this.vectorClient.addDocuments(vectorDocs);
-        console.log(`Vector batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(ids.length / BATCH_SIZE)} stored`);
+        console.log(
+          `Vector batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(ids.length / BATCH_SIZE)} stored`,
+        );
       } catch (error) {
         console.error(`Vector batch failed:`, error);
         vectorSuccess = false;
       }
     }
 
-    console.log(`Stored in SQLite${vectorSuccess ? ` + ${this.vectorClient.name}` : ` (${this.vectorClient.name} failed)`}`);
+    console.log(
+      `Stored in SQLite${vectorSuccess ? ` + ${this.vectorClient.name}` : ` (${this.vectorClient.name} failed)`}`,
+    );
   }
 
   /**
@@ -857,13 +917,16 @@ if (isMain) {
   const vaultRoot = 'path' in vaultResult ? vaultResult.path : null;
 
   // Vault may have project-first layout (github.com/org/repo/ψ/) without a root ψ/
-  const vaultHasContent = vaultRoot && (
-    fs.existsSync(path.join(vaultRoot, 'ψ')) ||
-    fs.existsSync(path.join(vaultRoot, 'github.com'))
-  );
-  const repoRoot = process.env.ORACLE_REPO_ROOT ||
-    (vaultHasContent ? vaultRoot :
-     fs.existsSync(path.join(projectRoot, 'ψ')) ? projectRoot : process.cwd());
+  const vaultHasContent =
+    vaultRoot &&
+    (fs.existsSync(path.join(vaultRoot, 'ψ')) || fs.existsSync(path.join(vaultRoot, 'github.com')));
+  const repoRoot =
+    process.env.ORACLE_REPO_ROOT ||
+    (vaultHasContent
+      ? vaultRoot
+      : fs.existsSync(path.join(projectRoot, 'ψ'))
+        ? projectRoot
+        : process.cwd());
 
   const config: IndexerConfig = {
     repoRoot,
@@ -872,18 +935,19 @@ if (isMain) {
     sourcePaths: {
       resonance: 'ψ/memory/resonance',
       learnings: 'ψ/memory/learnings',
-      retrospectives: 'ψ/memory/retrospectives'
-    }
+      retrospectives: 'ψ/memory/retrospectives',
+    },
   };
 
   const indexer = new OracleIndexer(config);
 
-  indexer.index()
+  indexer
+    .index()
     .then(async () => {
       console.log('Indexing complete!');
       await indexer.close();
     })
-    .catch(async err => {
+    .catch(async (err) => {
       console.error('Indexing failed:', err);
       await indexer.close();
       process.exit(1);

--- a/src/info-disclosure.test.ts
+++ b/src/info-disclosure.test.ts
@@ -57,27 +57,33 @@ const SERVER_PATH = join(SRC_ROOT, 'server.ts');
 const FORBIDDEN_IN_ERROR_BODY: Array<{ term: string; reason: string }> = [
   {
     term: 'browser',
-    reason: 'Reveals that auth is browser-based (session cookies). Attacker learns to target cookie theft rather than token theft.',
+    reason:
+      'Reveals that auth is browser-based (session cookies). Attacker learns to target cookie theft rather than token theft.',
   },
   {
     term: 'session',
-    reason: 'Reveals session-based auth mechanism. Generic "Access denied" or "Forbidden" gives nothing away.',
+    reason:
+      'Reveals session-based auth mechanism. Generic "Access denied" or "Forbidden" gives nothing away.',
   },
   {
     term: 'cookie',
-    reason: 'Reveals cookie-based auth. Same as "session" — tells attacker exactly what credential to steal.',
+    reason:
+      'Reveals cookie-based auth. Same as "session" — tells attacker exactly what credential to steal.',
   },
   {
     term: 'bearer',
-    reason: 'Reveals bearer token auth. Attacker knows to look for Authorization headers or token storage.',
+    reason:
+      'Reveals bearer token auth. Attacker knows to look for Authorization headers or token storage.',
   },
   {
     term: 'as=',
-    reason: 'Reveals the ?as= identity parameter. Attacker learns they can impersonate Beasts if they find a valid name.',
+    reason:
+      'Reveals the ?as= identity parameter. Attacker learns they can impersonate Beasts if they find a valid name.',
   },
   {
     term: 'local network',
-    reason: 'Reveals network topology restriction. Attacker learns the endpoint works from localhost, suggesting SSRF as a bypass.',
+    reason:
+      'Reveals network topology restriction. Attacker learns the endpoint works from localhost, suggesting SSRF as a bypass.',
   },
   {
     term: 'local access',
@@ -91,9 +97,7 @@ const FORBIDDEN_IN_ERROR_BODY: Array<{ term: string; reason: string }> = [
  * e.g. /api/auth/tokens — "Token creation requires..." is about the token
  * CRUD API, not revealing how auth works.
  */
-const TOKEN_TERM_EXEMPT_PATHS = [
-  '/api/auth/tokens',
-];
+const TOKEN_TERM_EXEMPT_PATHS = ['/api/auth/tokens'];
 
 /**
  * Spoof-detection 403 responses ("Identity spoof blocked. ?as=/body.beast must
@@ -161,7 +165,10 @@ function scanForInfoDisclosure(): { beastMatches: ErrorMatch[]; otherMatches: Er
     for (const forbidden of FORBIDDEN_IN_ERROR_BODY) {
       if (errorText.toLowerCase().includes(forbidden.term.toLowerCase())) {
         // Check token exemption
-        if (forbidden.term === 'token' && TOKEN_TERM_EXEMPT_PATHS.some(p => routePath.startsWith(p))) {
+        if (
+          forbidden.term === 'token' &&
+          TOKEN_TERM_EXEMPT_PATHS.some((p) => routePath.startsWith(p))
+        ) {
           continue;
         }
 
@@ -194,7 +201,7 @@ test('T#673: no info-disclosure in 403 responses on /api/beast/:name/* endpoints
         (m) =>
           `  server.ts:${m.line} [${m.routePath}]\n` +
           `    error: "${m.errorText}"\n` +
-          `    forbidden term: "${m.term}" — ${m.reason}`
+          `    forbidden term: "${m.term}" — ${m.reason}`,
       )
       .join('\n\n');
 
@@ -206,7 +213,7 @@ test('T#673: no info-disclosure in 403 responses on /api/beast/:name/* endpoints
         `If a specific message is intentional and reviewed:\n` +
         `  1. Document the security rationale in a comment at the call site\n` +
         `  2. Add an exemption in this test with a link to the review\n` +
-        `  3. Do not disable the test wholesale`
+        `  3. Do not disable the test wholesale`,
     );
   }
 
@@ -218,9 +225,7 @@ test('T#679: no info-disclosure in 403 responses on non-beast endpoints (post-T#
 
   // Filter out spoof-detection messages — owner-debug-affordance, not external
   // attack surface. See SPOOF_DETECTION_PATTERN definition for rationale.
-  const enforceableMatches = otherMatches.filter(
-    (m) => !SPOOF_DETECTION_PATTERN.test(m.errorText)
-  );
+  const enforceableMatches = otherMatches.filter((m) => !SPOOF_DETECTION_PATTERN.test(m.errorText));
 
   if (enforceableMatches.length > 0) {
     const summary = enforceableMatches
@@ -230,7 +235,7 @@ test('T#679: no info-disclosure in 403 responses on non-beast endpoints (post-T#
     throw new Error(
       `[T#679] Found ${enforceableMatches.length} info-disclosure leak(s) in non-beast 403 responses ` +
         `(spoof-detection messages excluded — see SPOOF_DETECTION_PATTERN):\n${summary}\n` +
-        `Replace verbose 403 message with { error: 'forbidden' } per T#679.\n`
+        `Replace verbose 403 message with { error: 'forbidden' } per T#679.\n`,
     );
   }
 

--- a/src/integration/audit.test.ts
+++ b/src/integration/audit.test.ts
@@ -8,10 +8,10 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect, beforeAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_BEAST = "pip";
+const BASE_URL = 'http://localhost:47778';
+const TEST_BEAST = 'pip';
 
 async function isServerRunning(): Promise<boolean> {
   try {
@@ -22,86 +22,86 @@ async function isServerRunning(): Promise<boolean> {
   }
 }
 
-describe("Audit Logging API Integration", () => {
+describe('Audit Logging API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   // =====================
   // Access Control (Regression Guards)
   // =====================
-  describe("Access Control — Gorn + Security Team", () => {
-    test("GET /api/audit rejects unauthenticated requests", async () => {
+  describe('Access Control — Gorn + Security Team', () => {
+    test('GET /api/audit rejects unauthenticated requests', async () => {
       const res = await fetch(`${BASE_URL}/api/audit`);
       expect(res.ok).toBe(false);
       const data = await res.json();
-      expect(data.error).toContain("restricted");
+      expect(data.error).toContain('restricted');
     });
 
-    test("GET /api/audit/stats rejects unauthenticated requests", async () => {
+    test('GET /api/audit/stats rejects unauthenticated requests', async () => {
       const res = await fetch(`${BASE_URL}/api/audit/stats`);
       expect(res.ok).toBe(false);
       const data = await res.json();
-      expect(data.error).toContain("restricted");
+      expect(data.error).toContain('restricted');
     });
 
-    test("GET /api/audit with ?as=pip rejects Beast identity", async () => {
+    test('GET /api/audit with ?as=pip rejects Beast identity', async () => {
       const res = await fetch(`${BASE_URL}/api/audit?as=${TEST_BEAST}`);
       expect(res.ok).toBe(false);
       const data = await res.json();
-      expect(data.error).toContain("restricted");
+      expect(data.error).toContain('restricted');
     });
 
-    test("GET /api/audit/stats with ?as=pip rejects Beast identity", async () => {
+    test('GET /api/audit/stats with ?as=pip rejects Beast identity', async () => {
       const res = await fetch(`${BASE_URL}/api/audit/stats?as=${TEST_BEAST}`);
       expect(res.ok).toBe(false);
       const data = await res.json();
-      expect(data.error).toContain("restricted");
+      expect(data.error).toContain('restricted');
     });
 
-    test("GET /api/audit with fake X-Beast header is rejected", async () => {
+    test('GET /api/audit with fake X-Beast header is rejected', async () => {
       const res = await fetch(`${BASE_URL}/api/audit`, {
-        headers: { "X-Beast": "gorn" },
+        headers: { 'X-Beast': 'gorn' },
       });
       expect(res.ok).toBe(false);
       const data = await res.json();
-      expect(data.error).toContain("restricted");
+      expect(data.error).toContain('restricted');
     });
 
-    test("GET /api/audit with ?as=karo rejects non-security Beast", async () => {
+    test('GET /api/audit with ?as=karo rejects non-security Beast', async () => {
       const res = await fetch(`${BASE_URL}/api/audit?as=karo`);
       expect(res.ok).toBe(false);
       const data = await res.json();
-      expect(data.error).toContain("restricted");
+      expect(data.error).toContain('restricted');
     });
   });
 
   // =====================
   // Security Team Access (Allowlist)
   // =====================
-  describe("Security Team Access", () => {
-    test("GET /api/audit with ?as=bertus allows security team", async () => {
+  describe('Security Team Access', () => {
+    test('GET /api/audit with ?as=bertus allows security team', async () => {
       const res = await fetch(`${BASE_URL}/api/audit?as=bertus`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.audit || data).toBeTruthy();
     });
 
-    test("GET /api/audit with ?as=talon allows security team", async () => {
+    test('GET /api/audit with ?as=talon allows security team', async () => {
       const res = await fetch(`${BASE_URL}/api/audit?as=talon`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.audit || data).toBeTruthy();
     });
 
-    test("GET /api/audit/stats with ?as=bertus allows security team", async () => {
+    test('GET /api/audit/stats with ?as=bertus allows security team', async () => {
       const res = await fetch(`${BASE_URL}/api/audit/stats?as=bertus`);
       expect(res.ok).toBe(true);
     });
 
-    test("Audit entries have expected fields", async () => {
+    test('Audit entries have expected fields', async () => {
       const res = await fetch(`${BASE_URL}/api/audit?as=bertus`);
       const data = await res.json();
       const entries = data.audit || data;
@@ -113,12 +113,12 @@ describe("Audit Logging API Integration", () => {
       }
     });
 
-    test("Actor field is populated (not all unknown)", async () => {
+    test('Actor field is populated (not all unknown)', async () => {
       const res = await fetch(`${BASE_URL}/api/audit?as=bertus`);
       const data = await res.json();
       const entries = data.audit || data;
       if (Array.isArray(entries) && entries.length > 0) {
-        const knownActors = entries.filter((e: any) => e.actor && e.actor !== "unknown");
+        const knownActors = entries.filter((e: any) => e.actor && e.actor !== 'unknown');
         // At least some entries should have known actors after the fix
         expect(knownActors.length).toBeGreaterThan(0);
       }
@@ -128,27 +128,25 @@ describe("Audit Logging API Integration", () => {
   // =====================
   // Actor Extraction (Indirect Verification)
   // =====================
-  describe("Actor Extraction — Indirect", () => {
-    test("API calls with ?as= param capture actor", async () => {
+  describe('Actor Extraction — Indirect', () => {
+    test('API calls with ?as= param capture actor', async () => {
       // Make a request that should log with actor=pip
       // (notifications endpoint was removed — use threads listing instead)
-      const res = await fetch(
-        `${BASE_URL}/api/threads?as=${TEST_BEAST}`
-      );
+      const res = await fetch(`${BASE_URL}/api/threads?as=${TEST_BEAST}`);
       expect(res.ok).toBe(true);
       // We can't read audit logs to verify, but if the request succeeded
       // the middleware should have captured actor=pip from ?as= param
     });
 
-    test("API calls with body author capture actor", async () => {
+    test('API calls with body author capture actor', async () => {
       // Forum post includes author in body
       const res = await fetch(`${BASE_URL}/api/thread`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           thread_id: 81,
           message: `test_audit_actor_${Date.now()}`,
-          role: "claude",
+          role: 'claude',
           author: TEST_BEAST,
         }),
       });
@@ -160,19 +158,15 @@ describe("Audit Logging API Integration", () => {
   // =====================
   // Edge Cases
   // =====================
-  describe("Edge Cases", () => {
+  describe('Edge Cases', () => {
     test("GET /api/audit with invalid query params doesn't crash", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/audit?limit=abc&offset=-1`
-      );
+      const res = await fetch(`${BASE_URL}/api/audit?limit=abc&offset=-1`);
       // Should still return the auth error, not a 500
       expect(res.status).toBeLessThan(500);
     });
 
     test("GET /api/audit/stats with invalid params doesn't crash", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/audit/stats?from=invalid&to=also-invalid`
-      );
+      const res = await fetch(`${BASE_URL}/api/audit/stats?from=invalid&to=also-invalid`);
       expect(res.status).toBeLessThan(500);
     });
   });

--- a/src/integration/auth.test.ts
+++ b/src/integration/auth.test.ts
@@ -7,11 +7,11 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_BEAST = "pip";
-const OTHER_BEAST = "bertus";
+const BASE_URL = 'http://localhost:47778';
+const TEST_BEAST = 'pip';
+const OTHER_BEAST = 'bertus';
 
 async function isServerRunning(): Promise<boolean> {
   try {
@@ -22,35 +22,35 @@ async function isServerRunning(): Promise<boolean> {
   }
 }
 
-describe("Auth & Ownership Integration", () => {
+describe('Auth & Ownership Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   // =====================
   // Auth Endpoints
   // =====================
-  describe("Auth Endpoints", () => {
-    test("GET /api/auth/status returns auth state", async () => {
+  describe('Auth Endpoints', () => {
+    test('GET /api/auth/status returns auth state', async () => {
       const res = await fetch(`${BASE_URL}/api/auth/status`);
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(typeof data).toBe("object");
+      expect(typeof data).toBe('object');
     });
 
-    test("GET /api/settings returns config", async () => {
+    test('GET /api/settings returns config', async () => {
       const res = await fetch(`${BASE_URL}/api/settings`);
       expect(res.ok).toBe(true);
     });
 
-    test("POST /api/settings restricted to gorn", async () => {
+    test('POST /api/settings restricted to gorn', async () => {
       // Non-gorn should be rejected
       const res = await fetch(`${BASE_URL}/api/settings`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ as: TEST_BEAST, key: "test", value: "test" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ as: TEST_BEAST, key: 'test', value: 'test' }),
       });
       // Should be 403 or similar
       expect(res.status).toBeGreaterThanOrEqual(400);
@@ -61,19 +61,19 @@ describe("Auth & Ownership Integration", () => {
   // =====================
   // Scheduler IDOR — Cross-beast mutations
   // =====================
-  describe("Scheduler IDOR", () => {
+  describe('Scheduler IDOR', () => {
     let ownScheduleId: number;
     let otherScheduleId: number;
 
     beforeAll(async () => {
       // Create own schedule
       const res1 = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
           task: `auth_test_own_${Date.now()}`,
-          interval: "1d",
+          interval: '1d',
         }),
       });
       if (res1.ok) {
@@ -83,12 +83,12 @@ describe("Auth & Ownership Integration", () => {
 
       // Create other beast's schedule
       const res2 = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: OTHER_BEAST,
           task: `auth_test_other_${Date.now()}`,
-          interval: "1d",
+          interval: '1d',
         }),
       });
       if (res2.ok) {
@@ -106,8 +106,8 @@ describe("Auth & Ownership Integration", () => {
         if (id) {
           try {
             await fetch(`${BASE_URL}/api/schedules/${id}`, {
-              method: "DELETE",
-              headers: { "Content-Type": "application/json" },
+              method: 'DELETE',
+              headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ beast }),
             });
           } catch {}
@@ -115,80 +115,74 @@ describe("Auth & Ownership Integration", () => {
       }
     });
 
-    test("own schedule PATCH succeeds", async () => {
+    test('own schedule PATCH succeeds', async () => {
       if (!ownScheduleId) return;
       const res = await fetch(`${BASE_URL}/api/schedules/${ownScheduleId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ beast: TEST_BEAST, interval: "6h" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, interval: '6h' }),
       });
       expect(res.ok).toBe(true);
     });
 
-    test("cross-beast PATCH returns 403", async () => {
+    test('cross-beast PATCH returns 403', async () => {
       if (!otherScheduleId) return;
       const res = await fetch(`${BASE_URL}/api/schedules/${otherScheduleId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ beast: TEST_BEAST, interval: "6h" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, interval: '6h' }),
       });
       expect(res.status).toBe(403);
     });
 
-    test("cross-beast DELETE returns 403", async () => {
+    test('cross-beast DELETE returns 403', async () => {
       if (!otherScheduleId) return;
       const res = await fetch(`${BASE_URL}/api/schedules/${otherScheduleId}`, {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       expect(res.status).toBe(403);
     });
 
-    test("cross-beast /trigger returns 403", async () => {
+    test('cross-beast /trigger returns 403', async () => {
       if (!otherScheduleId) return;
-      const res = await fetch(
-        `${BASE_URL}/api/schedules/${otherScheduleId}/trigger`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: TEST_BEAST }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/schedules/${otherScheduleId}/trigger`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST }),
+      });
       expect(res.status).toBe(403);
     });
 
-    test("no beast identity on PATCH returns 400", async () => {
+    test('no beast identity on PATCH returns 400', async () => {
       if (!ownScheduleId) return;
       const res = await fetch(`${BASE_URL}/api/schedules/${ownScheduleId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ interval: "6h" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ interval: '6h' }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("no beast identity on DELETE returns 400", async () => {
+    test('no beast identity on DELETE returns 400', async () => {
       if (!ownScheduleId) return;
       const res = await fetch(`${BASE_URL}/api/schedules/${ownScheduleId}`, {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
       expect(res.status).toBeGreaterThanOrEqual(400);
       expect(res.status).toBeLessThan(500);
     });
 
-    test("gorn can override ownership", async () => {
+    test('gorn can override ownership', async () => {
       if (!otherScheduleId) return;
-      const res = await fetch(
-        `${BASE_URL}/api/schedules/${otherScheduleId}/trigger`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: "gorn" }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/schedules/${otherScheduleId}/trigger`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: 'gorn' }),
+      });
       expect(res.ok).toBe(true);
     });
   });
@@ -196,20 +190,20 @@ describe("Auth & Ownership Integration", () => {
   // =====================
   // Beast Profile IDOR
   // =====================
-  describe("Beast Profile Access", () => {
-    test("GET /api/beasts lists all beasts", async () => {
+  describe('Beast Profile Access', () => {
+    test('GET /api/beasts lists all beasts', async () => {
       const res = await fetch(`${BASE_URL}/api/beasts`);
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/beast/:name returns profile", async () => {
+    test('GET /api/beast/:name returns profile', async () => {
       const res = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.name).toBe(TEST_BEAST);
     });
 
-    test("GET nonexistent beast returns 404", async () => {
+    test('GET nonexistent beast returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/beast/nonexistent_xyz`);
       expect(res.status).toBe(404);
     });
@@ -218,19 +212,19 @@ describe("Auth & Ownership Integration", () => {
   // =====================
   // Task/Board Ownership
   // =====================
-  describe("Task Ownership", () => {
+  describe('Task Ownership', () => {
     let testTaskId: number;
 
     beforeAll(async () => {
       const res = await fetch(`${BASE_URL}/api/tasks`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: `auth_test_task_${Date.now()}`,
-          description: "Auth test task",
+          description: 'Auth test task',
           assigned_to: TEST_BEAST,
           created_by: TEST_BEAST,
-          priority: "low",
+          priority: 'low',
         }),
       });
       if (res.ok) {
@@ -243,36 +237,36 @@ describe("Auth & Ownership Integration", () => {
       if (testTaskId) {
         try {
           await fetch(`${BASE_URL}/api/tasks/${testTaskId}`, {
-            method: "DELETE",
+            method: 'DELETE',
           });
         } catch {}
       }
     });
 
-    test("GET /api/tasks returns task list", async () => {
+    test('GET /api/tasks returns task list', async () => {
       const res = await fetch(`${BASE_URL}/api/tasks`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.tasks).toBeInstanceOf(Array);
     });
 
-    test("GET /api/tasks/:id returns task", async () => {
+    test('GET /api/tasks/:id returns task', async () => {
       if (!testTaskId) return;
       const res = await fetch(`${BASE_URL}/api/tasks/${testTaskId}`);
       expect(res.ok).toBe(true);
     });
 
-    test("PATCH /api/tasks/:id updates task", async () => {
+    test('PATCH /api/tasks/:id updates task', async () => {
       if (!testTaskId) return;
       const res = await fetch(`${BASE_URL}/api/tasks/${testTaskId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "in_progress" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'in_progress' }),
       });
       expect(res.ok).toBe(true);
     });
 
-    test("GET nonexistent task returns 404", async () => {
+    test('GET nonexistent task returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/tasks/99999`);
       expect(res.status).toBe(404);
     });
@@ -281,13 +275,13 @@ describe("Auth & Ownership Integration", () => {
   // =====================
   // Group Access
   // =====================
-  describe("Group Access", () => {
-    test("GET /api/groups lists groups", async () => {
+  describe('Group Access', () => {
+    test('GET /api/groups lists groups', async () => {
       const res = await fetch(`${BASE_URL}/api/groups`);
       expect(res.ok).toBe(true);
     });
 
-    test("GET nonexistent group returns 404", async () => {
+    test('GET nonexistent group returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/group/nonexistent_xyz`);
       expect(res.status).toBe(404);
     });
@@ -296,22 +290,22 @@ describe("Auth & Ownership Integration", () => {
   // =====================
   // Endpoint Security — No 500s
   // =====================
-  describe("No 500 errors on bad input", () => {
+  describe('No 500 errors on bad input', () => {
     const endpoints = [
-      { method: "GET", path: "/api/schedules/notanumber" },
-      { method: "GET", path: "/api/thread/notanumber" },
-      { method: "GET", path: "/api/tasks/notanumber" },
-      { method: "POST", path: "/api/thread", body: {} },
-      { method: "POST", path: "/api/dm", body: {} },
-      { method: "POST", path: "/api/schedules", body: {} },
-      { method: "POST", path: "/api/tasks", body: {} },
+      { method: 'GET', path: '/api/schedules/notanumber' },
+      { method: 'GET', path: '/api/thread/notanumber' },
+      { method: 'GET', path: '/api/tasks/notanumber' },
+      { method: 'POST', path: '/api/thread', body: {} },
+      { method: 'POST', path: '/api/dm', body: {} },
+      { method: 'POST', path: '/api/schedules', body: {} },
+      { method: 'POST', path: '/api/tasks', body: {} },
     ];
 
     for (const { method, path, body } of endpoints) {
       test(`${method} ${path} with bad input does not 500`, async () => {
         const res = await fetch(`${BASE_URL}${path}`, {
           method,
-          headers: body ? { "Content-Type": "application/json" } : undefined,
+          headers: body ? { 'Content-Type': 'application/json' } : undefined,
           body: body ? JSON.stringify(body) : undefined,
         });
         expect(res.status).toBeLessThan(500);

--- a/src/integration/beasts.test.ts
+++ b/src/integration/beasts.test.ts
@@ -4,11 +4,11 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect, beforeAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_BEAST = "pip";
-const OTHER_BEAST = "bertus";
+const BASE_URL = 'http://localhost:47778';
+const TEST_BEAST = 'pip';
+const OTHER_BEAST = 'bertus';
 
 async function isServerRunning(): Promise<boolean> {
   try {
@@ -19,18 +19,18 @@ async function isServerRunning(): Promise<boolean> {
   }
 }
 
-describe("Beast Profiles API Integration", () => {
+describe('Beast Profiles API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   // =====================
   // List & Read
   // =====================
-  describe("List & Read", () => {
-    test("GET /api/beasts returns all beasts", async () => {
+  describe('List & Read', () => {
+    test('GET /api/beasts returns all beasts', async () => {
       const res = await fetch(`${BASE_URL}/api/beasts`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -39,7 +39,7 @@ describe("Beast Profiles API Integration", () => {
       expect(beasts.length).toBeGreaterThan(0);
     });
 
-    test("GET /api/beast/:name returns a single profile", async () => {
+    test('GET /api/beast/:name returns a single profile', async () => {
       const res = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -48,7 +48,7 @@ describe("Beast Profiles API Integration", () => {
       expect(data.role).toBeTruthy();
     });
 
-    test("Beast profile has expected fields", async () => {
+    test('Beast profile has expected fields', async () => {
       const res = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`);
       const data = await res.json();
       expect(data.name).toBeTruthy();
@@ -59,10 +59,8 @@ describe("Beast Profiles API Integration", () => {
       expect(data.createdAt).toBeTruthy();
     });
 
-    test("GET /api/beast/nonexistent returns 404", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/beast/nonexistent_beast_xyz_999`
-      );
+    test('GET /api/beast/nonexistent returns 404', async () => {
+      const res = await fetch(`${BASE_URL}/api/beast/nonexistent_beast_xyz_999`);
       expect(res.status).toBe(404);
     });
   });
@@ -70,10 +68,10 @@ describe("Beast Profiles API Integration", () => {
   // =====================
   // Update
   // =====================
-  describe("Update Profile", () => {
+  describe('Update Profile', () => {
     let originalBio: string;
 
-    test("PATCH /api/beast/:name updates profile fields", async () => {
+    test('PATCH /api/beast/:name updates profile fields', async () => {
       // Save original
       const origRes = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`);
       const origData = await origRes.json();
@@ -81,8 +79,8 @@ describe("Beast Profiles API Integration", () => {
 
       const testBio = `test_bio_${Date.now()}`;
       const res = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ bio: testBio }),
       });
       expect(res.ok).toBe(true);
@@ -94,62 +92,59 @@ describe("Beast Profiles API Integration", () => {
 
       // Restore original
       await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ bio: originalBio }),
       });
     });
 
-    test("PATCH /api/beast/:name updates interests", async () => {
+    test('PATCH /api/beast/:name updates interests', async () => {
       const origRes = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`);
       const origData = await origRes.json();
       const originalInterests = origData.interests;
 
       const testInterests = `test_interest_${Date.now()}`;
       const res = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ interests: testInterests }),
       });
       expect(res.ok).toBe(true);
 
       // Restore
       await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ interests: originalInterests }),
       });
     });
 
-    test("PATCH /api/beast/:name updates themeColor", async () => {
+    test('PATCH /api/beast/:name updates themeColor', async () => {
       const origRes = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`);
       const origData = await origRes.json();
       const originalColor = origData.themeColor;
 
       const res = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ themeColor: "#FF0000" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ themeColor: '#FF0000' }),
       });
       expect(res.ok).toBe(true);
 
       // Restore
       await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ themeColor: originalColor }),
       });
     });
 
-    test("PATCH nonexistent beast returns 404", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/beast/nonexistent_beast_xyz_999`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ bio: "test" }),
-        }
-      );
+    test('PATCH nonexistent beast returns 404', async () => {
+      const res = await fetch(`${BASE_URL}/api/beast/nonexistent_beast_xyz_999`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bio: 'test' }),
+      });
       expect(res.status).toBe(404);
     });
   });
@@ -157,18 +152,16 @@ describe("Beast Profiles API Integration", () => {
   // =====================
   // Avatar
   // =====================
-  describe("Avatar", () => {
-    test("GET /api/beast/:name/avatar.svg returns SVG", async () => {
+  describe('Avatar', () => {
+    test('GET /api/beast/:name/avatar.svg returns SVG', async () => {
       const res = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}/avatar.svg`);
       expect(res.ok).toBe(true);
-      const contentType = res.headers.get("content-type");
-      expect(contentType).toContain("svg");
+      const contentType = res.headers.get('content-type');
+      expect(contentType).toContain('svg');
     });
 
-    test("GET /api/beast/nonexistent/avatar.svg handles missing beast", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/beast/nonexistent_beast_xyz_999/avatar.svg`
-      );
+    test('GET /api/beast/nonexistent/avatar.svg handles missing beast', async () => {
+      const res = await fetch(`${BASE_URL}/api/beast/nonexistent_beast_xyz_999/avatar.svg`);
       // Should return 404 or a fallback SVG
       expect(res.status).toBeLessThan(500);
     });
@@ -177,8 +170,8 @@ describe("Beast Profiles API Integration", () => {
   // =====================
   // Cross-beast Isolation
   // =====================
-  describe("Cross-beast", () => {
-    test("Different beasts have different profiles", async () => {
+  describe('Cross-beast', () => {
+    test('Different beasts have different profiles', async () => {
       const pipRes = await fetch(`${BASE_URL}/api/beast/${TEST_BEAST}`);
       const bertusRes = await fetch(`${BASE_URL}/api/beast/${OTHER_BEAST}`);
       const pip = await pipRes.json();

--- a/src/integration/database.test.ts
+++ b/src/integration/database.test.ts
@@ -3,28 +3,28 @@
  * Tests denbook database operations with Drizzle ORM
  * Uses isolated test database with proper migrations
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { Database } from "bun:sqlite";
-import { drizzle } from "drizzle-orm/bun-sqlite";
-import { eq, isNull, sql } from "drizzle-orm";
-import { existsSync, mkdirSync, rmSync, readFileSync } from "fs";
-import { join } from "path";
-import { homedir } from "os";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { eq, isNull, sql } from 'drizzle-orm';
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
 
 // Import schema
-import * as schema from "../db/schema";
+import * as schema from '../db/schema';
 
 // Test database (separate from production)
-const TEST_DB_PATH = join(homedir(), ".oracle", "test-integration.db");
-const PROJECT_ROOT = join(import.meta.dir, "../..");
+const TEST_DB_PATH = join(homedir(), '.oracle', 'test-integration.db');
+const PROJECT_ROOT = join(import.meta.dir, '../..');
 
 let sqlite: Database;
 let db: ReturnType<typeof drizzle>;
 
-describe("Database Integration (Drizzle ORM)", () => {
+describe('Database Integration (Drizzle ORM)', () => {
   beforeAll(async () => {
     // Ensure directory exists
-    const dir = join(homedir(), ".oracle");
+    const dir = join(homedir(), '.oracle');
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
@@ -38,23 +38,23 @@ describe("Database Integration (Drizzle ORM)", () => {
     db = drizzle(sqlite, { schema });
 
     // Apply migrations from migration files
-    const migrationsDir = join(PROJECT_ROOT, "src/db/migrations");
+    const migrationsDir = join(PROJECT_ROOT, 'src/db/migrations');
     const migrationFiles = [
-      "0000_unknown_viper.sql",
-      "0001_chunky_dark_phoenix.sql",
-      "0002_mixed_rhodey.sql",
-      "0003_rapid_strong_guy.sql",
-      "0004_warm_mesmero.sql",
-      "0005_add_schedule.sql",
-      "0006_magenta_screwball.sql",
+      '0000_unknown_viper.sql',
+      '0001_chunky_dark_phoenix.sql',
+      '0002_mixed_rhodey.sql',
+      '0003_rapid_strong_guy.sql',
+      '0004_warm_mesmero.sql',
+      '0005_add_schedule.sql',
+      '0006_magenta_screwball.sql',
     ];
 
     for (const file of migrationFiles) {
       const sqlPath = join(migrationsDir, file);
       if (existsSync(sqlPath)) {
-        const sql = readFileSync(sqlPath, "utf-8");
+        const sql = readFileSync(sqlPath, 'utf-8');
         // Execute each statement separately (split by --)
-        const statements = sql.split("--> statement-breakpoint").filter(s => s.trim());
+        const statements = sql.split('--> statement-breakpoint').filter((s) => s.trim());
         for (const stmt of statements) {
           if (stmt.trim()) {
             try {
@@ -89,15 +89,15 @@ describe("Database Integration (Drizzle ORM)", () => {
   // ===================
   // Document Operations (Drizzle)
   // ===================
-  describe("Document Operations (Drizzle ORM)", () => {
+  describe('Document Operations (Drizzle ORM)', () => {
     const now = Date.now();
 
-    test("INSERT document with Drizzle", async () => {
+    test('INSERT document with Drizzle', async () => {
       await db.insert(schema.oracleDocuments).values({
-        id: "drizzle_doc_1",
-        type: "learning",
-        sourceFile: "/test/drizzle.md",
-        concepts: JSON.stringify(["drizzle", "orm", "test"]),
+        id: 'drizzle_doc_1',
+        type: 'learning',
+        sourceFile: '/test/drizzle.md',
+        concepts: JSON.stringify(['drizzle', 'orm', 'test']),
         createdAt: now,
         updatedAt: now,
         indexedAt: now,
@@ -106,19 +106,19 @@ describe("Database Integration (Drizzle ORM)", () => {
       const docs = await db
         .select()
         .from(schema.oracleDocuments)
-        .where(eq(schema.oracleDocuments.id, "drizzle_doc_1"));
+        .where(eq(schema.oracleDocuments.id, 'drizzle_doc_1'));
 
       expect(docs.length).toBe(1);
-      expect(docs[0].type).toBe("learning");
-      expect(docs[0].sourceFile).toBe("/test/drizzle.md");
+      expect(docs[0].type).toBe('learning');
+      expect(docs[0].sourceFile).toBe('/test/drizzle.md');
     });
 
-    test("SELECT by type with Drizzle", async () => {
+    test('SELECT by type with Drizzle', async () => {
       await db.insert(schema.oracleDocuments).values({
-        id: "drizzle_doc_2",
-        type: "principle",
-        sourceFile: "/test/principle.md",
-        concepts: JSON.stringify(["core", "oracle"]),
+        id: 'drizzle_doc_2',
+        type: 'principle',
+        sourceFile: '/test/principle.md',
+        concepts: JSON.stringify(['core', 'oracle']),
         createdAt: now,
         updatedAt: now,
         indexedAt: now,
@@ -127,18 +127,18 @@ describe("Database Integration (Drizzle ORM)", () => {
       const learnings = await db
         .select()
         .from(schema.oracleDocuments)
-        .where(eq(schema.oracleDocuments.type, "learning"));
+        .where(eq(schema.oracleDocuments.type, 'learning'));
 
       expect(learnings.length).toBeGreaterThanOrEqual(1);
-      expect(learnings.every((d) => d.type === "learning")).toBe(true);
+      expect(learnings.every((d) => d.type === 'learning')).toBe(true);
     });
 
-    test("Supersede document (Nothing is Deleted)", async () => {
+    test('Supersede document (Nothing is Deleted)', async () => {
       await db.insert(schema.oracleDocuments).values({
-        id: "drizzle_doc_3",
-        type: "learning",
-        sourceFile: "/test/updated.md",
-        concepts: JSON.stringify(["updated"]),
+        id: 'drizzle_doc_3',
+        type: 'learning',
+        sourceFile: '/test/updated.md',
+        concepts: JSON.stringify(['updated']),
         createdAt: now,
         updatedAt: now,
         indexedAt: now,
@@ -147,22 +147,22 @@ describe("Database Integration (Drizzle ORM)", () => {
       await db
         .update(schema.oracleDocuments)
         .set({
-          supersededBy: "drizzle_doc_3",
+          supersededBy: 'drizzle_doc_3',
           supersededAt: Date.now(),
-          supersededReason: "Updated with new information",
+          supersededReason: 'Updated with new information',
         })
-        .where(eq(schema.oracleDocuments.id, "drizzle_doc_1"));
+        .where(eq(schema.oracleDocuments.id, 'drizzle_doc_1'));
 
       const oldDoc = await db
         .select()
         .from(schema.oracleDocuments)
-        .where(eq(schema.oracleDocuments.id, "drizzle_doc_1"));
+        .where(eq(schema.oracleDocuments.id, 'drizzle_doc_1'));
 
-      expect(oldDoc[0].supersededBy).toBe("drizzle_doc_3");
-      expect(oldDoc[0].supersededReason).toBe("Updated with new information");
+      expect(oldDoc[0].supersededBy).toBe('drizzle_doc_3');
+      expect(oldDoc[0].supersededReason).toBe('Updated with new information');
     });
 
-    test("Filter non-superseded documents", async () => {
+    test('Filter non-superseded documents', async () => {
       const activeDocs = await db
         .select()
         .from(schema.oracleDocuments)
@@ -172,23 +172,23 @@ describe("Database Integration (Drizzle ORM)", () => {
       expect(activeDocs.every((d) => d.supersededBy === null)).toBe(true);
     });
 
-    test("Project filtering with universal docs", async () => {
+    test('Project filtering with universal docs', async () => {
       await db.insert(schema.oracleDocuments).values({
-        id: "proj_doc_1",
-        type: "learning",
-        sourceFile: "/proj/a.md",
-        concepts: JSON.stringify(["project-specific"]),
+        id: 'proj_doc_1',
+        type: 'learning',
+        sourceFile: '/proj/a.md',
+        concepts: JSON.stringify(['project-specific']),
         createdAt: now,
         updatedAt: now,
         indexedAt: now,
-        project: "github.com/test/project",
+        project: 'github.com/test/project',
       });
 
       await db.insert(schema.oracleDocuments).values({
-        id: "universal_doc",
-        type: "principle",
-        sourceFile: "/core/universal.md",
-        concepts: JSON.stringify(["universal"]),
+        id: 'universal_doc',
+        type: 'principle',
+        sourceFile: '/core/universal.md',
+        concepts: JSON.stringify(['universal']),
         createdAt: now,
         updatedAt: now,
         indexedAt: now,
@@ -199,10 +199,10 @@ describe("Database Integration (Drizzle ORM)", () => {
         .select()
         .from(schema.oracleDocuments)
         .where(
-          sql`${schema.oracleDocuments.project} = ${"github.com/test/project"} OR ${schema.oracleDocuments.project} IS NULL`
+          sql`${schema.oracleDocuments.project} = ${'github.com/test/project'} OR ${schema.oracleDocuments.project} IS NULL`,
         );
 
-      const hasProjectDocs = docs.some((d) => d.project === "github.com/test/project");
+      const hasProjectDocs = docs.some((d) => d.project === 'github.com/test/project');
       const hasUniversalDocs = docs.some((d) => d.project === null);
 
       expect(hasProjectDocs).toBe(true);
@@ -213,33 +213,37 @@ describe("Database Integration (Drizzle ORM)", () => {
   // ===================
   // Search Logging (Drizzle)
   // ===================
-  describe("Search Logging (Drizzle ORM)", () => {
+  describe('Search Logging (Drizzle ORM)', () => {
     const now = Date.now();
 
-    test("LOG search query", async () => {
+    test('LOG search query', async () => {
       await db.insert(schema.searchLog).values({
-        query: "oracle philosophy",
-        type: "all",
-        mode: "hybrid",
+        query: 'oracle philosophy',
+        type: 'all',
+        mode: 'hybrid',
         resultsCount: 5,
         searchTimeMs: 42,
         createdAt: now,
-        project: "test-project",
-        results: JSON.stringify([{ id: "doc1", score: 0.9 }]),
+        project: 'test-project',
+        results: JSON.stringify([{ id: 'doc1', score: 0.9 }]),
       });
 
       const logs = await db
         .select()
         .from(schema.searchLog)
-        .where(eq(schema.searchLog.query, "oracle philosophy"));
+        .where(eq(schema.searchLog.query, 'oracle philosophy'));
 
       expect(logs.length).toBe(1);
-      expect(logs[0].mode).toBe("hybrid");
+      expect(logs[0].mode).toBe('hybrid');
     });
 
-    test("AGGREGATE search stats", async () => {
-      await db.insert(schema.searchLog).values({ query: "test1", resultsCount: 3, searchTimeMs: 20, createdAt: now });
-      await db.insert(schema.searchLog).values({ query: "test2", resultsCount: 7, searchTimeMs: 35, createdAt: now });
+    test('AGGREGATE search stats', async () => {
+      await db
+        .insert(schema.searchLog)
+        .values({ query: 'test1', resultsCount: 3, searchTimeMs: 20, createdAt: now });
+      await db
+        .insert(schema.searchLog)
+        .values({ query: 'test2', resultsCount: 7, searchTimeMs: 35, createdAt: now });
 
       const stats = await db
         .select({
@@ -256,18 +260,21 @@ describe("Database Integration (Drizzle ORM)", () => {
   // ===================
   // Forum Operations (Drizzle)
   // ===================
-  describe("Forum Operations (Drizzle ORM)", () => {
+  describe('Forum Operations (Drizzle ORM)', () => {
     let threadId: number;
     const now = Date.now();
 
-    test("CREATE thread", async () => {
-      const result = await db.insert(schema.forumThreads).values({
-        title: "Test Drizzle Thread",
-        createdBy: "user",
-        status: "active",
-        createdAt: now,
-        updatedAt: now,
-      }).returning({ id: schema.forumThreads.id });
+    test('CREATE thread', async () => {
+      const result = await db
+        .insert(schema.forumThreads)
+        .values({
+          title: 'Test Drizzle Thread',
+          createdBy: 'user',
+          status: 'active',
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning({ id: schema.forumThreads.id });
 
       threadId = result[0].id;
 
@@ -276,16 +283,16 @@ describe("Database Integration (Drizzle ORM)", () => {
         .from(schema.forumThreads)
         .where(eq(schema.forumThreads.id, threadId));
 
-      expect(threads[0].title).toBe("Test Drizzle Thread");
-      expect(threads[0].status).toBe("active");
+      expect(threads[0].title).toBe('Test Drizzle Thread');
+      expect(threads[0].status).toBe('active');
     });
 
-    test("ADD message to thread", async () => {
+    test('ADD message to thread', async () => {
       await db.insert(schema.forumMessages).values({
         threadId,
-        role: "human",
-        content: "Test message via Drizzle",
-        author: "user",
+        role: 'human',
+        content: 'Test message via Drizzle',
+        author: 'user',
         createdAt: Date.now(),
       });
 
@@ -295,13 +302,13 @@ describe("Database Integration (Drizzle ORM)", () => {
         .where(eq(schema.forumMessages.threadId, threadId));
 
       expect(messages.length).toBe(1);
-      expect(messages[0].content).toBe("Test message via Drizzle");
+      expect(messages[0].content).toBe('Test message via Drizzle');
     });
 
-    test("UPDATE thread status", async () => {
+    test('UPDATE thread status', async () => {
       await db
         .update(schema.forumThreads)
-        .set({ status: "answered", updatedAt: Date.now() })
+        .set({ status: 'answered', updatedAt: Date.now() })
         .where(eq(schema.forumThreads.id, threadId));
 
       const threads = await db
@@ -309,25 +316,25 @@ describe("Database Integration (Drizzle ORM)", () => {
         .from(schema.forumThreads)
         .where(eq(schema.forumThreads.id, threadId));
 
-      expect(threads[0].status).toBe("answered");
+      expect(threads[0].status).toBe('answered');
     });
   });
 
   // ===================
   // Trace Logging (Drizzle)
   // ===================
-  describe("Trace Logging (Drizzle ORM)", () => {
-    test("LOG trace session", async () => {
+  describe('Trace Logging (Drizzle ORM)', () => {
+    test('LOG trace session', async () => {
       const traceId = `trace_${Date.now()}`;
       const now = Date.now();
 
       await db.insert(schema.traceLog).values({
         traceId,
-        query: "oracle patterns",
-        queryType: "general",
-        foundFiles: JSON.stringify(["/path/to/file.md"]),
-        foundCommits: JSON.stringify([{ hash: "abc123", message: "test" }]),
-        status: "raw",
+        query: 'oracle patterns',
+        queryType: 'general',
+        foundFiles: JSON.stringify(['/path/to/file.md']),
+        foundCommits: JSON.stringify([{ hash: 'abc123', message: 'test' }]),
+        status: 'raw',
         createdAt: now,
         updatedAt: now,
       });
@@ -338,31 +345,41 @@ describe("Database Integration (Drizzle ORM)", () => {
         .where(eq(schema.traceLog.traceId, traceId));
 
       expect(traces.length).toBe(1);
-      expect(traces[0].query).toBe("oracle patterns");
+      expect(traces[0].query).toBe('oracle patterns');
     });
   });
 
   // ===================
   // FTS5 (Raw SQL)
   // ===================
-  describe("FTS5 Full-Text Search (Raw SQL)", () => {
+  describe('FTS5 Full-Text Search (Raw SQL)', () => {
     beforeAll(() => {
-      sqlite.exec(`INSERT INTO oracle_fts (id, content, concepts) VALUES ('fts_1', 'The Oracle philosophy emphasizes patterns', 'oracle,philosophy')`);
-      sqlite.exec(`INSERT INTO oracle_fts (id, content, concepts) VALUES ('fts_2', 'Integration testing with Drizzle ORM', 'testing,drizzle')`);
+      sqlite.exec(
+        `INSERT INTO oracle_fts (id, content, concepts) VALUES ('fts_1', 'The Oracle philosophy emphasizes patterns', 'oracle,philosophy')`,
+      );
+      sqlite.exec(
+        `INSERT INTO oracle_fts (id, content, concepts) VALUES ('fts_2', 'Integration testing with Drizzle ORM', 'testing,drizzle')`,
+      );
     });
 
-    test("FTS5 MATCH query", () => {
-      const results = sqlite.query("SELECT id, content FROM oracle_fts WHERE oracle_fts MATCH ?").all("oracle") as any[];
+    test('FTS5 MATCH query', () => {
+      const results = sqlite
+        .query('SELECT id, content FROM oracle_fts WHERE oracle_fts MATCH ?')
+        .all('oracle') as any[];
       expect(results.length).toBeGreaterThanOrEqual(1);
     });
 
-    test("FTS5 with porter stemming", () => {
-      const results = sqlite.query("SELECT id FROM oracle_fts WHERE oracle_fts MATCH ?").all("tests") as any[];
+    test('FTS5 with porter stemming', () => {
+      const results = sqlite
+        .query('SELECT id FROM oracle_fts WHERE oracle_fts MATCH ?')
+        .all('tests') as any[];
       expect(results.length).toBeGreaterThanOrEqual(1);
     });
 
-    test("FTS5 concept column search", () => {
-      const results = sqlite.query("SELECT id FROM oracle_fts WHERE oracle_fts MATCH 'concepts:philosophy'").all() as any[];
+    test('FTS5 concept column search', () => {
+      const results = sqlite
+        .query("SELECT id FROM oracle_fts WHERE oracle_fts MATCH 'concepts:philosophy'")
+        .all() as any[];
       expect(results.length).toBeGreaterThanOrEqual(1);
     });
   });

--- a/src/integration/dm.test.ts
+++ b/src/integration/dm.test.ts
@@ -4,12 +4,12 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_BEAST = "pip";
-const OTHER_BEAST = "bertus";
-const TEST_PREFIX = "test_dm_";
+const BASE_URL = 'http://localhost:47778';
+const TEST_BEAST = 'pip';
+const OTHER_BEAST = 'bertus';
+const TEST_PREFIX = 'test_dm_';
 const createdMessageIds: number[] = [];
 
 async function isServerRunning(): Promise<boolean> {
@@ -23,8 +23,8 @@ async function isServerRunning(): Promise<boolean> {
 
 async function sendDM(from: string, to: string, message: string) {
   const res = await fetch(`${BASE_URL}/api/dm`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ from, to, message }),
   });
   const data = await res.json();
@@ -32,17 +32,17 @@ async function sendDM(from: string, to: string, message: string) {
   return { res, data };
 }
 
-describe("DM API Integration", () => {
+describe('DM API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   afterAll(async () => {
     for (const id of createdMessageIds) {
       try {
-        await fetch(`${BASE_URL}/api/dm/messages/${id}?as=${TEST_BEAST}`, { method: "DELETE" });
+        await fetch(`${BASE_URL}/api/dm/messages/${id}?as=${TEST_BEAST}`, { method: 'DELETE' });
       } catch {
         // Best-effort cleanup
       }
@@ -52,35 +52,33 @@ describe("DM API Integration", () => {
   // =====================
   // Send & Read
   // =====================
-  describe("Send & Read", () => {
-    test("POST /api/dm sends a message", async () => {
+  describe('Send & Read', () => {
+    test('POST /api/dm sends a message', async () => {
       const { res, data } = await sendDM(
         TEST_BEAST,
         OTHER_BEAST,
-        `${TEST_PREFIX}hello ${Date.now()}`
+        `${TEST_PREFIX}hello ${Date.now()}`,
       );
       expect(res.ok).toBe(true);
       expect(data.message_id).toBeTruthy();
       expect(data.conversation_id).toBeTruthy();
     });
 
-    test("GET /api/dm/:name lists conversations", async () => {
+    test('GET /api/dm/:name lists conversations', async () => {
       const res = await fetch(`${BASE_URL}/api/dm/${TEST_BEAST}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.conversations).toBeInstanceOf(Array);
     });
 
-    test("GET /api/dm/:name/:other returns conversation thread", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/dm/${TEST_BEAST}/${OTHER_BEAST}`
-      );
+    test('GET /api/dm/:name/:other returns conversation thread', async () => {
+      const res = await fetch(`${BASE_URL}/api/dm/${TEST_BEAST}/${OTHER_BEAST}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.messages).toBeInstanceOf(Array);
     });
 
-    test("GET /api/dm/dashboard returns summary", async () => {
+    test('GET /api/dm/dashboard returns summary', async () => {
       const res = await fetch(`${BASE_URL}/api/dm/dashboard`);
       expect(res.ok).toBe(true);
     });
@@ -89,12 +87,11 @@ describe("DM API Integration", () => {
   // =====================
   // Read Tracking
   // =====================
-  describe("Read Tracking", () => {
-    test("PATCH /api/dm/:name/:other/read-all marks conversation read", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/dm/${TEST_BEAST}/${OTHER_BEAST}/read-all`,
-        { method: "PATCH" }
-      );
+  describe('Read Tracking', () => {
+    test('PATCH /api/dm/:name/:other/read-all marks conversation read', async () => {
+      const res = await fetch(`${BASE_URL}/api/dm/${TEST_BEAST}/${OTHER_BEAST}/read-all`, {
+        method: 'PATCH',
+      });
       expect(res.ok).toBe(true);
     });
   });
@@ -102,52 +99,50 @@ describe("DM API Integration", () => {
   // =====================
   // Validation
   // =====================
-  describe("Validation", () => {
-    test("POST DM without from fails", async () => {
+  describe('Validation', () => {
+    test('POST DM without from fails', async () => {
       const res = await fetch(`${BASE_URL}/api/dm`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ to: OTHER_BEAST, message: "no from" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to: OTHER_BEAST, message: 'no from' }),
       });
       expect(res.status).toBeGreaterThanOrEqual(400);
     });
 
-    test("POST DM without to fails", async () => {
+    test('POST DM without to fails', async () => {
       const res = await fetch(`${BASE_URL}/api/dm`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ from: TEST_BEAST, message: "no to" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ from: TEST_BEAST, message: 'no to' }),
       });
       expect(res.status).toBeGreaterThanOrEqual(400);
     });
 
-    test("POST DM without message fails", async () => {
+    test('POST DM without message fails', async () => {
       const res = await fetch(`${BASE_URL}/api/dm`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ from: TEST_BEAST, to: OTHER_BEAST }),
       });
       expect(res.status).toBeGreaterThanOrEqual(400);
     });
 
-    test("POST DM to self is handled", async () => {
+    test('POST DM to self is handled', async () => {
       const res = await fetch(`${BASE_URL}/api/dm`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           from: TEST_BEAST,
           to: TEST_BEAST,
-          message: "talking to myself",
+          message: 'talking to myself',
         }),
       });
       // Should either work or reject gracefully (no 500)
       expect(res.status).toBeLessThan(500);
     });
 
-    test("GET conversation with nonexistent beast returns empty or 404", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/dm/${TEST_BEAST}/nonexistent_beast_xyz`
-      );
+    test('GET conversation with nonexistent beast returns empty or 404', async () => {
+      const res = await fetch(`${BASE_URL}/api/dm/${TEST_BEAST}/nonexistent_beast_xyz`);
       expect(res.status).toBeLessThan(500);
     });
   });
@@ -155,68 +150,63 @@ describe("DM API Integration", () => {
   // =====================
   // Delete Messages
   // =====================
-  describe("Delete Messages", () => {
-    test("DELETE /api/dm/messages/:id removes a message", async () => {
+  describe('Delete Messages', () => {
+    test('DELETE /api/dm/messages/:id removes a message', async () => {
       const { data } = await sendDM(
         TEST_BEAST,
         OTHER_BEAST,
-        `${TEST_PREFIX}delete_test_${Date.now()}`
+        `${TEST_PREFIX}delete_test_${Date.now()}`,
       );
       const idx = createdMessageIds.indexOf(data.message_id);
       if (idx >= 0) createdMessageIds.splice(idx, 1); // Don't double-delete in cleanup
 
-      const res = await fetch(
-        `${BASE_URL}/api/dm/messages/${data.message_id}?as=${TEST_BEAST}`,
-        { method: "DELETE" }
-      );
+      const res = await fetch(`${BASE_URL}/api/dm/messages/${data.message_id}?as=${TEST_BEAST}`, {
+        method: 'DELETE',
+      });
       expect(res.ok).toBe(true);
     });
 
-    test("DELETE nonexistent message returns 404", async () => {
+    test('DELETE nonexistent message returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/dm/messages/99999999?as=${TEST_BEAST}`, {
-        method: "DELETE",
+        method: 'DELETE',
       });
       expect(res.status).toBe(404);
     });
 
-    test("DELETE without ?as= is rejected (auth required)", async () => {
+    test('DELETE without ?as= is rejected (auth required)', async () => {
       const { data } = await sendDM(
         TEST_BEAST,
         OTHER_BEAST,
-        `${TEST_PREFIX}auth_test_${Date.now()}`
+        `${TEST_PREFIX}auth_test_${Date.now()}`,
       );
-      const res = await fetch(
-        `${BASE_URL}/api/dm/messages/${data.message_id}`,
-        { method: "DELETE" }
-      );
+      const res = await fetch(`${BASE_URL}/api/dm/messages/${data.message_id}`, {
+        method: 'DELETE',
+      });
       expect(res.status).toBeGreaterThanOrEqual(400);
       expect(res.status).toBeLessThan(500);
       // Clean up since the delete failed
-      await fetch(
-        `${BASE_URL}/api/dm/messages/${data.message_id}?as=${TEST_BEAST}`,
-        { method: "DELETE" }
-      );
+      await fetch(`${BASE_URL}/api/dm/messages/${data.message_id}?as=${TEST_BEAST}`, {
+        method: 'DELETE',
+      });
       const idx = createdMessageIds.indexOf(data.message_id);
       if (idx >= 0) createdMessageIds.splice(idx, 1);
     });
 
-    test("DELETE by non-participant is rejected", async () => {
+    test('DELETE by non-participant is rejected', async () => {
       const { data } = await sendDM(
         TEST_BEAST,
         OTHER_BEAST,
-        `${TEST_PREFIX}idor_test_${Date.now()}`
+        `${TEST_PREFIX}idor_test_${Date.now()}`,
       );
       // Try deleting as a beast not in this conversation
-      const res = await fetch(
-        `${BASE_URL}/api/dm/messages/${data.message_id}?as=gnarl`,
-        { method: "DELETE" }
-      );
+      const res = await fetch(`${BASE_URL}/api/dm/messages/${data.message_id}?as=gnarl`, {
+        method: 'DELETE',
+      });
       expect(res.status).toBe(403);
       // Clean up
-      await fetch(
-        `${BASE_URL}/api/dm/messages/${data.message_id}?as=${TEST_BEAST}`,
-        { method: "DELETE" }
-      );
+      await fetch(`${BASE_URL}/api/dm/messages/${data.message_id}?as=${TEST_BEAST}`, {
+        method: 'DELETE',
+      });
       const idx = createdMessageIds.indexOf(data.message_id);
       if (idx >= 0) createdMessageIds.splice(idx, 1);
     });

--- a/src/integration/forum.test.ts
+++ b/src/integration/forum.test.ts
@@ -4,12 +4,12 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_BEAST = "pip";
-const OTHER_BEAST = "bertus";
-const TEST_PREFIX = "test_forum_";
+const BASE_URL = 'http://localhost:47778';
+const TEST_BEAST = 'pip';
+const OTHER_BEAST = 'bertus';
+const TEST_PREFIX = 'test_forum_';
 
 let testThreadId: number;
 let testMessageId: number;
@@ -26,12 +26,12 @@ async function isServerRunning(): Promise<boolean> {
 
 async function createThread(title: string, message: string) {
   const res = await fetch(`${BASE_URL}/api/thread`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       title,
       message,
-      role: "claude",
+      role: 'claude',
       author: TEST_BEAST,
     }),
   });
@@ -42,27 +42,27 @@ async function createThread(title: string, message: string) {
 
 async function postMessage(threadId: number, message: string, author = TEST_BEAST) {
   const res = await fetch(`${BASE_URL}/api/thread`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       thread_id: threadId,
       message,
-      role: "claude",
+      role: 'claude',
       author,
     }),
   });
   return { res, data: await res.json() };
 }
 
-describe("Forum API Integration", () => {
+describe('Forum API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
     // Create a test thread for use across tests
     const { data } = await createThread(
       `${TEST_PREFIX}main_thread`,
-      `${TEST_PREFIX}initial message`
+      `${TEST_PREFIX}initial message`,
     );
     testThreadId = data.thread_id;
     testMessageId = data.message_id;
@@ -73,9 +73,9 @@ describe("Forum API Integration", () => {
     for (const id of createdThreadIds) {
       try {
         await fetch(`${BASE_URL}/api/thread/${id}/status`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: "closed" }),
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'closed' }),
         });
       } catch {}
     }
@@ -84,8 +84,8 @@ describe("Forum API Integration", () => {
   // =====================
   // Threads — CRUD
   // =====================
-  describe("Threads — CRUD", () => {
-    test("GET /api/threads returns thread list", async () => {
+  describe('Threads — CRUD', () => {
+    test('GET /api/threads returns thread list', async () => {
       const res = await fetch(`${BASE_URL}/api/threads`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -93,24 +93,24 @@ describe("Forum API Integration", () => {
       expect(data.total).toBeGreaterThan(0);
     });
 
-    test("GET /api/threads with status filter", async () => {
+    test('GET /api/threads with status filter', async () => {
       const res = await fetch(`${BASE_URL}/api/threads?status=pending`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.threads).toBeInstanceOf(Array);
     });
 
-    test("POST /api/thread creates new thread", async () => {
+    test('POST /api/thread creates new thread', async () => {
       const { res, data } = await createThread(
         `${TEST_PREFIX}create_test`,
-        "Testing thread creation"
+        'Testing thread creation',
       );
       expect(res.ok).toBe(true);
       expect(data.thread_id).toBeTruthy();
       expect(data.message_id).toBeTruthy();
     });
 
-    test("GET /api/thread/:id returns thread with messages", async () => {
+    test('GET /api/thread/:id returns thread with messages', async () => {
       const res = await fetch(`${BASE_URL}/api/thread/${testThreadId}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -118,19 +118,17 @@ describe("Forum API Integration", () => {
       expect(data.messages.length).toBeGreaterThan(0);
     });
 
-    test("GET /api/thread/:id with limit and order", async () => {
+    test('GET /api/thread/:id with limit and order', async () => {
       // Add a few messages
       await postMessage(testThreadId, `${TEST_PREFIX}msg_1`);
       await postMessage(testThreadId, `${TEST_PREFIX}msg_2`);
-      const res = await fetch(
-        `${BASE_URL}/api/thread/${testThreadId}?limit=1&order=desc`
-      );
+      const res = await fetch(`${BASE_URL}/api/thread/${testThreadId}?limit=1&order=desc`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.messages.length).toBeLessThanOrEqual(1);
     });
 
-    test("GET nonexistent thread returns 404", async () => {
+    test('GET nonexistent thread returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/thread/99999`);
       expect(res.status).toBe(404);
     });
@@ -139,21 +137,18 @@ describe("Forum API Integration", () => {
   // =====================
   // Messages
   // =====================
-  describe("Messages", () => {
-    test("POST message to existing thread", async () => {
-      const { res, data } = await postMessage(
-        testThreadId,
-        `${TEST_PREFIX}reply message`
-      );
+  describe('Messages', () => {
+    test('POST message to existing thread', async () => {
+      const { res, data } = await postMessage(testThreadId, `${TEST_PREFIX}reply message`);
       expect(res.ok).toBe(true);
       expect(data.message_id).toBeTruthy();
       expect(data.thread_id).toBe(testThreadId);
     });
 
-    test("POST message with @mention notifies target", async () => {
+    test('POST message with @mention notifies target', async () => {
       const { res, data } = await postMessage(
         testThreadId,
-        `Hey @${OTHER_BEAST} check this ${TEST_PREFIX}mention_test`
+        `Hey @${OTHER_BEAST} check this ${TEST_PREFIX}mention_test`,
       );
       expect(res.ok).toBe(true);
       // Check that notified array includes the mentioned beast
@@ -162,14 +157,14 @@ describe("Forum API Integration", () => {
       }
     });
 
-    test("POST message with reply_to_id", async () => {
+    test('POST message with reply_to_id', async () => {
       const { res, data } = await fetch(`${BASE_URL}/api/thread`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           thread_id: testThreadId,
           message: `${TEST_PREFIX}reply to specific message`,
-          role: "claude",
+          role: 'claude',
           author: TEST_BEAST,
           reply_to_id: testMessageId,
         }),
@@ -178,14 +173,11 @@ describe("Forum API Integration", () => {
       expect(data.message_id).toBeTruthy();
     });
 
-    test("PATCH /api/message/:id edits message", async () => {
-      const { data: posted } = await postMessage(
-        testThreadId,
-        `${TEST_PREFIX}to_edit`
-      );
+    test('PATCH /api/message/:id edits message', async () => {
+      const { data: posted } = await postMessage(testThreadId, `${TEST_PREFIX}to_edit`);
       const res = await fetch(`${BASE_URL}/api/message/${posted.message_id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           content: `${TEST_PREFIX}edited content`,
           beast: TEST_BEAST,
@@ -194,23 +186,18 @@ describe("Forum API Integration", () => {
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/message/:id/history returns edit history", async () => {
-      const { data: posted } = await postMessage(
-        testThreadId,
-        `${TEST_PREFIX}history_test`
-      );
+    test('GET /api/message/:id/history returns edit history', async () => {
+      const { data: posted } = await postMessage(testThreadId, `${TEST_PREFIX}history_test`);
       // Edit it
       await fetch(`${BASE_URL}/api/message/${posted.message_id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           content: `${TEST_PREFIX}history_edited`,
           beast: TEST_BEAST,
         }),
       });
-      const res = await fetch(
-        `${BASE_URL}/api/message/${posted.message_id}/history`
-      );
+      const res = await fetch(`${BASE_URL}/api/message/${posted.message_id}/history`);
       expect(res.ok).toBe(true);
     });
   });
@@ -218,57 +205,43 @@ describe("Forum API Integration", () => {
   // =====================
   // Reactions
   // =====================
-  describe("Reactions", () => {
+  describe('Reactions', () => {
     let reactionMsgId: number;
 
     beforeAll(async () => {
-      const { data } = await postMessage(
-        testThreadId,
-        `${TEST_PREFIX}reaction_target`
-      );
+      const { data } = await postMessage(testThreadId, `${TEST_PREFIX}reaction_target`);
       reactionMsgId = data.message_id;
     });
 
-    test("POST /api/message/:id/react adds reaction", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/message/${reactionMsgId}/react`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: TEST_BEAST, emoji: "🔥" }),
-        }
-      );
+    test('POST /api/message/:id/react adds reaction', async () => {
+      const res = await fetch(`${BASE_URL}/api/message/${reactionMsgId}/react`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, emoji: '🔥' }),
+      });
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/message/:id/reactions returns reactions", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/message/${reactionMsgId}/reactions`
-      );
+    test('GET /api/message/:id/reactions returns reactions', async () => {
+      const res = await fetch(`${BASE_URL}/api/message/${reactionMsgId}/reactions`);
       expect(res.ok).toBe(true);
     });
 
-    test("DELETE /api/message/:id/react removes reaction", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/message/${reactionMsgId}/react`,
-        {
-          method: "DELETE",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: TEST_BEAST, emoji: "🔥" }),
-        }
-      );
+    test('DELETE /api/message/:id/react removes reaction', async () => {
+      const res = await fetch(`${BASE_URL}/api/message/${reactionMsgId}/react`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, emoji: '🔥' }),
+      });
       expect(res.ok).toBe(true);
     });
 
-    test("rejects unsupported emoji", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/message/${reactionMsgId}/react`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: TEST_BEAST, emoji: "invalid_emoji" }),
-        }
-      );
+    test('rejects unsupported emoji', async () => {
+      const res = await fetch(`${BASE_URL}/api/message/${reactionMsgId}/react`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, emoji: 'invalid_emoji' }),
+      });
       expect(res.status).toBe(400);
     });
   });
@@ -276,83 +249,71 @@ describe("Forum API Integration", () => {
   // =====================
   // Thread Management
   // =====================
-  describe("Thread Management", () => {
+  describe('Thread Management', () => {
     let managedThreadId: number;
 
     beforeAll(async () => {
       const { data } = await createThread(
         `${TEST_PREFIX}managed_thread`,
-        "Thread for management tests"
+        'Thread for management tests',
       );
       managedThreadId = data.thread_id;
     });
 
-    test("PATCH /:id/status changes status", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/thread/${managedThreadId}/status`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: "closed" }),
-        }
-      );
+    test('PATCH /:id/status changes status', async () => {
+      const res = await fetch(`${BASE_URL}/api/thread/${managedThreadId}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'closed' }),
+      });
       expect(res.ok).toBe(true);
 
       // Reopen
       await fetch(`${BASE_URL}/api/thread/${managedThreadId}/status`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "pending" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'pending' }),
       });
     });
 
-    test("PATCH /:id/pin toggles pin", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/thread/${managedThreadId}/pin`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ pinned: true }),
-        }
-      );
+    test('PATCH /:id/pin toggles pin', async () => {
+      const res = await fetch(`${BASE_URL}/api/thread/${managedThreadId}/pin`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pinned: true }),
+      });
       expect(res.ok).toBe(true);
 
       // Unpin
       await fetch(`${BASE_URL}/api/thread/${managedThreadId}/pin`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ pinned: false }),
       });
     });
 
-    test("PATCH /:id/lock locks thread", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/thread/${managedThreadId}/lock`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ locked: true }),
-        }
-      );
+    test('PATCH /:id/lock locks thread', async () => {
+      const res = await fetch(`${BASE_URL}/api/thread/${managedThreadId}/lock`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ locked: true }),
+      });
       expect(res.ok).toBe(true);
 
       // Unlock
       await fetch(`${BASE_URL}/api/thread/${managedThreadId}/lock`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ locked: false }),
       });
     });
 
-    test("PATCH /:id/category changes category", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/thread/${managedThreadId}/category`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ category: "announcement" }),
-        }
-      );
+    test('PATCH /:id/category changes category', async () => {
+      const res = await fetch(`${BASE_URL}/api/thread/${managedThreadId}/category`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category: 'announcement' }),
+      });
       expect(res.ok).toBe(true);
     });
   });
@@ -360,33 +321,31 @@ describe("Forum API Integration", () => {
   // =====================
   // Forum Metadata
   // =====================
-  describe("Forum Metadata", () => {
-    test("GET /api/forum/unread/:beast returns count", async () => {
+  describe('Forum Metadata', () => {
+    test('GET /api/forum/unread/:beast returns count', async () => {
       const res = await fetch(`${BASE_URL}/api/forum/unread/${TEST_BEAST}`);
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/forum/mentions/:beast returns mentions", async () => {
+    test('GET /api/forum/mentions/:beast returns mentions', async () => {
       const res = await fetch(`${BASE_URL}/api/forum/mentions/${TEST_BEAST}`);
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/forum/search returns results", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/forum/search?q=${TEST_PREFIX}`
-      );
+    test('GET /api/forum/search returns results', async () => {
+      const res = await fetch(`${BASE_URL}/api/forum/search?q=${TEST_PREFIX}`);
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/forum/activity returns timeline", async () => {
+    test('GET /api/forum/activity returns timeline', async () => {
       const res = await fetch(`${BASE_URL}/api/forum/activity?limit=5`);
       expect(res.ok).toBe(true);
     });
 
-    test("POST /api/forum/mute mutes thread", async () => {
+    test('POST /api/forum/mute mutes thread', async () => {
       const res = await fetch(`${BASE_URL}/api/forum/mute`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
           threadId: testThreadId,
@@ -397,8 +356,8 @@ describe("Forum API Integration", () => {
 
       // Unmute
       await fetch(`${BASE_URL}/api/forum/mute`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
           threadId: testThreadId,
@@ -407,10 +366,10 @@ describe("Forum API Integration", () => {
       });
     });
 
-    test("POST /api/forum/read marks thread as read", async () => {
+    test('POST /api/forum/read marks thread as read', async () => {
       const res = await fetch(`${BASE_URL}/api/forum/read`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
           threadId: testThreadId,
@@ -424,14 +383,14 @@ describe("Forum API Integration", () => {
   // =====================
   // Validation
   // =====================
-  describe("Validation", () => {
-    test("POST thread with empty message fails", async () => {
+  describe('Validation', () => {
+    test('POST thread with empty message fails', async () => {
       const res = await fetch(`${BASE_URL}/api/thread`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          title: "empty msg",
-          message: "",
+          title: 'empty msg',
+          message: '',
           author: TEST_BEAST,
         }),
       });
@@ -439,39 +398,33 @@ describe("Forum API Integration", () => {
     });
 
     // Fixed: Task #63 (ccdd877) — author now required
-    test("POST thread without author returns 400", async () => {
+    test('POST thread without author returns 400', async () => {
       const res = await fetch(`${BASE_URL}/api/thread`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: `${TEST_PREFIX}no_author`,
-          message: "test",
+          message: 'test',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("POST reaction without beast fails", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/message/${testMessageId}/react`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ emoji: "🔥" }),
-        }
-      );
+    test('POST reaction without beast fails', async () => {
+      const res = await fetch(`${BASE_URL}/api/message/${testMessageId}/react`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ emoji: '🔥' }),
+      });
       expect(res.status).toBeGreaterThanOrEqual(400);
     });
 
-    test("POST reaction without emoji fails", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/message/${testMessageId}/react`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: TEST_BEAST }),
-        }
-      );
+    test('POST reaction without emoji fails', async () => {
+      const res = await fetch(`${BASE_URL}/api/message/${testMessageId}/react`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST }),
+      });
       expect(res.status).toBeGreaterThanOrEqual(400);
     });
   });

--- a/src/integration/http.test.ts
+++ b/src/integration/http.test.ts
@@ -2,10 +2,10 @@
  * HTTP API Integration Tests
  * Tests denbook server endpoints
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import type { Subprocess } from "bun";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import type { Subprocess } from 'bun';
 
-const BASE_URL = "http://localhost:47778";
+const BASE_URL = 'http://localhost:47778';
 let serverProcess: Subprocess | null = null;
 
 async function waitForServer(maxAttempts = 30): Promise<boolean> {
@@ -30,21 +30,21 @@ async function isServerRunning(): Promise<boolean> {
   }
 }
 
-describe("HTTP API Integration", () => {
+describe('HTTP API Integration', () => {
   beforeAll(async () => {
     // Check if server already running
     if (await isServerRunning()) {
-      console.log("Using existing server");
+      console.log('Using existing server');
       return;
     }
 
     // Start server
-    console.log("Starting server...");
-    serverProcess = Bun.spawn(["bun", "run", "src/server.ts"], {
-      cwd: import.meta.dir.replace("/src/integration", ""),
-      stdout: "pipe",
-      stderr: "pipe",
-      env: { ...process.env, ORACLE_CHROMA_TIMEOUT: "3000" },
+    console.log('Starting server...');
+    serverProcess = Bun.spawn(['bun', 'run', 'src/server.ts'], {
+      cwd: import.meta.dir.replace('/src/integration', ''),
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, ORACLE_CHROMA_TIMEOUT: '3000' },
     });
 
     const ready = await waitForServer();
@@ -56,66 +56,67 @@ describe("HTTP API Integration", () => {
         try {
           const { value } = await reader.read();
           if (value) stderr = new TextDecoder().decode(value);
-        } catch { /* ignore */ }
+        } catch {
+          /* ignore */
+        }
       }
       throw new Error(`Server failed to start within 15 seconds.\nServer stderr: ${stderr}`);
     }
-    console.log("Server ready");
+    console.log('Server ready');
   }, 30_000);
 
   afterAll(() => {
     if (serverProcess) {
       serverProcess.kill();
-      console.log("Server stopped");
+      console.log('Server stopped');
     }
   });
 
   // ===================
   // Health & Stats
   // ===================
-  describe("Health & Stats", () => {
-    test("GET /api/health returns ok", async () => {
+  describe('Health & Stats', () => {
+    test('GET /api/health returns ok', async () => {
       const res = await fetch(`${BASE_URL}/api/health`);
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.status).toBe("ok");
+      expect(data.status).toBe('ok');
     });
 
-    test("GET /api/stats returns statistics", async () => {
+    test('GET /api/stats returns statistics', async () => {
       const res = await fetch(`${BASE_URL}/api/stats`);
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(typeof data.total).toBe("number");
+      expect(typeof data.total).toBe('number');
     }, 15_000);
-
   });
 
   // ===================
   // Search
   // ===================
-  describe("Search", () => {
-    test("GET /api/search with query returns results", async () => {
+  describe('Search', () => {
+    test('GET /api/search with query returns results', async () => {
       const res = await fetch(`${BASE_URL}/api/search?q=oracle`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     }, 30_000);
 
-    test("GET /api/search with type filter", async () => {
+    test('GET /api/search with type filter', async () => {
       const res = await fetch(`${BASE_URL}/api/search?q=test&type=learning`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     }, 30_000);
 
-    test("GET /api/search with limit and offset", async () => {
+    test('GET /api/search with limit and offset', async () => {
       const res = await fetch(`${BASE_URL}/api/search?q=test&limit=5&offset=0`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.results.length).toBeLessThanOrEqual(5);
     }, 30_000);
 
-    test("GET /api/search handles empty query", async () => {
+    test('GET /api/search handles empty query', async () => {
       const res = await fetch(`${BASE_URL}/api/search?q=`);
       // Should return empty or error gracefully
       expect(res.status).toBeLessThan(500);
@@ -125,22 +126,22 @@ describe("HTTP API Integration", () => {
   // ===================
   // List & Browse
   // ===================
-  describe("List & Browse", () => {
-    test("GET /api/list returns documents", async () => {
+  describe('List & Browse', () => {
+    test('GET /api/list returns documents', async () => {
       const res = await fetch(`${BASE_URL}/api/list`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     });
 
-    test("GET /api/list with type filter", async () => {
+    test('GET /api/list with type filter', async () => {
       const res = await fetch(`${BASE_URL}/api/list?type=principle`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     });
 
-    test("GET /api/list with pagination", async () => {
+    test('GET /api/list with pagination', async () => {
       const res = await fetch(`${BASE_URL}/api/list?limit=10&offset=0`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -151,54 +152,54 @@ describe("HTTP API Integration", () => {
   // ===================
   // Reflect
   // ===================
-  describe("Reflect", () => {
-    test("GET /api/reflect returns response", async () => {
+  describe('Reflect', () => {
+    test('GET /api/reflect returns response', async () => {
       const res = await fetch(`${BASE_URL}/api/reflect`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       // Empty DB returns { error: "No documents found" }, populated returns { content: ... }
-      expect(data).toHaveProperty(data.content ? "content" : "error");
+      expect(data).toHaveProperty(data.content ? 'content' : 'error');
     });
   });
 
   // ===================
   // Dashboard
   // ===================
-  describe("Dashboard", () => {
-    test("GET /api/dashboard returns summary", async () => {
+  describe('Dashboard', () => {
+    test('GET /api/dashboard returns summary', async () => {
       const res = await fetch(`${BASE_URL}/api/dashboard`);
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(typeof data).toBe("object");
+      expect(typeof data).toBe('object');
     });
 
-    test("GET /api/dashboard/activity returns history", async () => {
+    test('GET /api/dashboard/activity returns history', async () => {
       const res = await fetch(`${BASE_URL}/api/dashboard/activity?days=7`);
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(Array.isArray(data.activity) || typeof data === "object").toBe(true);
+      expect(Array.isArray(data.activity) || typeof data === 'object').toBe(true);
     });
 
-    test("GET /api/session/stats returns usage", async () => {
+    test('GET /api/session/stats returns usage', async () => {
       const res = await fetch(`${BASE_URL}/api/session/stats`);
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(typeof data).toBe("object");
+      expect(typeof data).toBe('object');
     });
   });
 
   // ===================
   // Threads
   // ===================
-  describe("Threads", () => {
-    test("GET /api/threads returns thread list", async () => {
+  describe('Threads', () => {
+    test('GET /api/threads returns thread list', async () => {
       const res = await fetch(`${BASE_URL}/api/threads`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.threads)).toBe(true);
     });
 
-    test("GET /api/threads with status filter", async () => {
+    test('GET /api/threads with status filter', async () => {
       const res = await fetch(`${BASE_URL}/api/threads?status=active`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -209,14 +210,14 @@ describe("HTTP API Integration", () => {
   // ===================
   // Error Handling
   // ===================
-  describe("Error Handling", () => {
-    test("Invalid endpoint returns 404", async () => {
+  describe('Error Handling', () => {
+    test('Invalid endpoint returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/nonexistent`);
       // Should be 404 or serve SPA
       expect(res.status).toBeLessThan(500);
     });
 
-    test("GET /api/file without path returns error", async () => {
+    test('GET /api/file without path returns error', async () => {
       const res = await fetch(`${BASE_URL}/api/file`);
       expect(res.status).toBeGreaterThanOrEqual(400);
     });

--- a/src/integration/library.test.ts
+++ b/src/integration/library.test.ts
@@ -4,10 +4,10 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_PREFIX = "test_library_";
+const BASE_URL = 'http://localhost:47778';
+const TEST_PREFIX = 'test_library_';
 const createdEntryIds: number[] = [];
 
 async function isServerRunning(): Promise<boolean> {
@@ -19,17 +19,17 @@ async function isServerRunning(): Promise<boolean> {
   }
 }
 
-describe("Library API Integration", () => {
+describe('Library API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   afterAll(async () => {
     for (const id of createdEntryIds) {
       try {
-        await fetch(`${BASE_URL}/api/library/${id}?as=pip`, { method: "DELETE" });
+        await fetch(`${BASE_URL}/api/library/${id}?as=pip`, { method: 'DELETE' });
       } catch {}
     }
   });
@@ -37,52 +37,50 @@ describe("Library API Integration", () => {
   // =====================
   // List & Filter
   // =====================
-  describe("List & Filter", () => {
-    test("GET /api/library returns entry list", async () => {
+  describe('List & Filter', () => {
+    test('GET /api/library returns entry list', async () => {
       const res = await fetch(`${BASE_URL}/api/library`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.entries).toBeInstanceOf(Array);
-      expect(typeof data.total).toBe("number");
+      expect(typeof data.total).toBe('number');
     });
 
-    test("GET /api/library with search query", async () => {
+    test('GET /api/library with search query', async () => {
       const res = await fetch(`${BASE_URL}/api/library?q=test`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.entries).toBeInstanceOf(Array);
     });
 
-    test("GET /api/library with type filter", async () => {
+    test('GET /api/library with type filter', async () => {
       const res = await fetch(`${BASE_URL}/api/library?type=research`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.entries).toBeInstanceOf(Array);
       for (const entry of data.entries) {
-        expect(entry.type).toBe("research");
+        expect(entry.type).toBe('research');
       }
     });
 
-    test("GET /api/library with author filter", async () => {
+    test('GET /api/library with author filter', async () => {
       const res = await fetch(`${BASE_URL}/api/library?author=gnarl`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.entries).toBeInstanceOf(Array);
       for (const entry of data.entries) {
-        expect(entry.author).toBe("gnarl");
+        expect(entry.author).toBe('gnarl');
       }
     });
 
-    test("GET /api/library with pagination", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/library?limit=2&offset=0`
-      );
+    test('GET /api/library with pagination', async () => {
+      const res = await fetch(`${BASE_URL}/api/library?limit=2&offset=0`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.entries.length).toBeLessThanOrEqual(2);
     });
 
-    test("GET /api/library with tag filter", async () => {
+    test('GET /api/library with tag filter', async () => {
       const res = await fetch(`${BASE_URL}/api/library?tag=security`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -93,89 +91,89 @@ describe("Library API Integration", () => {
   // =====================
   // Create
   // =====================
-  describe("Create", () => {
-    test("POST /api/library creates entry", async () => {
+  describe('Create', () => {
+    test('POST /api/library creates entry', async () => {
       const res = await fetch(`${BASE_URL}/api/library`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: `${TEST_PREFIX}QA Test Entry`,
-          content: "Test content for integration testing",
-          author: "pip",
-          type: "learning",
-          tags: ["test", "qa"],
+          content: 'Test content for integration testing',
+          author: 'pip',
+          type: 'learning',
+          tags: ['test', 'qa'],
         }),
       });
       expect(res.status).toBe(201);
       const data = await res.json();
       expect(data.id).toBeTruthy();
       expect(data.title).toContain(TEST_PREFIX);
-      expect(data.type).toBe("learning");
+      expect(data.type).toBe('learning');
       createdEntryIds.push(data.id);
     });
 
-    test("POST /api/library with valid type", async () => {
+    test('POST /api/library with valid type', async () => {
       const res = await fetch(`${BASE_URL}/api/library`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: `${TEST_PREFIX}Research Entry`,
-          content: "Research content",
-          author: "pip",
-          type: "research",
+          content: 'Research content',
+          author: 'pip',
+          type: 'research',
         }),
       });
       expect(res.status).toBe(201);
       const data = await res.json();
-      expect(data.type).toBe("research");
+      expect(data.type).toBe('research');
       createdEntryIds.push(data.id);
     });
 
-    test("POST /api/library defaults invalid type to learning", async () => {
+    test('POST /api/library defaults invalid type to learning', async () => {
       const res = await fetch(`${BASE_URL}/api/library`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: `${TEST_PREFIX}Bad Type Entry`,
-          content: "Content with bad type",
-          author: "pip",
-          type: "nonexistent_type",
+          content: 'Content with bad type',
+          author: 'pip',
+          type: 'nonexistent_type',
         }),
       });
       expect(res.status).toBe(201);
       const data = await res.json();
-      expect(data.type).toBe("learning");
+      expect(data.type).toBe('learning');
       createdEntryIds.push(data.id);
     });
 
-    test("POST /api/library rejects missing required fields", async () => {
+    test('POST /api/library rejects missing required fields', async () => {
       const res = await fetch(`${BASE_URL}/api/library`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          title: "No content or author",
+          title: 'No content or author',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("POST /api/library rejects missing title", async () => {
+    test('POST /api/library rejects missing title', async () => {
       const res = await fetch(`${BASE_URL}/api/library`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          content: "Content without title",
-          author: "pip",
+          content: 'Content without title',
+          author: 'pip',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("POST /api/library rejects invalid JSON", async () => {
+    test('POST /api/library rejects invalid JSON', async () => {
       const res = await fetch(`${BASE_URL}/api/library`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: "not json",
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
       });
       expect(res.status).toBe(400);
     });
@@ -184,13 +182,11 @@ describe("Library API Integration", () => {
   // =====================
   // Read Single
   // =====================
-  describe("Read Single", () => {
-    test("GET /api/library/:id returns entry", async () => {
+  describe('Read Single', () => {
+    test('GET /api/library/:id returns entry', async () => {
       if (createdEntryIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/library/${createdEntryIds[0]}`
-      );
+      const res = await fetch(`${BASE_URL}/api/library/${createdEntryIds[0]}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.id).toBe(createdEntryIds[0]);
@@ -201,7 +197,7 @@ describe("Library API Integration", () => {
       expect(data.updated_at).toBeTruthy();
     });
 
-    test("GET /api/library/99999 returns 404", async () => {
+    test('GET /api/library/99999 returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/library/99999`);
       expect(res.status).toBe(404);
     });
@@ -210,72 +206,60 @@ describe("Library API Integration", () => {
   // =====================
   // Update
   // =====================
-  describe("Update", () => {
-    test("PATCH /api/library/:id updates title", async () => {
+  describe('Update', () => {
+    test('PATCH /api/library/:id updates title', async () => {
       if (createdEntryIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/library/${createdEntryIds[0]}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            title: `${TEST_PREFIX}Updated Title`,
-          }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/library/${createdEntryIds[0]}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: `${TEST_PREFIX}Updated Title`,
+        }),
+      });
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.title).toBe(`${TEST_PREFIX}Updated Title`);
     });
 
-    test("PATCH /api/library/:id updates content", async () => {
+    test('PATCH /api/library/:id updates content', async () => {
       if (createdEntryIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/library/${createdEntryIds[0]}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            content: "Updated content by Pip QA",
-          }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/library/${createdEntryIds[0]}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content: 'Updated content by Pip QA',
+        }),
+      });
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.content).toBe("Updated content by Pip QA");
+      expect(data.content).toBe('Updated content by Pip QA');
     });
 
-    test("PATCH /api/library/:id updates tags", async () => {
+    test('PATCH /api/library/:id updates tags', async () => {
       if (createdEntryIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/library/${createdEntryIds[0]}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            tags: ["updated", "qa", "pip"],
-          }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/library/${createdEntryIds[0]}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tags: ['updated', 'qa', 'pip'],
+        }),
+      });
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.tags).toEqual(["updated", "qa", "pip"]);
+      expect(data.tags).toEqual(['updated', 'qa', 'pip']);
     });
 
-    test("PATCH /api/library/:id rejects invalid JSON", async () => {
+    test('PATCH /api/library/:id rejects invalid JSON', async () => {
       if (createdEntryIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/library/${createdEntryIds[0]}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: "not json",
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/library/${createdEntryIds[0]}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      });
       expect(res.status).toBe(400);
     });
   });
@@ -283,15 +267,15 @@ describe("Library API Integration", () => {
   // =====================
   // Types
   // =====================
-  describe("Types", () => {
-    test("GET /api/library/types returns type counts", async () => {
+  describe('Types', () => {
+    test('GET /api/library/types returns type counts', async () => {
       const res = await fetch(`${BASE_URL}/api/library/types`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.types).toBeInstanceOf(Array);
       for (const t of data.types) {
         expect(t.type).toBeTruthy();
-        expect(typeof t.count).toBe("number");
+        expect(typeof t.count).toBe('number');
       }
     });
   });

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -8,49 +8,52 @@
  * To run: ensure no other MCP process is using stdio, then `bun test src/integration/mcp.test.ts`
  * These tests are excluded from the default `bun test` via bunfig.toml preload/filter.
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import type { Subprocess } from "bun";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import type { Subprocess } from 'bun';
 
 interface McpRequest {
-  jsonrpc: "2.0";
+  jsonrpc: '2.0';
   id: number;
   method: string;
   params?: Record<string, unknown>;
 }
 
 interface McpResponse {
-  jsonrpc: "2.0";
+  jsonrpc: '2.0';
   id: number;
   result?: unknown;
   error?: { code: number; message: string };
 }
 
-let mcpProcess: Subprocess<"pipe", "pipe", "pipe"> | null = null;
+let mcpProcess: Subprocess<'pipe', 'pipe', 'pipe'> | null = null;
 let requestId = 0;
 
-async function sendMcpRequest(method: string, params?: Record<string, unknown>): Promise<McpResponse> {
-  if (!mcpProcess) throw new Error("MCP process not started");
+async function sendMcpRequest(
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<McpResponse> {
+  if (!mcpProcess) throw new Error('MCP process not started');
 
   const request: McpRequest = {
-    jsonrpc: "2.0",
+    jsonrpc: '2.0',
     id: ++requestId,
     method,
     params,
   };
 
-  const requestLine = JSON.stringify(request) + "\n";
+  const requestLine = JSON.stringify(request) + '\n';
   mcpProcess.stdin.write(requestLine);
 
   // Read response with timeout
   const reader = mcpProcess.stdout.getReader();
   const decoder = new TextDecoder();
-  let buffer = "";
+  let buffer = '';
 
   const timeoutPromise = new Promise<never>((_, reject) =>
     setTimeout(() => {
       reader.releaseLock();
-      reject(new Error("MCP request timed out after 5s"));
-    }, 5000)
+      reject(new Error('MCP request timed out after 5s'));
+    }, 5000),
   );
 
   const readPromise = (async () => {
@@ -59,7 +62,7 @@ async function sendMcpRequest(method: string, params?: Record<string, unknown>):
       if (done) break;
 
       buffer += decoder.decode(value);
-      const lines = buffer.split("\n");
+      const lines = buffer.split('\n');
 
       for (const line of lines) {
         if (line.trim()) {
@@ -77,14 +80,14 @@ async function sendMcpRequest(method: string, params?: Record<string, unknown>):
     }
 
     reader.releaseLock();
-    throw new Error("No response received - MCP process stdout closed");
+    throw new Error('No response received - MCP process stdout closed');
   })();
 
   return Promise.race([readPromise, timeoutPromise]);
 }
 
 async function callTool(name: string, args: Record<string, unknown> = {}): Promise<unknown> {
-  const response = await sendMcpRequest("tools/call", {
+  const response = await sendMcpRequest('tools/call', {
     name,
     arguments: args,
   });
@@ -98,26 +101,26 @@ async function callTool(name: string, args: Record<string, unknown> = {}): Promi
 
 // MCP tests require spawning an MCP server process - they're environment-dependent
 // and excluded from the default test run. Run explicitly when testing MCP changes.
-const MCP_TEST_ENABLED = process.env.MCP_TEST === "1";
+const MCP_TEST_ENABLED = process.env.MCP_TEST === '1';
 
-describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
+describe.skipIf(!MCP_TEST_ENABLED)('MCP Integration', () => {
   beforeAll(async () => {
     // Start MCP server
-    mcpProcess = Bun.spawn(["bun", "run", "src/index.ts"], {
-      cwd: import.meta.dir.replace("/src/integration", ""),
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
+    mcpProcess = Bun.spawn(['bun', 'run', 'src/index.ts'], {
+      cwd: import.meta.dir.replace('/src/integration', ''),
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
     });
 
     // Wait for server to initialize
     await Bun.sleep(2000);
 
     // Initialize connection
-    await sendMcpRequest("initialize", {
-      protocolVersion: "2024-11-05",
+    await sendMcpRequest('initialize', {
+      protocolVersion: '2024-11-05',
       capabilities: {},
-      clientInfo: { name: "test-client", version: "1.0.0" },
+      clientInfo: { name: 'test-client', version: '1.0.0' },
     });
   });
 
@@ -130,9 +133,9 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // ===================
   // Tool Listing
   // ===================
-  describe("Tool Discovery", () => {
-    test("lists available tools", async () => {
-      const response = await sendMcpRequest("tools/list");
+  describe('Tool Discovery', () => {
+    test('lists available tools', async () => {
+      const response = await sendMcpRequest('tools/list');
       expect(response.result).toBeDefined();
 
       const result = response.result as { tools: Array<{ name: string }> };
@@ -141,49 +144,49 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
 
       // Check for core tools
       const toolNames = result.tools.map((t) => t.name);
-      expect(toolNames).toContain("oracle_search");
-      expect(toolNames).toContain("oracle_list");
-      expect(toolNames).toContain("oracle_stats");
+      expect(toolNames).toContain('oracle_search');
+      expect(toolNames).toContain('oracle_list');
+      expect(toolNames).toContain('oracle_stats');
     });
   });
 
   // ===================
   // Read-Only Tools
   // ===================
-  describe("Read-Only Tools", () => {
-    test("oracle_search returns results", async () => {
-      const result = await callTool("oracle_search", {
-        query: "oracle",
+  describe('Read-Only Tools', () => {
+    test('oracle_search returns results', async () => {
+      const result = await callTool('oracle_search', {
+        query: 'oracle',
         limit: 5,
       });
 
       expect(result).toBeDefined();
-      expect(typeof result).toBe("object");
+      expect(typeof result).toBe('object');
     });
 
-    test("oracle_list returns documents", async () => {
-      const result = await callTool("oracle_list", {
+    test('oracle_list returns documents', async () => {
+      const result = await callTool('oracle_list', {
         limit: 10,
       });
 
       expect(result).toBeDefined();
     });
 
-    test("oracle_stats returns statistics", async () => {
-      const result = await callTool("oracle_stats", {});
+    test('oracle_stats returns statistics', async () => {
+      const result = await callTool('oracle_stats', {});
       expect(result).toBeDefined();
     });
 
-    test("oracle_concepts returns concept list", async () => {
-      const result = await callTool("oracle_concepts", {
+    test('oracle_concepts returns concept list', async () => {
+      const result = await callTool('oracle_concepts', {
         limit: 20,
       });
 
       expect(result).toBeDefined();
     });
 
-    test("oracle_reflect returns random wisdom", async () => {
-      const result = await callTool("oracle_reflect", {});
+    test('oracle_reflect returns random wisdom', async () => {
+      const result = await callTool('oracle_reflect', {});
       expect(result).toBeDefined();
     });
   });
@@ -191,18 +194,18 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // ===================
   // Thread Tools
   // ===================
-  describe("Thread Tools", () => {
-    test("oracle_threads lists threads", async () => {
-      const result = await callTool("oracle_threads", {
+  describe('Thread Tools', () => {
+    test('oracle_threads lists threads', async () => {
+      const result = await callTool('oracle_threads', {
         limit: 10,
       });
 
       expect(result).toBeDefined();
     });
 
-    test("oracle_threads with status filter", async () => {
-      const result = await callTool("oracle_threads", {
-        status: "active",
+    test('oracle_threads with status filter', async () => {
+      const result = await callTool('oracle_threads', {
+        status: 'active',
         limit: 5,
       });
 
@@ -213,9 +216,9 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // ===================
   // Trace Tools
   // ===================
-  describe("Trace Tools", () => {
-    test("oracle_trace_list returns traces", async () => {
-      const result = await callTool("oracle_trace_list", {
+  describe('Trace Tools', () => {
+    test('oracle_trace_list returns traces', async () => {
+      const result = await callTool('oracle_trace_list', {
         limit: 10,
       });
 
@@ -226,20 +229,20 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // ===================
   // Error Handling
   // ===================
-  describe("Error Handling", () => {
-    test("handles invalid tool name", async () => {
+  describe('Error Handling', () => {
+    test('handles invalid tool name', async () => {
       try {
-        await callTool("nonexistent_tool", {});
+        await callTool('nonexistent_tool', {});
         expect(true).toBe(false); // Should have thrown
       } catch (error) {
         expect(error).toBeDefined();
       }
     });
 
-    test("handles missing required params", async () => {
+    test('handles missing required params', async () => {
       try {
         // oracle_search requires 'query' param
-        await callTool("oracle_search", {});
+        await callTool('oracle_search', {});
         // May or may not throw depending on implementation
       } catch (error) {
         expect(error).toBeDefined();

--- a/src/integration/projects.test.ts
+++ b/src/integration/projects.test.ts
@@ -4,10 +4,10 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_PREFIX = "test_projects_";
+const BASE_URL = 'http://localhost:47778';
+const TEST_PREFIX = 'test_projects_';
 const createdProjectIds: number[] = [];
 
 async function isServerRunning(): Promise<boolean> {
@@ -19,17 +19,17 @@ async function isServerRunning(): Promise<boolean> {
   }
 }
 
-describe("Projects API Integration", () => {
+describe('Projects API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   afterAll(async () => {
     for (const id of createdProjectIds) {
       try {
-        await fetch(`${BASE_URL}/api/projects/${id}?as=pip`, { method: "DELETE" });
+        await fetch(`${BASE_URL}/api/projects/${id}?as=pip`, { method: 'DELETE' });
       } catch {}
     }
   });
@@ -37,15 +37,15 @@ describe("Projects API Integration", () => {
   // =====================
   // List
   // =====================
-  describe("List", () => {
-    test("GET /api/projects returns active projects", async () => {
+  describe('List', () => {
+    test('GET /api/projects returns active projects', async () => {
       const res = await fetch(`${BASE_URL}/api/projects`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.projects).toBeInstanceOf(Array);
     });
 
-    test("GET /api/projects with status filter", async () => {
+    test('GET /api/projects with status filter', async () => {
       const res = await fetch(`${BASE_URL}/api/projects?status=archived`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -56,15 +56,15 @@ describe("Projects API Integration", () => {
   // =====================
   // Create
   // =====================
-  describe("Create", () => {
-    test("POST /api/projects creates project", async () => {
+  describe('Create', () => {
+    test('POST /api/projects creates project', async () => {
       const res = await fetch(`${BASE_URL}/api/projects`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: `${TEST_PREFIX}QA Test Project`,
-          description: "Test project for integration testing",
-          created_by: "pip",
+          description: 'Test project for integration testing',
+          created_by: 'pip',
         }),
       });
       expect(res.status).toBe(201);
@@ -74,22 +74,22 @@ describe("Projects API Integration", () => {
       createdProjectIds.push(data.id);
     });
 
-    test("POST /api/projects rejects missing name", async () => {
+    test('POST /api/projects rejects missing name', async () => {
       const res = await fetch(`${BASE_URL}/api/projects`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          description: "No name",
-          created_by: "pip",
+          description: 'No name',
+          created_by: 'pip',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("POST /api/projects rejects missing created_by", async () => {
+    test('POST /api/projects rejects missing created_by', async () => {
       const res = await fetch(`${BASE_URL}/api/projects`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: `${TEST_PREFIX}No Creator`,
         }),
@@ -101,22 +101,20 @@ describe("Projects API Integration", () => {
   // =====================
   // Detail
   // =====================
-  describe("Detail", () => {
-    test("GET /api/projects/:id returns project with task counts", async () => {
+  describe('Detail', () => {
+    test('GET /api/projects/:id returns project with task counts', async () => {
       if (createdProjectIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/projects/${createdProjectIds[0]}`
-      );
+      const res = await fetch(`${BASE_URL}/api/projects/${createdProjectIds[0]}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.id).toBe(createdProjectIds[0]);
       expect(data.name).toContain(TEST_PREFIX);
       expect(data.task_counts).toBeTruthy();
-      expect(typeof data.task_counts).toBe("object");
+      expect(typeof data.task_counts).toBe('object');
     });
 
-    test("GET /api/projects/99999 returns 404", async () => {
+    test('GET /api/projects/99999 returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/projects/99999`);
       expect(res.status).toBe(404);
     });
@@ -125,52 +123,43 @@ describe("Projects API Integration", () => {
   // =====================
   // Update
   // =====================
-  describe("Update", () => {
-    test("PATCH /api/projects/:id updates name", async () => {
+  describe('Update', () => {
+    test('PATCH /api/projects/:id updates name', async () => {
       if (createdProjectIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/projects/${createdProjectIds[0]}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            name: `${TEST_PREFIX}Updated Name`,
-          }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/projects/${createdProjectIds[0]}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: `${TEST_PREFIX}Updated Name`,
+        }),
+      });
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.name).toBe(`${TEST_PREFIX}Updated Name`);
     });
 
-    test("PATCH /api/projects/:id updates status", async () => {
+    test('PATCH /api/projects/:id updates status', async () => {
       if (createdProjectIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/projects/${createdProjectIds[0]}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: "archived" }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/projects/${createdProjectIds[0]}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'archived' }),
+      });
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.status).toBe("archived");
+      expect(data.status).toBe('archived');
     });
 
-    test("PATCH /api/projects/:id rejects empty update", async () => {
+    test('PATCH /api/projects/:id rejects empty update', async () => {
       if (createdProjectIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/projects/${createdProjectIds[0]}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({}),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/projects/${createdProjectIds[0]}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
       expect(res.status).toBe(400);
     });
   });

--- a/src/integration/queue.test.ts
+++ b/src/integration/queue.test.ts
@@ -4,9 +4,9 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect, beforeAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
+const BASE_URL = 'http://localhost:47778';
 
 async function isServerRunning(): Promise<boolean> {
   try {
@@ -17,40 +17,40 @@ async function isServerRunning(): Promise<boolean> {
   }
 }
 
-describe("Queue API Integration", () => {
+describe('Queue API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   // =====================
   // List
   // =====================
-  describe("List", () => {
-    test("GET /api/queue/gorn returns pending items", async () => {
+  describe('List', () => {
+    test('GET /api/queue/gorn returns pending items', async () => {
       const res = await fetch(`${BASE_URL}/api/queue/gorn`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.items).toBeInstanceOf(Array);
-      expect(typeof data.total).toBe("number");
+      expect(typeof data.total).toBe('number');
     });
 
-    test("GET /api/queue/gorn with status filter", async () => {
+    test('GET /api/queue/gorn with status filter', async () => {
       const res = await fetch(`${BASE_URL}/api/queue/gorn?status=decided`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.items).toBeInstanceOf(Array);
     });
 
-    test("GET /api/queue/gorn with deferred filter", async () => {
+    test('GET /api/queue/gorn with deferred filter', async () => {
       const res = await fetch(`${BASE_URL}/api/queue/gorn?status=deferred`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.items).toBeInstanceOf(Array);
     });
 
-    test("GET /api/queue/gorn with withdrawn filter", async () => {
+    test('GET /api/queue/gorn with withdrawn filter', async () => {
       const res = await fetch(`${BASE_URL}/api/queue/gorn?status=withdrawn`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -61,21 +61,21 @@ describe("Queue API Integration", () => {
   // =====================
   // Tag (POST)
   // =====================
-  describe("Tag", () => {
-    test("POST /api/queue/gorn rejects missing thread_id", async () => {
+  describe('Tag', () => {
+    test('POST /api/queue/gorn rejects missing thread_id', async () => {
       const res = await fetch(`${BASE_URL}/api/queue/gorn`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tagged_by: "pip" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tagged_by: 'pip' }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("POST /api/queue/gorn rejects invalid JSON", async () => {
+    test('POST /api/queue/gorn rejects invalid JSON', async () => {
       const res = await fetch(`${BASE_URL}/api/queue/gorn`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: "not json",
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
       });
       expect(res.status).toBe(400);
     });
@@ -84,12 +84,12 @@ describe("Queue API Integration", () => {
   // =====================
   // Update Status (PATCH)
   // =====================
-  describe("Update Status", () => {
-    test("PATCH /api/queue/gorn/:id rejects invalid status", async () => {
+  describe('Update Status', () => {
+    test('PATCH /api/queue/gorn/:id rejects invalid status', async () => {
       const res = await fetch(`${BASE_URL}/api/queue/gorn/1`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "invalid", as: "gorn" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'invalid', as: 'gorn' }),
       });
       expect(res.status).toBe(400);
     });
@@ -97,11 +97,11 @@ describe("Queue API Integration", () => {
     // Note: localhost requests are trusted (isTrustedRequest=true),
     // so the `as` field check is bypassed for local requests.
     // Auth enforcement only applies to non-local (browser) requests.
-    test("PATCH /api/queue/gorn/:id accepts local requests (trusted)", async () => {
+    test('PATCH /api/queue/gorn/:id accepts local requests (trusted)', async () => {
       const res = await fetch(`${BASE_URL}/api/queue/gorn/1`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "decided", as: "pip" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'decided', as: 'pip' }),
       });
       // Local requests bypass auth — this is by design
       expect(res.ok).toBe(true);

--- a/src/integration/scheduler.test.ts
+++ b/src/integration/scheduler.test.ts
@@ -5,14 +5,14 @@
  * Tests: CRUD, ownership/IDOR, validation, trigger lifecycle, datetime handling
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_BEAST = "pip";
-const OTHER_BEAST = "bertus";
+const BASE_URL = 'http://localhost:47778';
+const TEST_BEAST = 'pip';
+const OTHER_BEAST = 'bertus';
 
 // Test data prefix for isolation
-const TEST_PREFIX = "test_sched_";
+const TEST_PREFIX = 'test_sched_';
 const createdScheduleIds: number[] = [];
 
 async function isServerRunning(): Promise<boolean> {
@@ -28,12 +28,12 @@ async function createSchedule(overrides: Record<string, unknown> = {}) {
   const body = {
     beast: TEST_BEAST,
     task: `${TEST_PREFIX}${Date.now()}`,
-    interval: "1d",
+    interval: '1d',
     ...overrides,
   };
   const res = await fetch(`${BASE_URL}/api/schedules`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
   if (res.ok) {
@@ -46,16 +46,16 @@ async function createSchedule(overrides: Record<string, unknown> = {}) {
 
 async function deleteSchedule(id: number, beast = TEST_BEAST) {
   return fetch(`${BASE_URL}/api/schedules/${id}`, {
-    method: "DELETE",
-    headers: { "Content-Type": "application/json" },
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ beast }),
   });
 }
 
-describe("Scheduler API Integration", () => {
+describe('Scheduler API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
@@ -73,17 +73,17 @@ describe("Scheduler API Integration", () => {
   // =====================
   // Health
   // =====================
-  describe("Health", () => {
-    test("GET /api/scheduler/health returns running status", async () => {
+  describe('Health', () => {
+    test('GET /api/scheduler/health returns running status', async () => {
       const res = await fetch(`${BASE_URL}/api/scheduler/health`);
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.status).toBe("running");
+      expect(data.status).toBe('running');
       expect(data.interval_seconds).toBe(10);
       expect(data.last_check).toBeTruthy();
     });
 
-    test("health last_check updates within 15 seconds", async () => {
+    test('health last_check updates within 15 seconds', async () => {
       const res1 = await fetch(`${BASE_URL}/api/scheduler/health`);
       const data1 = await res1.json();
       await Bun.sleep(12_000);
@@ -96,15 +96,15 @@ describe("Scheduler API Integration", () => {
   // =====================
   // CRUD — Happy Path
   // =====================
-  describe("CRUD — Happy Path", () => {
-    test("GET /api/schedules returns schedule list", async () => {
+  describe('CRUD — Happy Path', () => {
+    test('GET /api/schedules returns schedule list', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.schedules).toBeInstanceOf(Array);
     });
 
-    test("GET /api/schedules?beast=X filters by beast", async () => {
+    test('GET /api/schedules?beast=X filters by beast', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules?beast=${TEST_BEAST}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -113,22 +113,22 @@ describe("Scheduler API Integration", () => {
       }
     });
 
-    test("POST /api/schedules creates a schedule", async () => {
+    test('POST /api/schedules creates a schedule', async () => {
       const { res, data } = await createSchedule({
         task: `${TEST_PREFIX}create_happy`,
-        interval: "1h",
+        interval: '1h',
       });
       expect(res.status).toBe(201);
       expect(data.beast).toBe(TEST_BEAST);
       expect(data.task).toBe(`${TEST_PREFIX}create_happy`);
-      expect(data.interval).toBe("1h");
+      expect(data.interval).toBe('1h');
       expect(data.interval_seconds).toBe(3600);
       expect(data.enabled).toBe(1);
-      expect(data.trigger_status).toBe("pending");
+      expect(data.trigger_status).toBe('pending');
       expect(data.next_due_at).toBeTruthy();
     });
 
-    test("GET /api/schedules/:id returns single schedule", async () => {
+    test('GET /api/schedules/:id returns single schedule', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}get_single`,
       });
@@ -139,22 +139,22 @@ describe("Scheduler API Integration", () => {
       expect(data.task).toBe(`${TEST_PREFIX}get_single`);
     });
 
-    test("PATCH /api/schedules/:id updates schedule", async () => {
+    test('PATCH /api/schedules/:id updates schedule', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}patch_happy`,
       });
       const res = await fetch(`${BASE_URL}/api/schedules/${created.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ beast: TEST_BEAST, interval: "3h" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, interval: '3h' }),
       });
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.interval).toBe("3h");
+      expect(data.interval).toBe('3h');
       expect(data.interval_seconds).toBe(10800);
     });
 
-    test("DELETE /api/schedules/:id removes schedule", async () => {
+    test('DELETE /api/schedules/:id removes schedule', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}delete_happy`,
       });
@@ -167,78 +167,75 @@ describe("Scheduler API Integration", () => {
       expect(data.deleted).toBe(true);
     });
 
-    test("POST with schedule_time and timezone", async () => {
+    test('POST with schedule_time and timezone', async () => {
       const { res, data } = await createSchedule({
         task: `${TEST_PREFIX}fixed_time`,
-        interval: "1d",
-        schedule_time: "09:00",
-        timezone: "Asia/Bangkok",
+        interval: '1d',
+        schedule_time: '09:00',
+        timezone: 'Asia/Bangkok',
       });
       expect(res.ok).toBe(true);
-      expect(data.schedule_time).toBe("09:00");
-      expect(data.timezone).toBe("Asia/Bangkok");
+      expect(data.schedule_time).toBe('09:00');
+      expect(data.timezone).toBe('Asia/Bangkok');
       // 09:00 BKK = 02:00 UTC
-      expect(data.next_due_at).toContain("02:00:00");
+      expect(data.next_due_at).toContain('02:00:00');
     });
   });
 
   // =====================
   // Trigger Lifecycle
   // =====================
-  describe("Trigger Lifecycle", () => {
-    test("PATCH /:id/trigger sets status to triggered", async () => {
+  describe('Trigger Lifecycle', () => {
+    test('PATCH /:id/trigger sets status to triggered', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}trigger_test`,
       });
-      const res = await fetch(
-        `${BASE_URL}/api/schedules/${created.id}/trigger`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: TEST_BEAST }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/schedules/${created.id}/trigger`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST }),
+      });
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.trigger_status).toBe("triggered");
+      expect(data.trigger_status).toBe('triggered');
       expect(data.last_triggered_at).toBeTruthy();
     });
 
-    test("PATCH /:id/run resets status to pending and advances next_due", async () => {
+    test('PATCH /:id/run resets status to pending and advances next_due', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}run_test`,
-        interval: "1h",
+        interval: '1h',
       });
       // First trigger it
       await fetch(`${BASE_URL}/api/schedules/${created.id}/trigger`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       // Then /run
       const res = await fetch(`${BASE_URL}/api/schedules/${created.id}/run`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.trigger_status).toBe("pending");
+      expect(data.trigger_status).toBe('pending');
       // next_due_at should have advanced
       const nextDue = new Date(data.next_due_at);
       expect(nextDue.getTime()).toBeGreaterThan(Date.now());
     });
 
-    test("/run advances next_due_at by interval_seconds", async () => {
+    test('/run advances next_due_at by interval_seconds', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}run_advance`,
-        interval: "3h",
+        interval: '3h',
       });
       const originalDue = new Date(created.next_due_at).getTime();
 
       const res = await fetch(`${BASE_URL}/api/schedules/${created.id}/run`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       const data = await res.json();
@@ -251,18 +248,18 @@ describe("Scheduler API Integration", () => {
   // =====================
   // Ownership / IDOR
   // =====================
-  describe("Ownership / IDOR", () => {
+  describe('Ownership / IDOR', () => {
     let victimScheduleId: number;
 
     beforeAll(async () => {
       // Create a schedule owned by OTHER_BEAST via gorn override or direct
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: OTHER_BEAST,
           task: `${TEST_PREFIX}victim_schedule`,
-          interval: "1d",
+          interval: '1d',
         }),
       });
       if (res.ok) {
@@ -279,60 +276,54 @@ describe("Scheduler API Integration", () => {
       }
     });
 
-    test("PATCH rejects cross-beast modification (403)", async () => {
+    test('PATCH rejects cross-beast modification (403)', async () => {
       if (!victimScheduleId) return;
       const res = await fetch(`${BASE_URL}/api/schedules/${victimScheduleId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ beast: TEST_BEAST, task: "hacked" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, task: 'hacked' }),
       });
       expect(res.status).toBe(403);
     });
 
-    test("DELETE rejects cross-beast deletion (403)", async () => {
+    test('DELETE rejects cross-beast deletion (403)', async () => {
       if (!victimScheduleId) return;
       const res = await fetch(`${BASE_URL}/api/schedules/${victimScheduleId}`, {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       expect(res.status).toBe(403);
     });
 
-    test("/trigger rejects cross-beast trigger (403)", async () => {
+    test('/trigger rejects cross-beast trigger (403)', async () => {
       if (!victimScheduleId) return;
-      const res = await fetch(
-        `${BASE_URL}/api/schedules/${victimScheduleId}/trigger`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: TEST_BEAST }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/schedules/${victimScheduleId}/trigger`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST }),
+      });
       expect(res.status).toBe(403);
     });
 
-    test("/run rejects cross-beast run (403 or 404)", async () => {
+    test('/run rejects cross-beast run (403 or 404)', async () => {
       if (!victimScheduleId) return;
-      const res = await fetch(
-        `${BASE_URL}/api/schedules/${victimScheduleId}/run`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: TEST_BEAST }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/schedules/${victimScheduleId}/run`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST }),
+      });
       // Should be 403 (forbidden) or 404 (not found for this beast)
       expect(res.status).toBeGreaterThanOrEqual(400);
       expect(res.status).toBeLessThan(500);
     });
 
-    test("PATCH with no beast param is rejected (400)", async () => {
+    test('PATCH with no beast param is rejected (400)', async () => {
       if (!victimScheduleId) return;
       const res = await fetch(`${BASE_URL}/api/schedules/${victimScheduleId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ task: "no-identity" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ task: 'no-identity' }),
       });
       expect(res.status).toBe(400);
     });
@@ -341,134 +332,134 @@ describe("Scheduler API Integration", () => {
   // =====================
   // Validation
   // =====================
-  describe("Validation", () => {
-    test("rejects missing beast", async () => {
+  describe('Validation', () => {
+    test('rejects missing beast', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ task: "no-beast", interval: "1h" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ task: 'no-beast', interval: '1h' }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects missing task", async () => {
+    test('rejects missing task', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ beast: TEST_BEAST, interval: "1h" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, interval: '1h' }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects empty task name", async () => {
+    test('rejects empty task name', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ beast: TEST_BEAST, task: "", interval: "1h" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, task: '', interval: '1h' }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects missing interval", async () => {
+    test('rejects missing interval', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ beast: TEST_BEAST, task: "no-interval" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, task: 'no-interval' }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects invalid interval format", async () => {
+    test('rejects invalid interval format', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          task: "bad-interval",
-          interval: "banana",
+          task: 'bad-interval',
+          interval: 'banana',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects negative interval", async () => {
+    test('rejects negative interval', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          task: "negative",
-          interval: "-1h",
+          task: 'negative',
+          interval: '-1h',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects too-short interval (1s)", async () => {
+    test('rejects too-short interval (1s)', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          task: "too-short",
-          interval: "1s",
+          task: 'too-short',
+          interval: '1s',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects invalid schedule_time (25:99)", async () => {
+    test('rejects invalid schedule_time (25:99)', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          task: "bad-time",
-          interval: "1d",
-          schedule_time: "25:99",
+          task: 'bad-time',
+          interval: '1d',
+          schedule_time: '25:99',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects invalid timezone", async () => {
+    test('rejects invalid timezone', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          task: "bad-tz",
-          interval: "1d",
-          schedule_time: "09:00",
-          timezone: "Mars/Olympus",
+          task: 'bad-tz',
+          interval: '1d',
+          schedule_time: '09:00',
+          timezone: 'Mars/Olympus',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects duplicate task name for same beast", async () => {
+    test('rejects duplicate task name for same beast', async () => {
       const taskName = `${TEST_PREFIX}duplicate_${Date.now()}`;
       await createSchedule({ task: taskName });
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
           task: taskName,
-          interval: "1h",
+          interval: '1h',
         }),
       });
       expect(res.status).toBe(409);
     });
 
-    test("rejects very long task name", async () => {
+    test('rejects very long task name', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          task: "A".repeat(500),
-          interval: "1h",
+          task: 'A'.repeat(500),
+          interval: '1h',
         }),
       });
       expect(res.status).toBe(400);
@@ -478,41 +469,41 @@ describe("Scheduler API Integration", () => {
   // =====================
   // Security — Injection
   // =====================
-  describe("Security — Injection", () => {
-    test("rejects SQL injection in task name", async () => {
+  describe('Security — Injection', () => {
+    test('rejects SQL injection in task name', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
           task: "'; DROP TABLE schedules; --",
-          interval: "1h",
+          interval: '1h',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects shell injection in task name", async () => {
+    test('rejects shell injection in task name', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          task: "test; rm -rf /",
-          interval: "1h",
+          task: 'test; rm -rf /',
+          interval: '1h',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("rejects XSS in task name", async () => {
+    test('rejects XSS in task name', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          task: "<script>alert(1)</script>",
-          interval: "1h",
+          task: '<script>alert(1)</script>',
+          interval: '1h',
         }),
       });
       expect(res.status).toBe(400);
@@ -522,58 +513,58 @@ describe("Scheduler API Integration", () => {
   // =====================
   // Edge Cases
   // =====================
-  describe("Edge Cases", () => {
-    test("GET nonexistent schedule returns 404", async () => {
+  describe('Edge Cases', () => {
+    test('GET nonexistent schedule returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules/99999`);
       expect(res.status).toBe(404);
     });
 
-    test("PATCH nonexistent schedule returns 404", async () => {
+    test('PATCH nonexistent schedule returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules/99999`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ beast: TEST_BEAST, task: "ghost" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, task: 'ghost' }),
       });
       expect(res.status).toBe(404);
     });
 
-    test("DELETE nonexistent schedule returns 404", async () => {
+    test('DELETE nonexistent schedule returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/schedules/99999`, {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       expect(res.status).toBe(404);
     });
 
-    test("PATCH preserves fields not being updated", async () => {
+    test('PATCH preserves fields not being updated', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}preserve_fields`,
-        interval: "1d",
-        schedule_time: "09:00",
-        timezone: "Asia/Bangkok",
+        interval: '1d',
+        schedule_time: '09:00',
+        timezone: 'Asia/Bangkok',
       });
       // Update only interval
       const res = await fetch(`${BASE_URL}/api/schedules/${created.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ beast: TEST_BEAST, interval: "12h" }),
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST, interval: '12h' }),
       });
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.interval).toBe("12h");
-      expect(data.schedule_time).toBe("09:00");
-      expect(data.timezone).toBe("Asia/Bangkok");
+      expect(data.interval).toBe('12h');
+      expect(data.schedule_time).toBe('09:00');
+      expect(data.timezone).toBe('Asia/Bangkok');
     });
 
-    test("enable/disable toggle works", async () => {
+    test('enable/disable toggle works', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}toggle_enable`,
       });
       // Disable
       const res1 = await fetch(`${BASE_URL}/api/schedules/${created.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST, enabled: false }),
       });
       const data1 = await res1.json();
@@ -581,8 +572,8 @@ describe("Scheduler API Integration", () => {
 
       // Re-enable
       const res2 = await fetch(`${BASE_URL}/api/schedules/${created.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST, enabled: true }),
       });
       const data2 = await res2.json();
@@ -593,44 +584,44 @@ describe("Scheduler API Integration", () => {
   // =====================
   // Re-trigger — regression guard for a78e350
   // =====================
-  describe("Re-trigger — stale triggered schedules", () => {
-    test("triggered schedule appears in /due after being stuck (daemon query coverage)", async () => {
+  describe('Re-trigger — stale triggered schedules', () => {
+    test('triggered schedule appears in /due after being stuck (daemon query coverage)', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}retrigger_test`,
-        interval: "10m",
+        interval: '10m',
       });
       // Manually trigger it
       await fetch(`${BASE_URL}/api/schedules/${created.id}/trigger`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       // Verify it's in triggered state
       const check = await fetch(`${BASE_URL}/api/schedules/${created.id}`);
       const checkData = await check.json();
-      expect(checkData.trigger_status).toBe("triggered");
+      expect(checkData.trigger_status).toBe('triggered');
     });
 
-    test("/run after trigger resets to pending with advanced next_due", async () => {
+    test('/run after trigger resets to pending with advanced next_due', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}retrigger_run`,
-        interval: "10m",
+        interval: '10m',
       });
       // Trigger
       await fetch(`${BASE_URL}/api/schedules/${created.id}/trigger`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       // Run
       const res = await fetch(`${BASE_URL}/api/schedules/${created.id}/run`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.trigger_status).toBe("pending");
+      expect(data.trigger_status).toBe('pending');
       expect(new Date(data.next_due_at).getTime()).toBeGreaterThan(Date.now());
     });
   });
@@ -638,8 +629,8 @@ describe("Scheduler API Integration", () => {
   // =====================
   // DateTime Format (regression guard for Task #58)
   // =====================
-  describe("DateTime Format — Task #58 regression guard", () => {
-    test("next_due_at is valid ISO 8601", async () => {
+  describe('DateTime Format — Task #58 regression guard', () => {
+    test('next_due_at is valid ISO 8601', async () => {
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}datetime_check`,
       });
@@ -648,12 +639,12 @@ describe("Scheduler API Integration", () => {
       expect(parsed.getTime()).not.toBeNaN();
     });
 
-    test("schedule_time 09:00 BKK correctly computes next_due_at", async () => {
+    test('schedule_time 09:00 BKK correctly computes next_due_at', async () => {
       const { data } = await createSchedule({
         task: `${TEST_PREFIX}bkk_time_check`,
-        interval: "1d",
-        schedule_time: "09:00",
-        timezone: "Asia/Bangkok",
+        interval: '1d',
+        schedule_time: '09:00',
+        timezone: 'Asia/Bangkok',
       });
       const nextDue = new Date(data.next_due_at);
       // 09:00 BKK = 02:00 UTC
@@ -661,39 +652,35 @@ describe("Scheduler API Integration", () => {
       expect(nextDue.getUTCMinutes()).toBe(0);
     });
 
-    test("daemon trigger query finds overdue schedules (format compatibility)", async () => {
+    test('daemon trigger query finds overdue schedules (format compatibility)', async () => {
       // Create a schedule, manually set it to overdue via /trigger + /run pattern
       const { data: created } = await createSchedule({
         task: `${TEST_PREFIX}daemon_query_test`,
-        interval: "10m", // shortest allowed
+        interval: '10m', // shortest allowed
       });
       expect(created).toBeTruthy();
       // Verify it appears in the schedules list with correct status
-      const res = await fetch(
-        `${BASE_URL}/api/schedules?beast=${TEST_BEAST}`
-      );
+      const res = await fetch(`${BASE_URL}/api/schedules?beast=${TEST_BEAST}`);
       const list = await res.json();
-      const found = list.schedules.find(
-        (s: Record<string, unknown>) => s.id === created!.id
-      );
+      const found = list.schedules.find((s: Record<string, unknown>) => s.id === created!.id);
       expect(found).toBeTruthy();
-      expect(found.trigger_status).toBe("pending");
+      expect(found.trigger_status).toBe('pending');
     });
   });
 
   // =====================
   // T#706: Weekday-anchored recurring (days_of_week)
   // =====================
-  describe("Weekday-anchored recurring (days_of_week)", () => {
-    test("POST accepts valid days_of_week with interval=7d + schedule_time", async () => {
+  describe('Weekday-anchored recurring (days_of_week)', () => {
+    test('POST accepts valid days_of_week with interval=7d + schedule_time', async () => {
       const { res, data } = await createSchedule({
-        interval: "7d",
-        schedule_time: "09:00",
+        interval: '7d',
+        schedule_time: '09:00',
         days_of_week: [1, 4],
       });
       expect(res.ok).toBe(true);
       expect(data).toBeTruthy();
-      expect(data.days_of_week).toBe("[1,4]");
+      expect(data.days_of_week).toBe('[1,4]');
       // next_due_at should be a future ISO string falling on Mon or Thu
       const nextDue = new Date(data.next_due_at);
       const utc7 = new Date(nextDue.getTime() + 7 * 60 * 60 * 1000);
@@ -703,30 +690,30 @@ describe("Scheduler API Integration", () => {
       expect(utc7.getUTCMinutes()).toBe(0);
     });
 
-    test("POST rejects days_of_week without interval=7d", async () => {
+    test('POST rejects days_of_week without interval=7d', async () => {
       const { res, data } = await createSchedule({
-        interval: "1d",
-        schedule_time: "09:00",
+        interval: '1d',
+        schedule_time: '09:00',
         days_of_week: [1, 4],
       });
       expect(res.status).toBe(400);
       expect(data).toBeNull();
     });
 
-    test("POST rejects days_of_week without schedule_time", async () => {
+    test('POST rejects days_of_week without schedule_time', async () => {
       const { res, data } = await createSchedule({
-        interval: "7d",
+        interval: '7d',
         days_of_week: [1, 4],
       });
       expect(res.status).toBe(400);
       expect(data).toBeNull();
     });
 
-    test("POST rejects days_of_week with one-off (once=true)", async () => {
+    test('POST rejects days_of_week with one-off (once=true)', async () => {
       const future = new Date(Date.now() + 86400000).toISOString();
       const { res, data } = await createSchedule({
-        interval: "7d",
-        schedule_time: "09:00",
+        interval: '7d',
+        schedule_time: '09:00',
         once: true,
         run_at: future,
         days_of_week: [1, 4],
@@ -735,22 +722,22 @@ describe("Scheduler API Integration", () => {
       expect(data).toBeNull();
     });
 
-    test("POST rejects empty days_of_week", async () => {
+    test('POST rejects empty days_of_week', async () => {
       const { res, data } = await createSchedule({
-        interval: "7d",
-        schedule_time: "09:00",
+        interval: '7d',
+        schedule_time: '09:00',
         days_of_week: [],
       });
       expect(res.status).toBe(400);
       expect(data).toBeNull();
     });
 
-    test("POST rejects days_of_week with invalid weekday ints", async () => {
-      const cases: unknown[][] = [[0, 1], [1, 8], [1.5], ["mon"], [1, 1, 1, 1, 1, 1, 1, 1]];
+    test('POST rejects days_of_week with invalid weekday ints', async () => {
+      const cases: unknown[][] = [[0, 1], [1, 8], [1.5], ['mon'], [1, 1, 1, 1, 1, 1, 1, 1]];
       for (const dow of cases) {
         const { res, data } = await createSchedule({
-          interval: "7d",
-          schedule_time: "09:00",
+          interval: '7d',
+          schedule_time: '09:00',
           days_of_week: dow,
           task: `${TEST_PREFIX}invalid_${Math.random()}`,
         });
@@ -759,35 +746,35 @@ describe("Scheduler API Integration", () => {
       }
     });
 
-    test("POST accepts all-seven days_of_week (degenerate weekly)", async () => {
+    test('POST accepts all-seven days_of_week (degenerate weekly)', async () => {
       const { res, data } = await createSchedule({
-        interval: "7d",
-        schedule_time: "09:00",
+        interval: '7d',
+        schedule_time: '09:00',
         days_of_week: [1, 2, 3, 4, 5, 6, 7],
       });
       expect(res.ok).toBe(true);
-      expect(data.days_of_week).toBe("[1,2,3,4,5,6,7]");
+      expect(data.days_of_week).toBe('[1,2,3,4,5,6,7]');
     });
 
-    test("POST deduplicates and sorts days_of_week", async () => {
+    test('POST deduplicates and sorts days_of_week', async () => {
       const { res, data } = await createSchedule({
-        interval: "7d",
-        schedule_time: "09:00",
+        interval: '7d',
+        schedule_time: '09:00',
         days_of_week: [4, 1, 4],
       });
       expect(res.ok).toBe(true);
-      expect(data.days_of_week).toBe("[1,4]");
+      expect(data.days_of_week).toBe('[1,4]');
     });
 
-    test("PATCH /run advances to next qualifying weekday strictly future", async () => {
+    test('PATCH /run advances to next qualifying weekday strictly future', async () => {
       const { res, data: created } = await createSchedule({
-        interval: "7d",
-        schedule_time: "09:00",
+        interval: '7d',
+        schedule_time: '09:00',
         days_of_week: [1, 4],
       });
       expect(res.ok).toBe(true);
       const runRes = await fetch(`${BASE_URL}/api/schedules/${created.id}/run?as=${TEST_BEAST}`, {
-        method: "PATCH",
+        method: 'PATCH',
       });
       expect(runRes.ok).toBe(true);
       const updated = await runRes.json();
@@ -798,45 +785,45 @@ describe("Scheduler API Integration", () => {
       expect(nextDue.getTime()).toBeGreaterThan(Date.now());
     });
 
-    test("PATCH days_of_week recomputes next_due_at and rejects invalid", async () => {
+    test('PATCH days_of_week recomputes next_due_at and rejects invalid', async () => {
       const { res, data: created } = await createSchedule({
-        interval: "7d",
-        schedule_time: "09:00",
+        interval: '7d',
+        schedule_time: '09:00',
         days_of_week: [1, 4],
       });
       expect(res.ok).toBe(true);
       // Update to Tue+Fri
       const upd = await fetch(`${BASE_URL}/api/schedules/${created.id}?as=${TEST_BEAST}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ as: TEST_BEAST, days_of_week: [2, 5] }),
       });
       expect(upd.ok).toBe(true);
       const updated = await upd.json();
-      expect(updated.days_of_week).toBe("[2,5]");
+      expect(updated.days_of_week).toBe('[2,5]');
       const nextDue = new Date(updated.next_due_at);
       const utc7 = new Date(nextDue.getTime() + 7 * 60 * 60 * 1000);
       const isoWeekday = utc7.getUTCDay() === 0 ? 7 : utc7.getUTCDay();
       expect([2, 5]).toContain(isoWeekday);
       // Invalid update rejected
       const bad = await fetch(`${BASE_URL}/api/schedules/${created.id}?as=${TEST_BEAST}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ as: TEST_BEAST, days_of_week: [0] }),
       });
       expect(bad.status).toBe(400);
     });
 
-    test("PATCH days_of_week=null clears the field", async () => {
+    test('PATCH days_of_week=null clears the field', async () => {
       const { res, data: created } = await createSchedule({
-        interval: "7d",
-        schedule_time: "09:00",
+        interval: '7d',
+        schedule_time: '09:00',
         days_of_week: [1, 4],
       });
       expect(res.ok).toBe(true);
       const upd = await fetch(`${BASE_URL}/api/schedules/${created.id}?as=${TEST_BEAST}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ as: TEST_BEAST, days_of_week: null }),
       });
       expect(upd.ok).toBe(true);
@@ -844,9 +831,9 @@ describe("Scheduler API Integration", () => {
       expect(updated.days_of_week).toBeNull();
     });
 
-    test("Backwards-compat: existing schedules without days_of_week unaffected", async () => {
+    test('Backwards-compat: existing schedules without days_of_week unaffected', async () => {
       const { res, data } = await createSchedule({
-        interval: "1d",
+        interval: '1d',
       });
       expect(res.ok).toBe(true);
       expect(data.days_of_week).toBeNull();

--- a/src/integration/specs.test.ts
+++ b/src/integration/specs.test.ts
@@ -4,10 +4,10 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_PREFIX = "test_specs_";
+const BASE_URL = 'http://localhost:47778';
+const TEST_PREFIX = 'test_specs_';
 const TEST_RUN_ID = Date.now();
 const createdSpecIds: number[] = [];
 
@@ -20,17 +20,17 @@ async function isServerRunning(): Promise<boolean> {
   }
 }
 
-describe("Specs API Integration", () => {
+describe('Specs API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   afterAll(async () => {
     for (const id of createdSpecIds) {
       try {
-        await fetch(`${BASE_URL}/api/specs/${id}?as=pip`, { method: "DELETE" });
+        await fetch(`${BASE_URL}/api/specs/${id}?as=pip`, { method: 'DELETE' });
       } catch {}
     }
   });
@@ -38,38 +38,36 @@ describe("Specs API Integration", () => {
   // =====================
   // List & Filter
   // =====================
-  describe("List & Filter", () => {
-    test("GET /api/specs returns spec list", async () => {
+  describe('List & Filter', () => {
+    test('GET /api/specs returns spec list', async () => {
       const res = await fetch(`${BASE_URL}/api/specs`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.specs).toBeInstanceOf(Array);
     });
 
-    test("GET /api/specs with status filter", async () => {
+    test('GET /api/specs with status filter', async () => {
       const res = await fetch(`${BASE_URL}/api/specs?status=approved`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.specs).toBeInstanceOf(Array);
       for (const spec of data.specs) {
-        expect(spec.status).toBe("approved");
+        expect(spec.status).toBe('approved');
       }
     });
 
-    test("GET /api/specs with repo filter", async () => {
+    test('GET /api/specs with repo filter', async () => {
       const res = await fetch(`${BASE_URL}/api/specs?repo=denbook`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.specs).toBeInstanceOf(Array);
       for (const spec of data.specs) {
-        expect(spec.repo).toBe("denbook");
+        expect(spec.repo).toBe('denbook');
       }
     });
 
-    test("GET /api/specs with both filters", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/specs?status=pending&repo=denbook`
-      );
+    test('GET /api/specs with both filters', async () => {
+      const res = await fetch(`${BASE_URL}/api/specs?status=pending&repo=denbook`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.specs).toBeInstanceOf(Array);
@@ -85,8 +83,8 @@ describe("Specs API Integration", () => {
   // =====================
   // Spec Detail
   // =====================
-  describe("Spec Detail", () => {
-    test("GET /api/specs/:id returns spec detail", async () => {
+  describe('Spec Detail', () => {
+    test('GET /api/specs/:id returns spec detail', async () => {
       // Get first spec
       const listRes = await fetch(`${BASE_URL}/api/specs`);
       const listData = await listRes.json();
@@ -102,12 +100,12 @@ describe("Specs API Integration", () => {
       expect(data.status).toBeTruthy();
     });
 
-    test("GET /api/specs/99999 returns 404", async () => {
+    test('GET /api/specs/99999 returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/specs/99999`);
       expect(res.status).toBe(404);
     });
 
-    test("GET /api/specs/:id/content returns raw markdown", async () => {
+    test('GET /api/specs/:id/content returns raw markdown', async () => {
       const listRes = await fetch(`${BASE_URL}/api/specs`);
       const listData = await listRes.json();
       if (listData.specs.length === 0) return;
@@ -123,7 +121,7 @@ describe("Specs API Integration", () => {
       }
     });
 
-    test("GET /api/specs/99999/content returns 404", async () => {
+    test('GET /api/specs/99999/content returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/specs/99999/content`);
       expect(res.status).toBe(404);
     });
@@ -132,77 +130,77 @@ describe("Specs API Integration", () => {
   // =====================
   // Spec Registration
   // =====================
-  describe("Spec Registration", () => {
-    test("POST /api/specs creates new spec", async () => {
+  describe('Spec Registration', () => {
+    test('POST /api/specs creates new spec', async () => {
       const res = await fetch(`${BASE_URL}/api/specs`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          repo: "denbook",
+          repo: 'denbook',
           file_path: `docs/specs/${TEST_PREFIX}${TEST_RUN_ID}.md`,
-          task_id: "T999",
+          task_id: 'T999',
           title: `${TEST_PREFIX}Test Spec`,
-          author: "pip",
+          author: 'pip',
         }),
       });
       expect(res.status).toBe(201);
       const data = await res.json();
       expect(data.id).toBeTruthy();
-      expect(data.status).toBe("pending");
-      expect(data.author).toBe("pip");
+      expect(data.status).toBe('pending');
+      expect(data.author).toBe('pip');
       createdSpecIds.push(data.id);
     });
 
-    test("POST /api/specs rejects missing fields", async () => {
+    test('POST /api/specs rejects missing fields', async () => {
       const res = await fetch(`${BASE_URL}/api/specs`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          repo: "denbook",
+          repo: 'denbook',
           // missing file_path, title, author
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("POST /api/specs rejects invalid repo", async () => {
+    test('POST /api/specs rejects invalid repo', async () => {
       const res = await fetch(`${BASE_URL}/api/specs`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          repo: "evil-repo",
-          file_path: "docs/test.md",
-          title: "Evil Spec",
-          author: "pip",
+          repo: 'evil-repo',
+          file_path: 'docs/test.md',
+          title: 'Evil Spec',
+          author: 'pip',
         }),
       });
       expect(res.status).toBe(400);
     });
 
-    test("POST /api/specs rejects duplicate repo+path", async () => {
+    test('POST /api/specs rejects duplicate repo+path', async () => {
       // Try to register the same spec again
       const res = await fetch(`${BASE_URL}/api/specs`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          repo: "denbook",
+          repo: 'denbook',
           file_path: `docs/specs/${TEST_PREFIX}${TEST_RUN_ID}.md`,
           title: `${TEST_PREFIX}Duplicate`,
-          author: "pip",
+          author: 'pip',
         }),
       });
       expect(res.status).toBe(409);
     });
 
-    test("POST /api/specs rejects author mismatch", async () => {
+    test('POST /api/specs rejects author mismatch', async () => {
       const res = await fetch(`${BASE_URL}/api/specs?as=karo`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          repo: "denbook",
+          repo: 'denbook',
           file_path: `docs/specs/${TEST_PREFIX}mismatch_${TEST_RUN_ID}.md`,
-          title: "Mismatch Test",
-          author: "pip",
+          title: 'Mismatch Test',
+          author: 'pip',
         }),
       });
       expect(res.status).toBe(403);
@@ -212,8 +210,8 @@ describe("Specs API Integration", () => {
   // =====================
   // Spec History & Diff
   // =====================
-  describe("History & Diff", () => {
-    test("GET /api/specs/:id/history returns versions", async () => {
+  describe('History & Diff', () => {
+    test('GET /api/specs/:id/history returns versions', async () => {
       const listRes = await fetch(`${BASE_URL}/api/specs`);
       const listData = await listRes.json();
       if (listData.specs.length === 0) return;
@@ -226,12 +224,12 @@ describe("Specs API Integration", () => {
       expect(data.file_path).toBeTruthy();
     });
 
-    test("GET /api/specs/99999/history returns 404", async () => {
+    test('GET /api/specs/99999/history returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/specs/99999/history`);
       expect(res.status).toBe(404);
     });
 
-    test("GET /api/specs/:id/diff requires from param", async () => {
+    test('GET /api/specs/:id/diff requires from param', async () => {
       const listRes = await fetch(`${BASE_URL}/api/specs`);
       const listData = await listRes.json();
       if (listData.specs.length === 0) return;
@@ -240,41 +238,35 @@ describe("Specs API Integration", () => {
       const res = await fetch(`${BASE_URL}/api/specs/${specId}/diff`);
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toContain("from");
+      expect(data.error).toContain('from');
     });
 
-    test("GET /api/specs/:id/diff rejects invalid hash", async () => {
+    test('GET /api/specs/:id/diff rejects invalid hash', async () => {
       const listRes = await fetch(`${BASE_URL}/api/specs`);
       const listData = await listRes.json();
       if (listData.specs.length === 0) return;
 
       const specId = listData.specs[0].id;
-      const res = await fetch(
-        `${BASE_URL}/api/specs/${specId}/diff?from=; rm -rf /`
-      );
+      const res = await fetch(`${BASE_URL}/api/specs/${specId}/diff?from=; rm -rf /`);
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toContain("Invalid commit hash");
+      expect(data.error).toContain('Invalid commit hash');
     });
 
-    test("GET /api/specs/:id/diff with valid hashes", async () => {
+    test('GET /api/specs/:id/diff with valid hashes', async () => {
       const listRes = await fetch(`${BASE_URL}/api/specs`);
       const listData = await listRes.json();
       if (listData.specs.length === 0) return;
 
       // Find a spec with history
       const specId = listData.specs[0].id;
-      const histRes = await fetch(
-        `${BASE_URL}/api/specs/${specId}/history`
-      );
+      const histRes = await fetch(`${BASE_URL}/api/specs/${specId}/history`);
       const histData = await histRes.json();
       if (histData.versions.length < 2) return; // need 2 versions for diff
 
       const from = histData.versions[1].hash;
       const to = histData.versions[0].hash;
-      const res = await fetch(
-        `${BASE_URL}/api/specs/${specId}/diff?from=${from}&to=${to}`
-      );
+      const res = await fetch(`${BASE_URL}/api/specs/${specId}/diff?from=${from}&to=${to}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.from).toBe(from);
@@ -285,47 +277,41 @@ describe("Specs API Integration", () => {
   // =====================
   // Review Workflow
   // =====================
-  describe("Review Workflow", () => {
-    test("POST /api/specs/:id/review requires auth", async () => {
+  describe('Review Workflow', () => {
+    test('POST /api/specs/:id/review requires auth', async () => {
       if (createdSpecIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/specs/${createdSpecIds[0]}/review`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action: "approve" }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/specs/${createdSpecIds[0]}/review`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'approve' }),
+      });
       expect(res.status).toBe(403);
     });
 
-    test("POST /api/specs/:id/review rejects invalid action", async () => {
+    test('POST /api/specs/:id/review rejects invalid action', async () => {
       if (createdSpecIds.length === 0) return;
 
-      const res = await fetch(
-        `${BASE_URL}/api/specs/${createdSpecIds[0]}/review`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Cookie: "session=gorn",
-          },
-          body: JSON.stringify({ action: "maybe" }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/specs/${createdSpecIds[0]}/review`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: 'session=gorn',
+        },
+        body: JSON.stringify({ action: 'maybe' }),
+      });
       // Either 403 (no real session) or 400 (invalid action)
       expect(res.status).toBeGreaterThanOrEqual(400);
     });
 
-    test("POST /api/specs/99999/review returns 404", async () => {
+    test('POST /api/specs/99999/review returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/specs/99999/review`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
-          Cookie: "session=gorn",
+          'Content-Type': 'application/json',
+          Cookie: 'session=gorn',
         },
-        body: JSON.stringify({ action: "approve" }),
+        body: JSON.stringify({ action: 'approve' }),
       });
       // 403 (no auth) or 404 (not found)
       expect(res.status).toBeGreaterThanOrEqual(400);
@@ -335,101 +321,97 @@ describe("Specs API Integration", () => {
   // =====================
   // Resubmit
   // =====================
-  describe("Resubmit", () => {
-    test("POST /api/specs/:id/resubmit only works on rejected specs", async () => {
+  describe('Resubmit', () => {
+    test('POST /api/specs/:id/resubmit only works on rejected specs', async () => {
       if (createdSpecIds.length === 0) return;
 
       // Our test spec is pending, not rejected
-      const res = await fetch(
-        `${BASE_URL}/api/specs/${createdSpecIds[0]}/resubmit`,
-        { method: "POST" }
-      );
+      const res = await fetch(`${BASE_URL}/api/specs/${createdSpecIds[0]}/resubmit`, {
+        method: 'POST',
+      });
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toContain("rejected");
+      expect(data.error).toContain('rejected');
     });
 
-    test("POST /api/specs/99999/resubmit returns 404", async () => {
+    test('POST /api/specs/99999/resubmit returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/specs/99999/resubmit`, {
-        method: "POST",
+        method: 'POST',
       });
       expect(res.status).toBe(404);
     });
   });
 
   // T#754 / Spec #57 Phase 1 — reopen endpoint + version chain
-  describe("Reopen + Version Chain (Spec #57)", () => {
-    test("POST /api/specs/99999/reopen returns 404", async () => {
+  describe('Reopen + Version Chain (Spec #57)', () => {
+    test('POST /api/specs/99999/reopen returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/specs/99999/reopen`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ author: "karo", reason: "test" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ author: 'karo', reason: 'test' }),
       });
       expect(res.status).toBe(404);
     });
 
-    test("POST /api/specs/:id/reopen rejects non-approved specs", async () => {
+    test('POST /api/specs/:id/reopen rejects non-approved specs', async () => {
       if (createdSpecIds.length === 0) return;
       // Test spec is pending, not approved
-      const res = await fetch(
-        `${BASE_URL}/api/specs/${createdSpecIds[0]}/reopen`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ author: "pip", reason: "test" }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/specs/${createdSpecIds[0]}/reopen`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ author: 'pip', reason: 'test' }),
+      });
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toContain("approved specs");
+      expect(data.error).toContain('approved specs');
     });
 
-    test("POST /api/specs/:id/reopen requires reason", async () => {
+    test('POST /api/specs/:id/reopen requires reason', async () => {
       const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
       const approvedData = await approvedRes.json();
       if (!approvedData.specs || approvedData.specs.length === 0) return;
       const specId = approvedData.specs[0].id;
       const res = await fetch(`${BASE_URL}/api/specs/${specId}/reopen`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ author: "gorn" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ author: 'gorn' }),
       });
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toContain("reason required");
+      expect(data.error).toContain('reason required');
     });
 
-    test("POST /api/specs/:id/reopen requires identity", async () => {
+    test('POST /api/specs/:id/reopen requires identity', async () => {
       const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
       const approvedData = await approvedRes.json();
       if (!approvedData.specs || approvedData.specs.length === 0) return;
       const specId = approvedData.specs[0].id;
       const res = await fetch(`${BASE_URL}/api/specs/${specId}/reopen`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ reason: "test" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'test' }),
       });
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toContain("Identity required");
+      expect(data.error).toContain('Identity required');
     });
 
-    test("POST /api/specs/:id/reopen rejects unauthorized requester", async () => {
+    test('POST /api/specs/:id/reopen rejects unauthorized requester', async () => {
       const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
       const approvedData = await approvedRes.json();
       if (!approvedData.specs || approvedData.specs.length === 0) return;
       const specId = approvedData.specs[0].id;
       // bertus is not author/sable/gorn — should be rejected
       const res = await fetch(`${BASE_URL}/api/specs/${specId}/reopen`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ author: "bertus", reason: "unauthorized test" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ author: 'bertus', reason: 'unauthorized test' }),
       });
       expect(res.status).toBe(403);
     });
 
     // T#755 / Spec #57 Phase 2 — version endpoints
-    test("GET /api/specs/:id/versions returns version list", async () => {
+    test('GET /api/specs/:id/versions returns version list', async () => {
       const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
       const approvedData = await approvedRes.json();
       if (!approvedData.specs || approvedData.specs.length === 0) return;
@@ -442,7 +424,7 @@ describe("Specs API Integration", () => {
       expect(data.current_version).toBeTruthy();
     });
 
-    test("GET /api/specs/:id/content?version=v1 returns v1 snapshot", async () => {
+    test('GET /api/specs/:id/content?version=v1 returns v1 snapshot', async () => {
       const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
       const approvedData = await approvedRes.json();
       if (!approvedData.specs || approvedData.specs.length === 0) return;
@@ -453,11 +435,11 @@ describe("Specs API Integration", () => {
       const res = await fetch(`${BASE_URL}/api/specs/${specId}/content?version=v1`);
       expect(res.ok).toBe(true);
       const data = await res.json();
-      expect(data.version).toBe("v1");
+      expect(data.version).toBe('v1');
       expect(data.content).toBeTruthy();
     });
 
-    test("GET /api/specs/:id/content?version=v999 returns 404", async () => {
+    test('GET /api/specs/:id/content?version=v999 returns 404', async () => {
       const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
       const approvedData = await approvedRes.json();
       if (!approvedData.specs || approvedData.specs.length === 0) return;
@@ -466,24 +448,24 @@ describe("Specs API Integration", () => {
       expect(res.status).toBe(404);
     });
 
-    test("GET /api/specs/99999/versions returns 404", async () => {
+    test('GET /api/specs/99999/versions returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/specs/99999/versions`);
       expect(res.status).toBe(404);
     });
 
-    test("POST /api/specs/:id/resubmit on approved spec points at reopen", async () => {
+    test('POST /api/specs/:id/resubmit on approved spec points at reopen', async () => {
       const approvedRes = await fetch(`${BASE_URL}/api/specs?status=approved`);
       const approvedData = await approvedRes.json();
       if (!approvedData.specs || approvedData.specs.length === 0) return;
       const specId = approvedData.specs[0].id;
       const res = await fetch(`${BASE_URL}/api/specs/${specId}/resubmit`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ author: "karo" }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ author: 'karo' }),
       });
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toContain("reopen");
+      expect(data.error).toContain('reopen');
     });
   });
 });

--- a/src/integration/tasks.test.ts
+++ b/src/integration/tasks.test.ts
@@ -4,12 +4,12 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_BEAST = "pip";
-const OTHER_BEAST = "bertus";
-const TEST_PREFIX = "test_task_";
+const BASE_URL = 'http://localhost:47778';
+const TEST_BEAST = 'pip';
+const OTHER_BEAST = 'bertus';
+const TEST_PREFIX = 'test_task_';
 
 const createdTaskIds: number[] = [];
 
@@ -25,15 +25,15 @@ async function isServerRunning(): Promise<boolean> {
 async function createTask(overrides: Record<string, unknown> = {}) {
   const body = {
     title: `${TEST_PREFIX}${Date.now()}`,
-    description: "Test task created by Pip",
-    priority: "medium",
+    description: 'Test task created by Pip',
+    priority: 'medium',
     assigned_to: TEST_BEAST,
     created_by: TEST_BEAST,
     ...overrides,
   };
   const res = await fetch(`${BASE_URL}/api/tasks`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
   if (res.ok) {
@@ -46,16 +46,16 @@ async function createTask(overrides: Record<string, unknown> = {}) {
 
 async function deleteTask(id: number) {
   return fetch(`${BASE_URL}/api/tasks/${id}`, {
-    method: "DELETE",
-    headers: { "Content-Type": "application/json" },
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ beast: TEST_BEAST }),
   });
 }
 
-describe("Tasks & Board API Integration", () => {
+describe('Tasks & Board API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
@@ -69,15 +69,15 @@ describe("Tasks & Board API Integration", () => {
   // =====================
   // CRUD
   // =====================
-  describe("Task CRUD", () => {
-    test("POST /api/tasks creates a task", async () => {
+  describe('Task CRUD', () => {
+    test('POST /api/tasks creates a task', async () => {
       const { res, data } = await createTask();
       expect(res.ok).toBe(true);
       expect(data.id).toBeTruthy();
       expect(data.title).toContain(TEST_PREFIX);
     });
 
-    test("GET /api/tasks lists tasks", async () => {
+    test('GET /api/tasks lists tasks', async () => {
       const res = await fetch(`${BASE_URL}/api/tasks`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -85,7 +85,7 @@ describe("Tasks & Board API Integration", () => {
       expect(data.total).toBeGreaterThan(0);
     });
 
-    test("GET /api/tasks/:id returns a single task", async () => {
+    test('GET /api/tasks/:id returns a single task', async () => {
       const { data: created } = await createTask();
       const res = await fetch(`${BASE_URL}/api/tasks/${created.id}`);
       expect(res.ok).toBe(true);
@@ -94,13 +94,13 @@ describe("Tasks & Board API Integration", () => {
       expect(data.title).toBe(created.title);
     });
 
-    test("PATCH /api/tasks/:id updates a task", async () => {
+    test('PATCH /api/tasks/:id updates a task', async () => {
       const { data: created } = await createTask();
       const res = await fetch(`${BASE_URL}/api/tasks/${created.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          status: "in_progress",
+          status: 'in_progress',
           beast: TEST_BEAST,
         }),
       });
@@ -109,7 +109,7 @@ describe("Tasks & Board API Integration", () => {
       expect(data.status || data.task?.status).toBeTruthy();
     });
 
-    test("DELETE /api/tasks/:id deletes a task", async () => {
+    test('DELETE /api/tasks/:id deletes a task', async () => {
       const { data: created } = await createTask();
       const id = created.id;
       // Remove from cleanup list since we're deleting it here
@@ -117,14 +117,14 @@ describe("Tasks & Board API Integration", () => {
       if (idx > -1) createdTaskIds.splice(idx, 1);
 
       const res = await fetch(`${BASE_URL}/api/tasks/${id}`, {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ beast: TEST_BEAST }),
       });
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/tasks/:id returns 404 for nonexistent task", async () => {
+    test('GET /api/tasks/:id returns 404 for nonexistent task', async () => {
       const res = await fetch(`${BASE_URL}/api/tasks/999999`);
       expect(res.status).toBe(404);
     });
@@ -133,19 +133,19 @@ describe("Tasks & Board API Integration", () => {
   // =====================
   // Filtering
   // =====================
-  describe("Filtering & Queries", () => {
-    test("GET /api/tasks?status=done filters by status", async () => {
+  describe('Filtering & Queries', () => {
+    test('GET /api/tasks?status=done filters by status', async () => {
       const res = await fetch(`${BASE_URL}/api/tasks?status=done`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.tasks).toBeInstanceOf(Array);
       // All returned tasks should have status=done
       for (const task of data.tasks) {
-        expect(task.status).toBe("done");
+        expect(task.status).toBe('done');
       }
     });
 
-    test("GET /api/tasks?assignee=pip filters by assignee", async () => {
+    test('GET /api/tasks?assignee=pip filters by assignee', async () => {
       await createTask({ assigned_to: TEST_BEAST });
       const res = await fetch(`${BASE_URL}/api/tasks?assignee=${TEST_BEAST}`);
       expect(res.ok).toBe(true);
@@ -153,7 +153,7 @@ describe("Tasks & Board API Integration", () => {
       expect(data.tasks).toBeInstanceOf(Array);
     });
 
-    test("GET /api/tasks?priority=high filters by priority", async () => {
+    test('GET /api/tasks?priority=high filters by priority', async () => {
       const res = await fetch(`${BASE_URL}/api/tasks?priority=high`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -164,12 +164,12 @@ describe("Tasks & Board API Integration", () => {
   // =====================
   // Comments
   // =====================
-  describe("Task Comments", () => {
-    test("POST /api/tasks/:id/comments adds a comment", async () => {
+  describe('Task Comments', () => {
+    test('POST /api/tasks/:id/comments adds a comment', async () => {
       const { data: task } = await createTask();
       const res = await fetch(`${BASE_URL}/api/tasks/${task.id}/comments`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           author: TEST_BEAST,
           content: `${TEST_PREFIX}comment ${Date.now()}`,
@@ -178,12 +178,12 @@ describe("Tasks & Board API Integration", () => {
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/tasks/:id/comments lists comments", async () => {
+    test('GET /api/tasks/:id/comments lists comments', async () => {
       const { data: task } = await createTask();
       // Add a comment first
       await fetch(`${BASE_URL}/api/tasks/${task.id}/comments`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           author: TEST_BEAST,
           content: `${TEST_PREFIX}read_test ${Date.now()}`,
@@ -199,16 +199,16 @@ describe("Tasks & Board API Integration", () => {
   // =====================
   // Bulk Operations
   // =====================
-  describe("Bulk Operations", () => {
-    test("POST /api/tasks/bulk-status updates multiple tasks", async () => {
+  describe('Bulk Operations', () => {
+    test('POST /api/tasks/bulk-status updates multiple tasks', async () => {
       const { data: t1 } = await createTask();
       const { data: t2 } = await createTask();
       const res = await fetch(`${BASE_URL}/api/tasks/bulk-status`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           task_ids: [t1.id, t2.id],
-          status: "in_progress",
+          status: 'in_progress',
           beast: TEST_BEAST,
         }),
       });
@@ -219,8 +219,8 @@ describe("Tasks & Board API Integration", () => {
   // =====================
   // Board
   // =====================
-  describe("Board", () => {
-    test("GET /api/board returns board state", async () => {
+  describe('Board', () => {
+    test('GET /api/board returns board state', async () => {
       const res = await fetch(`${BASE_URL}/api/board`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -232,23 +232,23 @@ describe("Tasks & Board API Integration", () => {
   // =====================
   // Validation
   // =====================
-  describe("Validation", () => {
-    test("POST /api/tasks without title fails", async () => {
+  describe('Validation', () => {
+    test('POST /api/tasks without title fails', async () => {
       const res = await fetch(`${BASE_URL}/api/tasks`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          description: "no title",
+          description: 'no title',
           created_by: TEST_BEAST,
         }),
       });
       expect(res.ok).toBe(false);
     });
 
-    test("POST /api/tasks without created_by fails", async () => {
+    test('POST /api/tasks without created_by fails', async () => {
       const res = await fetch(`${BASE_URL}/api/tasks`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: `${TEST_PREFIX}no_creator`,
         }),
@@ -256,13 +256,13 @@ describe("Tasks & Board API Integration", () => {
       expect(res.ok).toBe(false);
     });
 
-    test("PATCH /api/tasks/:id with invalid status fails gracefully", async () => {
+    test('PATCH /api/tasks/:id with invalid status fails gracefully', async () => {
       const { data: task } = await createTask();
       const res = await fetch(`${BASE_URL}/api/tasks/${task.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          status: "nonexistent_status_xyz",
+          status: 'nonexistent_status_xyz',
           beast: TEST_BEAST,
         }),
       });
@@ -273,11 +273,11 @@ describe("Tasks & Board API Integration", () => {
   });
 
   // T#759: deleted tasks excluded from list by default
-  describe("Deleted task exclusion (T#759)", () => {
-    test("GET /api/tasks excludes deleted tasks by default", async () => {
+  describe('Deleted task exclusion (T#759)', () => {
+    test('GET /api/tasks excludes deleted tasks by default', async () => {
       const { data: task } = await createTask();
       // Delete it
-      await fetch(`${BASE_URL}/api/tasks/${task.id}`, { method: "DELETE" });
+      await fetch(`${BASE_URL}/api/tasks/${task.id}`, { method: 'DELETE' });
       // List should not include deleted task
       const listRes = await fetch(`${BASE_URL}/api/tasks`);
       const listData = await listRes.json();
@@ -285,19 +285,19 @@ describe("Tasks & Board API Integration", () => {
       expect(found).toBeUndefined();
     });
 
-    test("GET /api/tasks?include_deleted=true returns deleted tasks", async () => {
+    test('GET /api/tasks?include_deleted=true returns deleted tasks', async () => {
       const { data: task } = await createTask();
-      await fetch(`${BASE_URL}/api/tasks/${task.id}`, { method: "DELETE" });
+      await fetch(`${BASE_URL}/api/tasks/${task.id}`, { method: 'DELETE' });
       const listRes = await fetch(`${BASE_URL}/api/tasks?include_deleted=true`);
       const listData = await listRes.json();
       const found = listData.tasks.find((t: any) => t.id === task.id);
       expect(found).toBeTruthy();
-      expect(found.status).toBe("deleted");
+      expect(found.status).toBe('deleted');
     });
 
-    test("GET /api/board excludes deleted tasks", async () => {
+    test('GET /api/board excludes deleted tasks', async () => {
       const { data: task } = await createTask();
-      await fetch(`${BASE_URL}/api/tasks/${task.id}`, { method: "DELETE" });
+      await fetch(`${BASE_URL}/api/tasks/${task.id}`, { method: 'DELETE' });
       const boardRes = await fetch(`${BASE_URL}/api/board`);
       const boardData = await boardRes.json();
       const allTasks = Object.values(boardData.columns || {}).flat() as any[];
@@ -305,10 +305,13 @@ describe("Tasks & Board API Integration", () => {
       expect(found).toBeUndefined();
     });
 
-    test("GET /api/tasks/:id/subtree excludes deleted subtasks", async () => {
+    test('GET /api/tasks/:id/subtree excludes deleted subtasks', async () => {
       const { data: parent } = await createTask({ title: `${TEST_PREFIX}parent_${Date.now()}` });
-      const { data: child } = await createTask({ title: `${TEST_PREFIX}child_${Date.now()}`, parent_task_id: parent.id });
-      await fetch(`${BASE_URL}/api/tasks/${child.id}`, { method: "DELETE" });
+      const { data: child } = await createTask({
+        title: `${TEST_PREFIX}child_${Date.now()}`,
+        parent_task_id: parent.id,
+      });
+      await fetch(`${BASE_URL}/api/tasks/${child.id}`, { method: 'DELETE' });
       const subtreeRes = await fetch(`${BASE_URL}/api/tasks/${parent.id}/subtree`);
       const subtreeData = await subtreeRes.json();
       const found = subtreeData.subtasks.find((t: any) => t.id === child.id);

--- a/src/integration/teams.test.ts
+++ b/src/integration/teams.test.ts
@@ -4,12 +4,12 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
-const TEST_BEAST = "pip";
-const OTHER_BEAST = "bertus";
-const TEST_PREFIX = "test_team_";
+const BASE_URL = 'http://localhost:47778';
+const TEST_BEAST = 'pip';
+const OTHER_BEAST = 'bertus';
+const TEST_PREFIX = 'test_team_';
 
 const createdTeamIds: number[] = [];
 
@@ -25,13 +25,13 @@ async function isServerRunning(): Promise<boolean> {
 async function createTeam(overrides: Record<string, unknown> = {}) {
   const body = {
     name: `${TEST_PREFIX}${Date.now()}`,
-    description: "Test team created by Pip",
+    description: 'Test team created by Pip',
     created_by: TEST_BEAST,
     ...overrides,
   };
   const res = await fetch(`${BASE_URL}/api/teams`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
   const data = await res.json();
@@ -39,17 +39,17 @@ async function createTeam(overrides: Record<string, unknown> = {}) {
   return { res, data };
 }
 
-describe("Teams API Integration", () => {
+describe('Teams API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   afterAll(async () => {
     for (const id of createdTeamIds) {
       try {
-        await fetch(`${BASE_URL}/api/teams/${id}?as=${TEST_BEAST}`, { method: "DELETE" });
+        await fetch(`${BASE_URL}/api/teams/${id}?as=${TEST_BEAST}`, { method: 'DELETE' });
       } catch {
         // Best-effort cleanup
       }
@@ -59,15 +59,15 @@ describe("Teams API Integration", () => {
   // =====================
   // CRUD
   // =====================
-  describe("Team CRUD", () => {
-    test("POST /api/teams creates a team", async () => {
+  describe('Team CRUD', () => {
+    test('POST /api/teams creates a team', async () => {
       const { res, data } = await createTeam();
       expect(res.ok).toBe(true);
       expect(data.id).toBeTruthy();
       expect(data.name).toContain(TEST_PREFIX);
     });
 
-    test("GET /api/teams lists teams", async () => {
+    test('GET /api/teams lists teams', async () => {
       const res = await fetch(`${BASE_URL}/api/teams`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -75,7 +75,7 @@ describe("Teams API Integration", () => {
       expect(Array.isArray(data.teams || data)).toBe(true);
     });
 
-    test("GET /api/teams/:id returns a single team", async () => {
+    test('GET /api/teams/:id returns a single team', async () => {
       const { data: created } = await createTeam();
       const res = await fetch(`${BASE_URL}/api/teams/${created.id}`);
       expect(res.ok).toBe(true);
@@ -84,12 +84,12 @@ describe("Teams API Integration", () => {
       expect(data.name).toBe(created.name);
     });
 
-    test("PATCH /api/teams/:id updates a team", async () => {
+    test('PATCH /api/teams/:id updates a team', async () => {
       const { data: created } = await createTeam();
       const newDesc = `updated_${Date.now()}`;
       const res = await fetch(`${BASE_URL}/api/teams/${created.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           description: newDesc,
           beast: TEST_BEAST,
@@ -98,7 +98,7 @@ describe("Teams API Integration", () => {
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/teams/beast/:beast returns teams for a beast", async () => {
+    test('GET /api/teams/beast/:beast returns teams for a beast', async () => {
       const res = await fetch(`${BASE_URL}/api/teams/beast/${TEST_BEAST}`);
       expect(res.ok).toBe(true);
       const data = await res.json();
@@ -109,70 +109,67 @@ describe("Teams API Integration", () => {
   // =====================
   // Members
   // =====================
-  describe("Team Members", () => {
-    test("POST /api/teams/:id/members adds a member", async () => {
+  describe('Team Members', () => {
+    test('POST /api/teams/:id/members adds a member', async () => {
       const { data: team } = await createTeam();
       const res = await fetch(`${BASE_URL}/api/teams/${team.id}/members`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: OTHER_BEAST,
-          role: "member",
+          role: 'member',
           added_by: TEST_BEAST,
         }),
       });
       expect(res.ok).toBe(true);
     });
 
-    test("DELETE /api/teams/:id/members/:beast removes a member", async () => {
+    test('DELETE /api/teams/:id/members/:beast removes a member', async () => {
       const { data: team } = await createTeam();
       // Add member first
       await fetch(`${BASE_URL}/api/teams/${team.id}/members`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: OTHER_BEAST,
-          role: "member",
+          role: 'member',
           added_by: TEST_BEAST,
         }),
       });
       // Remove member
-      const res = await fetch(
-        `${BASE_URL}/api/teams/${team.id}/members/${OTHER_BEAST}`,
-        {
-          method: "DELETE",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ beast: TEST_BEAST }),
-        }
-      );
+      const res = await fetch(`${BASE_URL}/api/teams/${team.id}/members/${OTHER_BEAST}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ beast: TEST_BEAST }),
+      });
       expect(res.ok).toBe(true);
     });
 
-    test("Cannot add nonexistent beast as member (ghost member fix)", async () => {
+    test('Cannot add nonexistent beast as member (ghost member fix)', async () => {
       const { data: team } = await createTeam();
       const res = await fetch(`${BASE_URL}/api/teams/${team.id}/members`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          beast: "nonexistent_beast_xyz",
-          role: "member",
+          beast: 'nonexistent_beast_xyz',
+          role: 'member',
           added_by: TEST_BEAST,
         }),
       });
       expect(res.ok).toBe(false);
       const data = await res.json();
-      expect(data.error).toContain("not found");
+      expect(data.error).toContain('not found');
     });
 
-    test("Cannot add duplicate member", async () => {
+    test('Cannot add duplicate member', async () => {
       const { data: team } = await createTeam();
       // Creator is already a member — try adding them again
       const res = await fetch(`${BASE_URL}/api/teams/${team.id}/members`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          role: "member",
+          role: 'member',
           added_by: TEST_BEAST,
         }),
       });
@@ -184,11 +181,11 @@ describe("Teams API Integration", () => {
   // =====================
   // Validation — Regression Guards
   // =====================
-  describe("Validation (Regression Guards)", () => {
-    test("SQL injection chars rejected in team name", async () => {
+  describe('Validation (Regression Guards)', () => {
+    test('SQL injection chars rejected in team name', async () => {
       const res = await fetch(`${BASE_URL}/api/teams`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: "test'; DROP TABLE teams;--",
           created_by: TEST_BEAST,
@@ -196,39 +193,39 @@ describe("Teams API Integration", () => {
       });
       expect(res.ok).toBe(false);
       const data = await res.json();
-      expect(data.error).toContain("invalid characters");
+      expect(data.error).toContain('invalid characters');
     });
 
-    test("XSS script tags rejected in team name", async () => {
+    test('XSS script tags rejected in team name', async () => {
       const res = await fetch(`${BASE_URL}/api/teams`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          name: "<script>alert(1)</script>",
+          name: '<script>alert(1)</script>',
           created_by: TEST_BEAST,
         }),
       });
       expect(res.ok).toBe(false);
       const data = await res.json();
-      expect(data.error).toContain("invalid characters");
+      expect(data.error).toContain('invalid characters');
     });
 
-    test("POST /api/teams without name fails", async () => {
+    test('POST /api/teams without name fails', async () => {
       const res = await fetch(`${BASE_URL}/api/teams`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          description: "no name",
+          description: 'no name',
           created_by: TEST_BEAST,
         }),
       });
       expect(res.ok).toBe(false);
     });
 
-    test("POST /api/teams without created_by fails", async () => {
+    test('POST /api/teams without created_by fails', async () => {
       const res = await fetch(`${BASE_URL}/api/teams`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: `${TEST_PREFIX}no_creator`,
         }),
@@ -240,12 +237,12 @@ describe("Teams API Integration", () => {
   // =====================
   // Projects
   // =====================
-  describe("Team Projects", () => {
-    test("POST /api/teams/:id/projects assigns a project", async () => {
+  describe('Team Projects', () => {
+    test('POST /api/teams/:id/projects assigns a project', async () => {
       const { data: team } = await createTeam();
       const res = await fetch(`${BASE_URL}/api/teams/${team.id}/projects`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           project_id: 1,
           beast: TEST_BEAST,
@@ -259,16 +256,14 @@ describe("Teams API Integration", () => {
   // =====================
   // Edge Cases
   // =====================
-  describe("Edge Cases", () => {
-    test("GET /api/teams/999999 returns 404", async () => {
+  describe('Edge Cases', () => {
+    test('GET /api/teams/999999 returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/teams/999999`);
       expect(res.status).toBe(404);
     });
 
-    test("GET /api/teams/beast/nonexistent returns empty", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/teams/beast/nonexistent_beast_xyz`
-      );
+    test('GET /api/teams/beast/nonexistent returns empty', async () => {
+      const res = await fetch(`${BASE_URL}/api/teams/beast/nonexistent_beast_xyz`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       const teams = data.teams || data;
@@ -276,20 +271,20 @@ describe("Teams API Integration", () => {
       expect(teams.length).toBe(0);
     });
 
-    test("POST /api/teams/:id/members on nonexistent team fails", async () => {
+    test('POST /api/teams/:id/members on nonexistent team fails', async () => {
       const res = await fetch(`${BASE_URL}/api/teams/999999/members`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           beast: TEST_BEAST,
-          role: "member",
+          role: 'member',
           added_by: TEST_BEAST,
         }),
       });
       expect(res.ok).toBe(false);
     });
 
-    test("DELETE /api/teams/:id removes team with cascading delete", async () => {
+    test('DELETE /api/teams/:id removes team with cascading delete', async () => {
       const { data: team } = await createTeam({
         name: `${TEST_PREFIX}delete_cascade_${Date.now()}`,
       });
@@ -297,7 +292,7 @@ describe("Teams API Integration", () => {
       if (idx >= 0) createdTeamIds.splice(idx, 1);
 
       const res = await fetch(`${BASE_URL}/api/teams/${team.id}?as=${TEST_BEAST}`, {
-        method: "DELETE",
+        method: 'DELETE',
       });
       expect(res.ok).toBe(true);
 
@@ -306,30 +301,30 @@ describe("Teams API Integration", () => {
       expect(check.status).toBe(404);
     });
 
-    test("DELETE nonexistent team returns 404", async () => {
+    test('DELETE nonexistent team returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/teams/999999?as=${TEST_BEAST}`, {
-        method: "DELETE",
+        method: 'DELETE',
       });
       expect(res.status).toBe(404);
     });
 
-    test("DELETE without ?as= is rejected (auth required)", async () => {
+    test('DELETE without ?as= is rejected (auth required)', async () => {
       const { data: team } = await createTeam({
         name: `${TEST_PREFIX}noauth_${Date.now()}`,
       });
       const res = await fetch(`${BASE_URL}/api/teams/${team.id}`, {
-        method: "DELETE",
+        method: 'DELETE',
       });
       expect(res.status).toBeGreaterThanOrEqual(400);
       expect(res.status).toBeLessThan(500);
     });
 
-    test("DELETE by non-creator is rejected (403)", async () => {
+    test('DELETE by non-creator is rejected (403)', async () => {
       const { data: team } = await createTeam({
         name: `${TEST_PREFIX}idor_delete_${Date.now()}`,
       });
       const res = await fetch(`${BASE_URL}/api/teams/${team.id}?as=${OTHER_BEAST}`, {
-        method: "DELETE",
+        method: 'DELETE',
       });
       expect(res.status).toBe(403);
     });

--- a/src/integration/traces.test.ts
+++ b/src/integration/traces.test.ts
@@ -4,9 +4,9 @@
  *
  * Author: Pip (QA/Chaos Testing)
  */
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect, beforeAll } from 'bun:test';
 
-const BASE_URL = "http://localhost:47778";
+const BASE_URL = 'http://localhost:47778';
 
 async function isServerRunning(): Promise<boolean> {
   try {
@@ -17,42 +17,40 @@ async function isServerRunning(): Promise<boolean> {
   }
 }
 
-describe("Traces API Integration", () => {
+describe('Traces API Integration', () => {
   beforeAll(async () => {
     if (!(await isServerRunning())) {
-      throw new Error("Server not running on port 47778");
+      throw new Error('Server not running on port 47778');
     }
   });
 
   // =====================
   // List
   // =====================
-  describe("List", () => {
-    test("GET /api/traces returns trace list", async () => {
+  describe('List', () => {
+    test('GET /api/traces returns trace list', async () => {
       const res = await fetch(`${BASE_URL}/api/traces`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.traces).toBeInstanceOf(Array);
     });
 
-    test("GET /api/traces with query filter", async () => {
+    test('GET /api/traces with query filter', async () => {
       const res = await fetch(`${BASE_URL}/api/traces?query=test`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.traces).toBeInstanceOf(Array);
     });
 
-    test("GET /api/traces with status filter", async () => {
+    test('GET /api/traces with status filter', async () => {
       const res = await fetch(`${BASE_URL}/api/traces?status=raw`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.traces).toBeInstanceOf(Array);
     });
 
-    test("GET /api/traces with pagination", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/traces?limit=5&offset=0`
-      );
+    test('GET /api/traces with pagination', async () => {
+      const res = await fetch(`${BASE_URL}/api/traces?limit=5&offset=0`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.traces).toBeInstanceOf(Array);
@@ -63,13 +61,13 @@ describe("Traces API Integration", () => {
   // =====================
   // Detail
   // =====================
-  describe("Detail", () => {
-    test("GET /api/traces/:id with nonexistent id returns 404", async () => {
+  describe('Detail', () => {
+    test('GET /api/traces/:id with nonexistent id returns 404', async () => {
       const res = await fetch(`${BASE_URL}/api/traces/nonexistent_id_99999`);
       expect(res.status).toBe(404);
     });
 
-    test("GET /api/traces/:id returns trace if exists", async () => {
+    test('GET /api/traces/:id returns trace if exists', async () => {
       const listRes = await fetch(`${BASE_URL}/api/traces?limit=1`);
       const listData = await listRes.json();
       if (listData.traces.length === 0) return;
@@ -85,8 +83,8 @@ describe("Traces API Integration", () => {
   // =====================
   // Chain
   // =====================
-  describe("Chain", () => {
-    test("GET /api/traces/:id/chain returns chain", async () => {
+  describe('Chain', () => {
+    test('GET /api/traces/:id/chain returns chain', async () => {
       const listRes = await fetch(`${BASE_URL}/api/traces?limit=1`);
       const listData = await listRes.json();
       if (listData.traces.length === 0) return;
@@ -96,27 +94,23 @@ describe("Traces API Integration", () => {
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/traces/:id/chain with direction", async () => {
+    test('GET /api/traces/:id/chain with direction', async () => {
       const listRes = await fetch(`${BASE_URL}/api/traces?limit=1`);
       const listData = await listRes.json();
       if (listData.traces.length === 0) return;
 
       const traceId = listData.traces[0].id;
-      const res = await fetch(
-        `${BASE_URL}/api/traces/${traceId}/chain?direction=up`
-      );
+      const res = await fetch(`${BASE_URL}/api/traces/${traceId}/chain?direction=up`);
       expect(res.ok).toBe(true);
     });
 
-    test("GET /api/traces/:id/linked-chain returns linked chain", async () => {
+    test('GET /api/traces/:id/linked-chain returns linked chain', async () => {
       const listRes = await fetch(`${BASE_URL}/api/traces?limit=1`);
       const listData = await listRes.json();
       if (listData.traces.length === 0) return;
 
       const traceId = listData.traces[0].id;
-      const res = await fetch(
-        `${BASE_URL}/api/traces/${traceId}/linked-chain`
-      );
+      const res = await fetch(`${BASE_URL}/api/traces/${traceId}/linked-chain`);
       expect(res.ok).toBe(true);
     });
   });
@@ -124,32 +118,31 @@ describe("Traces API Integration", () => {
   // =====================
   // Linking
   // =====================
-  describe("Linking", () => {
-    test("POST /api/traces/:prevId/link rejects missing nextId", async () => {
+  describe('Linking', () => {
+    test('POST /api/traces/:prevId/link rejects missing nextId', async () => {
       const res = await fetch(`${BASE_URL}/api/traces/fake_id/link`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toContain("nextId");
+      expect(data.error).toContain('nextId');
     });
 
-    test("DELETE /api/traces/:id/link rejects missing direction", async () => {
+    test('DELETE /api/traces/:id/link rejects missing direction', async () => {
       const res = await fetch(`${BASE_URL}/api/traces/fake_id/link`, {
-        method: "DELETE",
+        method: 'DELETE',
       });
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toContain("direction");
+      expect(data.error).toContain('direction');
     });
 
-    test("DELETE /api/traces/:id/link rejects invalid direction", async () => {
-      const res = await fetch(
-        `${BASE_URL}/api/traces/fake_id/link?direction=sideways`,
-        { method: "DELETE" }
-      );
+    test('DELETE /api/traces/:id/link rejects invalid direction', async () => {
+      const res = await fetch(`${BASE_URL}/api/traces/fake_id/link?direction=sideways`, {
+        method: 'DELETE',
+      });
       expect(res.status).toBe(400);
     });
   });

--- a/src/integrations/routes.ts
+++ b/src/integrations/routes.ts
@@ -45,7 +45,11 @@ interface IntegrationsHelpers {
   isForgeAuthorized: (c: any, options?: { mode: 'read' | 'write' }) => boolean;
 }
 
-export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: IntegrationsHelpers): void {
+export function registerIntegrationsRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: IntegrationsHelpers,
+): void {
   const { hasSessionAuth, isTrustedRequest, isForgeAuthorized } = helpers;
   const sqlite: Database = sqliteDb;
   // Drop-in: integ_block (constants + helpers + state Maps + routes)
@@ -53,7 +57,8 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
   const OAUTH_KEY = process.env.OAUTH_ENCRYPTION_KEY; // 32-byte hex string
   const WITHINGS_CLIENT_ID = process.env.WITHINGS_CLIENT_ID || '';
   const WITHINGS_CLIENT_SECRET = process.env.WITHINGS_CLIENT_SECRET || '';
-  const WITHINGS_REDIRECT_URI = process.env.WITHINGS_REDIRECT_URI || 'https://denbook.online/api/oauth/withings/callback';
+  const WITHINGS_REDIRECT_URI =
+    process.env.WITHINGS_REDIRECT_URI || 'https://denbook.online/api/oauth/withings/callback';
 
   function encryptToken(token: string): { encrypted: string; iv: string; tag: string } {
     if (!OAUTH_KEY) throw new Error('OAUTH_ENCRYPTION_KEY not set');
@@ -89,48 +94,86 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
     const res = await fetch('https://wbsapi.withings.net/v2/signature', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({ action: 'getnonce', client_id: WITHINGS_CLIENT_ID, timestamp: String(timestamp), signature }),
+      body: new URLSearchParams({
+        action: 'getnonce',
+        client_id: WITHINGS_CLIENT_ID,
+        timestamp: String(timestamp),
+        signature,
+      }),
     });
-    const data = await res.json() as any;
+    const data = (await res.json()) as any;
     if (data.status !== 0) throw new Error(`Nonce failed: ${data.error}`);
     return data.body.nonce;
   }
 
   // Refresh Withings tokens if needed
-  async function ensureFreshWithingsToken(): Promise<{ accessToken: string; userId: string } | null> {
-    const token = sqlite.prepare("SELECT * FROM oauth_tokens WHERE provider = 'withings' LIMIT 1").get() as any;
+  async function ensureFreshWithingsToken(): Promise<{
+    accessToken: string;
+    userId: string;
+  } | null> {
+    const token = sqlite
+      .prepare("SELECT * FROM oauth_tokens WHERE provider = 'withings' LIMIT 1")
+      .get() as any;
     if (!token) return null;
 
     const now = Math.floor(Date.now() / 1000);
     if (token.expires_at > now + 600) {
       // Token still fresh (>10 min remaining)
-      return { accessToken: decryptToken(token.access_token_enc, token.access_iv || token.token_iv, token.access_tag || token.token_tag), userId: token.user_id };
+      return {
+        accessToken: decryptToken(
+          token.access_token_enc,
+          token.access_iv || token.token_iv,
+          token.access_tag || token.token_tag,
+        ),
+        userId: token.user_id,
+      };
     }
 
     // Refresh token
     try {
-      const refreshToken = decryptToken(token.refresh_token_enc, token.refresh_iv || token.token_iv, token.refresh_tag || token.token_tag);
+      const refreshToken = decryptToken(
+        token.refresh_token_enc,
+        token.refresh_iv || token.token_iv,
+        token.refresh_tag || token.token_tag,
+      );
       const nonce = await getWithingsNonce();
       const signature = withingsSign(`requesttoken,${WITHINGS_CLIENT_ID},${nonce}`);
       const res = await fetch('https://wbsapi.withings.net/v2/oauth2', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({
-          action: 'requesttoken', grant_type: 'refresh_token',
-          client_id: WITHINGS_CLIENT_ID, client_secret: WITHINGS_CLIENT_SECRET,
-          refresh_token: refreshToken, nonce, signature,
+          action: 'requesttoken',
+          grant_type: 'refresh_token',
+          client_id: WITHINGS_CLIENT_ID,
+          client_secret: WITHINGS_CLIENT_SECRET,
+          refresh_token: refreshToken,
+          nonce,
+          signature,
         }),
       });
-      const data = await res.json() as any;
+      const data = (await res.json()) as any;
       if (data.status !== 0) throw new Error(`Refresh failed: ${data.error}`);
 
       const { access_token, refresh_token, expires_in, userid } = data.body;
       const enc = encryptToken(access_token);
       const refreshEnc = encryptToken(refresh_token);
-      sqlite.prepare(
-        `UPDATE oauth_tokens SET access_token_enc = ?, refresh_token_enc = ?, access_iv = ?, access_tag = ?, refresh_iv = ?, refresh_tag = ?,
-         expires_at = ?, user_id = ?, updated_at = ? WHERE id = ?`
-      ).run(enc.encrypted, refreshEnc.encrypted, enc.iv, enc.tag, refreshEnc.iv, refreshEnc.tag, now + expires_in, userid, now, token.id);
+      sqlite
+        .prepare(
+          `UPDATE oauth_tokens SET access_token_enc = ?, refresh_token_enc = ?, access_iv = ?, access_tag = ?, refresh_iv = ?, refresh_tag = ?,
+         expires_at = ?, user_id = ?, updated_at = ? WHERE id = ?`,
+        )
+        .run(
+          enc.encrypted,
+          refreshEnc.encrypted,
+          enc.iv,
+          enc.tag,
+          refreshEnc.iv,
+          refreshEnc.tag,
+          now + expires_in,
+          userid,
+          now,
+          token.id,
+        );
 
       logSecurityEvent({
         eventType: 'token_refreshed',
@@ -154,12 +197,15 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
   // GET /api/oauth/withings/authorize — start OAuth flow
   app.get('/api/oauth/withings/authorize', (c) => {
     if (!hasSessionAuth(c)) return c.json({ error: 'Gorn authentication required' }, 403);
-    if (!WITHINGS_CLIENT_ID) return c.json({ error: 'Withings not configured (missing WITHINGS_CLIENT_ID)' }, 500);
+    if (!WITHINGS_CLIENT_ID)
+      return c.json({ error: 'Withings not configured (missing WITHINGS_CLIENT_ID)' }, 500);
 
     const state = require('crypto').randomBytes(16).toString('hex');
     oauthStates.set(state, Date.now());
     // Clean old states (>10 min)
-    for (const [k, v] of oauthStates) { if (Date.now() - v > 600000) oauthStates.delete(k); }
+    for (const [k, v] of oauthStates) {
+      if (Date.now() - v > 600000) oauthStates.delete(k);
+    }
 
     const params = new URLSearchParams({
       response_type: 'code',
@@ -179,7 +225,8 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
     if (error) return c.redirect('/forge?oauth_error=' + encodeURIComponent(error));
     if (!code || !state) return c.json({ error: 'Missing code or state' }, 400);
-    if (!oauthStates.has(state)) return c.json({ error: 'Invalid or expired state (CSRF check failed)' }, 403);
+    if (!oauthStates.has(state))
+      return c.json({ error: 'Invalid or expired state (CSRF check failed)' }, 403);
     oauthStates.delete(state);
 
     try {
@@ -190,13 +237,21 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({
-          action: 'requesttoken', grant_type: 'authorization_code',
-          client_id: WITHINGS_CLIENT_ID, client_secret: WITHINGS_CLIENT_SECRET,
-          code, redirect_uri: WITHINGS_REDIRECT_URI, nonce, signature,
+          action: 'requesttoken',
+          grant_type: 'authorization_code',
+          client_id: WITHINGS_CLIENT_ID,
+          client_secret: WITHINGS_CLIENT_SECRET,
+          code,
+          redirect_uri: WITHINGS_REDIRECT_URI,
+          nonce,
+          signature,
         }),
       });
-      const data = await res.json() as any;
-      if (data.status !== 0) return c.redirect('/forge?oauth_error=' + encodeURIComponent(data.error || 'Token exchange failed'));
+      const data = (await res.json()) as any;
+      if (data.status !== 0)
+        return c.redirect(
+          '/forge?oauth_error=' + encodeURIComponent(data.error || 'Token exchange failed'),
+        );
 
       const { access_token, refresh_token, expires_in, userid, scope } = data.body;
       const now = Math.floor(Date.now() / 1000);
@@ -207,10 +262,25 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
       // Store (upsert — replace existing Withings connection)
       sqlite.prepare("DELETE FROM oauth_tokens WHERE provider = 'withings'").run();
-      sqlite.prepare(
-        `INSERT INTO oauth_tokens (provider, user_id, access_token_enc, refresh_token_enc, access_iv, access_tag, refresh_iv, refresh_tag, expires_at, scopes, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      ).run('withings', String(userid), accessEnc.encrypted, refreshEnc.encrypted, accessEnc.iv, accessEnc.tag, refreshEnc.iv, refreshEnc.tag, now + expires_in, scope || 'user.info,user.metrics', now, now);
+      sqlite
+        .prepare(
+          `INSERT INTO oauth_tokens (provider, user_id, access_token_enc, refresh_token_enc, access_iv, access_tag, refresh_iv, refresh_tag, expires_at, scopes, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'withings',
+          String(userid),
+          accessEnc.encrypted,
+          refreshEnc.encrypted,
+          accessEnc.iv,
+          accessEnc.tag,
+          refreshEnc.iv,
+          refreshEnc.tag,
+          now + expires_in,
+          scope || 'user.info,user.metrics',
+          now,
+          now,
+        );
 
       logSecurityEvent({
         eventType: 'token_created',
@@ -225,10 +295,22 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
       try {
         await fetch('https://wbsapi.withings.net/notify', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: `Bearer ${access_token}` },
-          body: new URLSearchParams({ action: 'subscribe', callbackurl: WITHINGS_REDIRECT_URI.replace('/callback', '').replace('/api/oauth/withings', '/api/webhooks/withings'), appli: '1' }),
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Bearer ${access_token}`,
+          },
+          body: new URLSearchParams({
+            action: 'subscribe',
+            callbackurl: WITHINGS_REDIRECT_URI.replace('/callback', '').replace(
+              '/api/oauth/withings',
+              '/api/webhooks/withings',
+            ),
+            appli: '1',
+          }),
         });
-      } catch { /* webhook subscription failure is non-critical */ }
+      } catch {
+        /* webhook subscription failure is non-critical */
+      }
 
       return c.redirect('/forge?withings=connected');
     } catch (err) {
@@ -239,17 +321,24 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
   // GET /api/oauth/withings/status — connection status
   app.get('/api/oauth/withings/status', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge access required' }, 403);
-    const token = sqlite.prepare("SELECT provider, user_id, expires_at, scopes, updated_at FROM oauth_tokens WHERE provider = 'withings' LIMIT 1").get() as any;
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge access required' }, 403);
+    const token = sqlite
+      .prepare(
+        "SELECT provider, user_id, expires_at, scopes, updated_at FROM oauth_tokens WHERE provider = 'withings' LIMIT 1",
+      )
+      .get() as any;
     if (!token) return c.json({ connected: false });
     const now = Math.floor(Date.now() / 1000);
     // Last successful sync time — use in-memory tracker (updated every sync, even with 0 new records)
     // Fall back to DB created_at for first load after server restart (T#536)
     let lastSync = withingsLastSyncAt;
     if (!lastSync) {
-      const lastSyncRow = sqlite.prepare(
-        "SELECT MAX(created_at) as sync_time FROM routine_logs WHERE source = 'withings' AND deleted_at IS NULL"
-      ).get() as any;
+      const lastSyncRow = sqlite
+        .prepare(
+          "SELECT MAX(created_at) as sync_time FROM routine_logs WHERE source = 'withings' AND deleted_at IS NULL",
+        )
+        .get() as any;
       lastSync = lastSyncRow?.sync_time || null;
     }
     return c.json({
@@ -264,17 +353,22 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
   // GET /api/withings/devices — proxy to Withings device list (T#478)
   app.get('/api/withings/devices', async (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Forge access required' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Forge access required' }, 403);
     try {
       const tokenData = await ensureFreshWithingsToken();
       if (!tokenData) return c.json({ error: 'Withings not connected' }, 400);
       const res = await fetch('https://wbsapi.withings.net/v2/user', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: `Bearer ${tokenData.accessToken}` },
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Bearer ${tokenData.accessToken}`,
+        },
         body: new URLSearchParams({ action: 'getdevice' }),
       });
-      const data = await res.json() as any;
-      if (data.status !== 0) return c.json({ error: data.error || `Withings API error: ${data.status}` }, 502);
+      const data = (await res.json()) as any;
+      if (data.status !== 0)
+        return c.json({ error: data.error || `Withings API error: ${data.status}` }, 502);
       return c.json({ devices: data.body?.devices || [] });
     } catch (err: any) {
       return c.json({ error: err?.message || 'Failed to fetch devices' }, 500);
@@ -290,13 +384,28 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
       if (tokenData) {
         await fetch('https://wbsapi.withings.net/notify', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: `Bearer ${tokenData.accessToken}` },
-          body: new URLSearchParams({ action: 'revoke', callbackurl: WITHINGS_REDIRECT_URI.replace('/callback', '').replace('/api/oauth/withings', '/api/webhooks/withings'), appli: '1' }),
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Bearer ${tokenData.accessToken}`,
+          },
+          body: new URLSearchParams({
+            action: 'revoke',
+            callbackurl: WITHINGS_REDIRECT_URI.replace('/callback', '').replace(
+              '/api/oauth/withings',
+              '/api/webhooks/withings',
+            ),
+            appli: '1',
+          }),
         });
       }
-    } catch { /* best effort */ }
+    } catch {
+      /* best effort */
+    }
     sqlite.prepare("DELETE FROM oauth_tokens WHERE provider = 'withings'").run();
-    const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+    const ip =
+      c.req.header('x-real-ip') ||
+      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+      'local';
     logSecurityEvent({
       eventType: 'token_revoked',
       severity: 'info',
@@ -312,13 +421,23 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
   // Withings measurement type mapping
   const WITHINGS_MEASTYPES: Record<number, string> = {
-    1: 'weight', 5: 'fat_free_mass', 6: 'body_fat_pct', 8: 'fat_mass',
-    9: 'diastolic', 10: 'systolic',
-    76: 'muscle_mass', 77: 'hydration', 88: 'bone_mass', 170: 'visceral_fat',
+    1: 'weight',
+    5: 'fat_free_mass',
+    6: 'body_fat_pct',
+    8: 'fat_mass',
+    9: 'diastolic',
+    10: 'systolic',
+    76: 'muscle_mass',
+    77: 'hydration',
+    88: 'bone_mass',
+    170: 'visceral_fat',
   };
 
   // Fetch and store Withings measurements for a date range
-  async function syncWithingsMeasurements(startdate: number, enddate: number): Promise<{ synced: number; skipped: number }> {
+  async function syncWithingsMeasurements(
+    startdate: number,
+    enddate: number,
+  ): Promise<{ synced: number; skipped: number }> {
     const tokenData = await ensureFreshWithingsToken();
     if (!tokenData) throw new Error('No Withings connection');
 
@@ -332,20 +451,31 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
     const res = await fetch('https://wbsapi.withings.net/measure', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: `Bearer ${tokenData.accessToken}` },
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Bearer ${tokenData.accessToken}`,
+      },
       body: new URLSearchParams(params),
     });
-    const data = await res.json() as any;
+    const data = (await res.json()) as any;
     if (data.status !== 0) throw new Error(`Withings API error: ${data.error || data.status}`);
 
     const measuregrps = data.body?.measuregrps || [];
-    let synced = 0, skipped = 0;
+    let synced = 0,
+      skipped = 0;
 
     for (const grp of measuregrps) {
       const grpid = grp.grpid;
       // Dedup by withings_grpid (check both weight and measurement types)
-      const existing = sqlite.prepare("SELECT id FROM routine_logs WHERE source = 'withings' AND json_extract(data, '$.withings_grpid') = ? AND deleted_at IS NULL LIMIT 1").get(grpid);
-      if (existing) { skipped++; continue; }
+      const existing = sqlite
+        .prepare(
+          "SELECT id FROM routine_logs WHERE source = 'withings' AND json_extract(data, '$.withings_grpid') = ? AND deleted_at IS NULL LIMIT 1",
+        )
+        .get(grpid);
+      if (existing) {
+        skipped++;
+        continue;
+      }
 
       const measurements: Record<string, number> = {};
       for (const m of grp.measures || []) {
@@ -367,28 +497,39 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
           source: 'withings',
           withings_grpid: grpid,
         });
-        sqlite.prepare(
-          'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)'
-        ).run('blood_pressure', loggedAt, bpData, 'withings', now);
+        sqlite
+          .prepare(
+            'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)',
+          )
+          .run('blood_pressure', loggedAt, bpData, 'withings', now);
         delete measurements.systolic;
         delete measurements.diastolic;
       }
 
       // Store weight as 'weight' type so Forge chart picks it up
       if (measurements.weight) {
-        const weightData = JSON.stringify({ value: measurements.weight, unit: 'kg', source: 'withings', withings_grpid: grpid });
-        sqlite.prepare(
-          'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)'
-        ).run('weight', loggedAt, weightData, 'withings', now);
+        const weightData = JSON.stringify({
+          value: measurements.weight,
+          unit: 'kg',
+          source: 'withings',
+          withings_grpid: grpid,
+        });
+        sqlite
+          .prepare(
+            'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)',
+          )
+          .run('weight', loggedAt, weightData, 'withings', now);
       }
 
       // Store full body composition as 'measurement' type (only if body-comp fields remain)
       const bodyCompKeys = Object.keys(measurements);
       if (bodyCompKeys.length > 0 && (bodyCompKeys.length > 1 || !measurements.weight)) {
         const logData = JSON.stringify({ ...measurements, withings_grpid: grpid });
-        sqlite.prepare(
-          'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)'
-        ).run('measurement', loggedAt, logData, 'withings', now);
+        sqlite
+          .prepare(
+            'INSERT INTO routine_logs (type, logged_at, data, source, created_at) VALUES (?, ?, ?, ?, ?)',
+          )
+          .run('measurement', loggedAt, logData, 'withings', now);
       }
       synced++;
     }
@@ -407,10 +548,14 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
     const startdate = parseInt(String(body.startdate || '0'), 10);
     const enddate = parseInt(String(body.enddate || '0'), 10);
 
-    console.log(`[Withings] Webhook received: userid=${userid} appli=${appli} startdate=${startdate} enddate=${enddate}`);
+    console.log(
+      `[Withings] Webhook received: userid=${userid} appli=${appli} startdate=${startdate} enddate=${enddate}`,
+    );
 
     // Validate userid matches stored token
-    const token = sqlite.prepare("SELECT user_id FROM oauth_tokens WHERE provider = 'withings' LIMIT 1").get() as any;
+    const token = sqlite
+      .prepare("SELECT user_id FROM oauth_tokens WHERE provider = 'withings' LIMIT 1")
+      .get() as any;
     if (!token || token.user_id !== userid) {
       console.log(`[Withings] Webhook rejected: unknown userid ${userid}`);
       return c.text('OK', 200); // Still return 200 to avoid Withings retries
@@ -422,7 +567,7 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
     }
 
     // Async sync — don't block the 200 response
-    syncWithingsMeasurements(startdate, enddate).catch(err => {
+    syncWithingsMeasurements(startdate, enddate).catch((err) => {
       console.error('[Withings] Async sync failed:', err);
     });
 
@@ -431,16 +576,21 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
   // POST /api/oauth/withings/sync — manual sync trigger (T#415)
   app.post('/api/oauth/withings/sync', async (c) => {
-    if (!isForgeAuthorized(c, { mode: 'write' })) return c.json({ error: 'Forge access required' }, 403);
+    if (!isForgeAuthorized(c, { mode: 'write' }))
+      return c.json({ error: 'Forge access required' }, 403);
 
-    const token = sqlite.prepare("SELECT * FROM oauth_tokens WHERE provider = 'withings' LIMIT 1").get() as any;
+    const token = sqlite
+      .prepare("SELECT * FROM oauth_tokens WHERE provider = 'withings' LIMIT 1")
+      .get() as any;
     if (!token) return c.json({ error: 'Withings not connected' }, 400);
 
     try {
       // Get last sync time from most recent Withings log
-      const lastLog = sqlite.prepare(
-        "SELECT logged_at FROM routine_logs WHERE source = 'withings' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1"
-      ).get() as any;
+      const lastLog = sqlite
+        .prepare(
+          "SELECT logged_at FROM routine_logs WHERE source = 'withings' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1",
+        )
+        .get() as any;
 
       const now = Math.floor(Date.now() / 1000);
       const full = c.req.query('full') === 'true';
@@ -464,7 +614,8 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
   const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || '';
   const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || '';
-  const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || 'https://denbook.online/api/oauth/google/callback';
+  const GOOGLE_REDIRECT_URI =
+    process.env.GOOGLE_REDIRECT_URI || 'https://denbook.online/api/oauth/google/callback';
   const GOOGLE_SCOPES = 'https://www.googleapis.com/auth/gmail.readonly';
 
   // PKCE state storage (in-memory, short-lived) — stores state → { timestamp, codeVerifier }
@@ -500,7 +651,7 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
   function checkGoogleRateLimit(beast: string): boolean {
     const now = Date.now();
     const oneMinAgo = now - 60000;
-    const timestamps = (googleRateLimits.get(beast) || []).filter(t => t > oneMinAgo);
+    const timestamps = (googleRateLimits.get(beast) || []).filter((t) => t > oneMinAgo);
     if (timestamps.length >= GOOGLE_RATE_LIMIT) return false;
     timestamps.push(now);
     googleRateLimits.set(beast, timestamps);
@@ -518,17 +669,30 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
   // Refresh Google tokens if needed
   async function ensureFreshGoogleToken(): Promise<{ accessToken: string; userId: string } | null> {
-    const token = sqlite.prepare("SELECT * FROM oauth_tokens WHERE provider = 'google' LIMIT 1").get() as any;
+    const token = sqlite
+      .prepare("SELECT * FROM oauth_tokens WHERE provider = 'google' LIMIT 1")
+      .get() as any;
     if (!token) return null;
 
     const now = Math.floor(Date.now() / 1000);
     if (token.expires_at > now + 600) {
-      return { accessToken: decryptToken(token.access_token_enc, token.access_iv || token.token_iv, token.access_tag || token.token_tag), userId: token.user_id };
+      return {
+        accessToken: decryptToken(
+          token.access_token_enc,
+          token.access_iv || token.token_iv,
+          token.access_tag || token.token_tag,
+        ),
+        userId: token.user_id,
+      };
     }
 
     // Refresh — Google does NOT rotate refresh tokens
     try {
-      const refreshToken = decryptToken(token.refresh_token_enc, token.refresh_iv || token.token_iv, token.refresh_tag || token.token_tag);
+      const refreshToken = decryptToken(
+        token.refresh_token_enc,
+        token.refresh_iv || token.token_iv,
+        token.refresh_tag || token.token_tag,
+      );
       const res = await fetch('https://oauth2.googleapis.com/token', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -539,16 +703,18 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
           grant_type: 'refresh_token',
         }),
       });
-      const data = await res.json() as any;
+      const data = (await res.json()) as any;
       if (data.error) throw new Error(`Refresh failed: ${data.error}`);
 
       const { access_token, expires_in } = data;
       const enc = encryptToken(access_token);
       // Google keeps same refresh token — only update access token
-      sqlite.prepare(
-        `UPDATE oauth_tokens SET access_token_enc = ?, access_iv = ?, access_tag = ?,
-         expires_at = ?, updated_at = ? WHERE id = ?`
-      ).run(enc.encrypted, enc.iv, enc.tag, now + expires_in, now, token.id);
+      sqlite
+        .prepare(
+          `UPDATE oauth_tokens SET access_token_enc = ?, access_iv = ?, access_tag = ?,
+         expires_at = ?, updated_at = ? WHERE id = ?`,
+        )
+        .run(enc.encrypted, enc.iv, enc.tag, now + expires_in, now, token.id);
 
       logSecurityEvent({
         eventType: 'token_refreshed',
@@ -567,23 +733,36 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
   }
 
   // Google access control middleware
-  function checkGoogleAccess(beast: string, requiredScope: string = 'gmail.readonly'): { allowed: boolean; error?: string; status?: number } {
-    const access = sqlite.prepare("SELECT scopes FROM google_access WHERE beast = ?").get(beast) as any;
+  function checkGoogleAccess(
+    beast: string,
+    requiredScope: string = 'gmail.readonly',
+  ): { allowed: boolean; error?: string; status?: number } {
+    const access = sqlite
+      .prepare('SELECT scopes FROM google_access WHERE beast = ?')
+      .get(beast) as any;
     if (!access) return { allowed: false, error: 'Not authorized for Google access', status: 401 };
     const scopes = access.scopes.split(',').map((s: string) => s.trim());
-    if (!scopes.includes(requiredScope)) return { allowed: false, error: 'Insufficient Google scope', status: 403 };
+    if (!scopes.includes(requiredScope))
+      return { allowed: false, error: 'Insufficient Google scope', status: 403 };
     return { allowed: true };
   }
 
   // Log Google API access
   function logGoogleAccess(beast: string, endpoint: string, query?: string, messageId?: string) {
     const now = Math.floor(Date.now() / 1000);
-    sqlite.prepare("INSERT INTO google_audit_log (beast, endpoint, query, message_id, created_at) VALUES (?, ?, ?, ?, ?)").run(beast, endpoint, query || null, messageId || null, now);
+    sqlite
+      .prepare(
+        'INSERT INTO google_audit_log (beast, endpoint, query, message_id, created_at) VALUES (?, ?, ?, ?, ?)',
+      )
+      .run(beast, endpoint, query || null, messageId || null, now);
   }
 
   // Wrap email content with untrusted boundary tags (prompt injection defense)
   function tagUntrustedContent(content: string, maxLength: number = 50000): string {
-    const truncated = content.length > maxLength ? content.substring(0, maxLength) + '\n[... truncated at 50KB]' : content;
+    const truncated =
+      content.length > maxLength
+        ? content.substring(0, maxLength) + '\n[... truncated at 50KB]'
+        : content;
     return `--- BEGIN UNTRUSTED EMAIL CONTENT ---\n${truncated}\n--- END UNTRUSTED EMAIL CONTENT ---`;
   }
 
@@ -596,7 +775,8 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
   // GET /api/oauth/google/authorize — start OAuth flow with PKCE
   app.get('/api/oauth/google/authorize', (c) => {
     if (!hasSessionAuth(c)) return c.json({ error: 'Gorn authentication required' }, 403);
-    if (!GOOGLE_CLIENT_ID) return c.json({ error: 'Google not configured (missing GOOGLE_CLIENT_ID)' }, 500);
+    if (!GOOGLE_CLIENT_ID)
+      return c.json({ error: 'Google not configured (missing GOOGLE_CLIENT_ID)' }, 500);
 
     // CSRF state + PKCE code verifier
     const state = require('crypto').randomBytes(16).toString('hex');
@@ -605,7 +785,9 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
     googleOauthStates.set(state, { ts: Date.now(), codeVerifier });
     // Clean old states (>10 min)
-    for (const [k, v] of googleOauthStates) { if (Date.now() - v.ts > 600000) googleOauthStates.delete(k); }
+    for (const [k, v] of googleOauthStates) {
+      if (Date.now() - v.ts > 600000) googleOauthStates.delete(k);
+    }
 
     const params = new URLSearchParams({
       response_type: 'code',
@@ -650,11 +832,20 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
           code_verifier: stateData.codeVerifier,
         }),
       });
-      const data = await res.json() as any;
-      if (data.error) return c.redirect('/settings?oauth_error=' + encodeURIComponent(data.error_description || data.error));
+      const data = (await res.json()) as any;
+      if (data.error)
+        return c.redirect(
+          '/settings?oauth_error=' + encodeURIComponent(data.error_description || data.error),
+        );
 
       const { access_token, refresh_token, expires_in, scope } = data;
-      if (!refresh_token) return c.redirect('/settings?oauth_error=' + encodeURIComponent('No refresh token returned — try disconnecting from Google and reconnecting'));
+      if (!refresh_token)
+        return c.redirect(
+          '/settings?oauth_error=' +
+            encodeURIComponent(
+              'No refresh token returned — try disconnecting from Google and reconnecting',
+            ),
+        );
 
       const now = Math.floor(Date.now() / 1000);
 
@@ -664,9 +855,11 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
         const infoRes = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
           headers: { Authorization: `Bearer ${access_token}` },
         });
-        const info = await infoRes.json() as any;
+        const info = (await infoRes.json()) as any;
         userEmail = info.email || 'unknown';
-      } catch { /* non-critical */ }
+      } catch {
+        /* non-critical */
+      }
 
       // Encrypt tokens
       const accessEnc = encryptToken(access_token);
@@ -674,10 +867,25 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
       // Store (upsert — replace existing Google connection)
       sqlite.prepare("DELETE FROM oauth_tokens WHERE provider = 'google'").run();
-      sqlite.prepare(
-        `INSERT INTO oauth_tokens (provider, user_id, access_token_enc, refresh_token_enc, access_iv, access_tag, refresh_iv, refresh_tag, expires_at, scopes, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      ).run('google', userEmail, accessEnc.encrypted, refreshEnc.encrypted, accessEnc.iv, accessEnc.tag, refreshEnc.iv, refreshEnc.tag, now + expires_in, scope || GOOGLE_SCOPES, now, now);
+      sqlite
+        .prepare(
+          `INSERT INTO oauth_tokens (provider, user_id, access_token_enc, refresh_token_enc, access_iv, access_tag, refresh_iv, refresh_tag, expires_at, scopes, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'google',
+          userEmail,
+          accessEnc.encrypted,
+          refreshEnc.encrypted,
+          accessEnc.iv,
+          accessEnc.tag,
+          refreshEnc.iv,
+          refreshEnc.tag,
+          now + expires_in,
+          scope || GOOGLE_SCOPES,
+          now,
+          now,
+        );
 
       logSecurityEvent({
         eventType: 'token_created',
@@ -698,8 +906,13 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
   // GET /api/oauth/google/status — connection status
   app.get('/api/oauth/google/status', (c) => {
-    if (!isForgeAuthorized(c, { mode: 'read' })) return c.json({ error: 'Authentication required' }, 403);
-    const token = sqlite.prepare("SELECT provider, user_id, expires_at, scopes, updated_at FROM oauth_tokens WHERE provider = 'google' LIMIT 1").get() as any;
+    if (!isForgeAuthorized(c, { mode: 'read' }))
+      return c.json({ error: 'Authentication required' }, 403);
+    const token = sqlite
+      .prepare(
+        "SELECT provider, user_id, expires_at, scopes, updated_at FROM oauth_tokens WHERE provider = 'google' LIMIT 1",
+      )
+      .get() as any;
     if (!token) return c.json({ connected: false });
     const now = Math.floor(Date.now() / 1000);
     return c.json({
@@ -725,9 +938,14 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
         });
         console.log('[Google] Token revoked at Google');
       }
-    } catch { /* best effort */ }
+    } catch {
+      /* best effort */
+    }
     sqlite.prepare("DELETE FROM oauth_tokens WHERE provider = 'google'").run();
-    const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+    const ip =
+      c.req.header('x-real-ip') ||
+      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+      'local';
     logSecurityEvent({
       eventType: 'token_revoked',
       severity: 'info',
@@ -746,19 +964,27 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
   // GET /api/google/access — list allowed Beasts
   app.get('/api/google/access', (c) => {
     if (!hasSessionAuth(c)) return c.json({ error: 'Gorn authentication required' }, 403);
-    const rows = sqlite.prepare("SELECT beast, scopes, granted_by, created_at FROM google_access ORDER BY created_at").all();
+    const rows = sqlite
+      .prepare(
+        'SELECT beast, scopes, granted_by, created_at FROM google_access ORDER BY created_at',
+      )
+      .all();
     return c.json({ access: rows });
   });
 
   // POST /api/google/access — grant Beast access
   app.post('/api/google/access', async (c) => {
     if (!hasSessionAuth(c)) return c.json({ error: 'Gorn authentication required' }, 403);
-    const body = await c.req.json() as any;
+    const body = (await c.req.json()) as any;
     const { beast, scopes } = body;
     if (!beast || !scopes) return c.json({ error: 'Missing beast or scopes' }, 400);
     const now = Math.floor(Date.now() / 1000);
     try {
-      sqlite.prepare("INSERT OR REPLACE INTO google_access (beast, scopes, granted_by, created_at) VALUES (?, ?, 'gorn', ?)").run(beast.toLowerCase(), scopes, now);
+      sqlite
+        .prepare(
+          "INSERT OR REPLACE INTO google_access (beast, scopes, granted_by, created_at) VALUES (?, ?, 'gorn', ?)",
+        )
+        .run(beast.toLowerCase(), scopes, now);
       console.log(`[Google] Access granted: ${beast} (${scopes})`);
       return c.json({ granted: true, beast, scopes });
     } catch (err: any) {
@@ -770,7 +996,7 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
   app.delete('/api/google/access/:beast', (c) => {
     if (!hasSessionAuth(c)) return c.json({ error: 'Gorn authentication required' }, 403);
     const beast = c.req.param('beast').toLowerCase();
-    sqlite.prepare("DELETE FROM google_access WHERE beast = ?").run(beast);
+    sqlite.prepare('DELETE FROM google_access WHERE beast = ?').run(beast);
     console.log(`[Google] Access revoked: ${beast}`);
     return c.json({ revoked: true, beast });
   });
@@ -780,8 +1006,11 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
     if (!hasSessionAuth(c)) return c.json({ error: 'Gorn authentication required' }, 403);
     const limit = Math.min(parseInt(c.req.query('limit') || '50'), 200);
     const offset = parseInt(c.req.query('offset') || '0');
-    const rows = sqlite.prepare("SELECT * FROM google_audit_log ORDER BY created_at DESC LIMIT ? OFFSET ?").all(limit, offset);
-    const total = (sqlite.prepare("SELECT COUNT(*) as count FROM google_audit_log").get() as any).count;
+    const rows = sqlite
+      .prepare('SELECT * FROM google_audit_log ORDER BY created_at DESC LIMIT ? OFFSET ?')
+      .all(limit, offset);
+    const total = (sqlite.prepare('SELECT COUNT(*) as count FROM google_audit_log').get() as any)
+      .count;
     return c.json({ logs: rows, total });
   });
 
@@ -814,8 +1043,9 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
       const res = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/profile', {
         headers: { Authorization: `Bearer ${tokenData.accessToken}` },
       });
-      const data = await res.json() as any;
-      if (!res.ok) return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
+      const data = (await res.json()) as any;
+      if (!res.ok)
+        return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
 
       logGoogleAccess(beast, '/api/google/gmail/profile');
       return c.json(data);
@@ -839,8 +1069,9 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
       const res = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/labels', {
         headers: { Authorization: `Bearer ${tokenData.accessToken}` },
       });
-      const data = await res.json() as any;
-      if (!res.ok) return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
+      const data = (await res.json()) as any;
+      if (!res.ok)
+        return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
 
       logGoogleAccess(beast, '/api/google/gmail/labels');
       return c.json(data);
@@ -869,13 +1100,14 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
       const params = new URLSearchParams({ maxResults: String(maxResults) });
       if (q) params.set('q', q);
       if (pageToken) params.set('pageToken', pageToken);
-      if (labelIds) labelIds.split(',').forEach(id => params.append('labelIds', id.trim()));
+      if (labelIds) labelIds.split(',').forEach((id) => params.append('labelIds', id.trim()));
 
       const res = await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages?${params}`, {
         headers: { Authorization: `Bearer ${tokenData.accessToken}` },
       });
-      const data = await res.json() as any;
-      if (!res.ok) return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
+      const data = (await res.json()) as any;
+      if (!res.ok)
+        return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
 
       logGoogleAccess(beast, '/api/google/gmail/messages', q || undefined);
       return c.json(data);
@@ -898,15 +1130,20 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
       const tokenData = await ensureFreshGoogleToken();
       if (!tokenData) return c.json({ error: 'Google not connected' }, 401);
 
-      const res = await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${messageId}?format=full`, {
-        headers: { Authorization: `Bearer ${tokenData.accessToken}` },
-      });
-      const data = await res.json() as any;
-      if (!res.ok) return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
+      const res = await fetch(
+        `https://gmail.googleapis.com/gmail/v1/users/me/messages/${messageId}?format=full`,
+        {
+          headers: { Authorization: `Bearer ${tokenData.accessToken}` },
+        },
+      );
+      const data = (await res.json()) as any;
+      if (!res.ok)
+        return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
 
       // Parse message into clean format — text only, no HTML (XSS prevention per Bertus)
       const headers = data.payload?.headers || [];
-      const getHeader = (name: string) => headers.find((h: any) => h.name.toLowerCase() === name.toLowerCase())?.value || '';
+      const getHeader = (name: string) =>
+        headers.find((h: any) => h.name.toLowerCase() === name.toLowerCase())?.value || '';
 
       // Extract plain text body from MIME parts
       let textBody = '';
@@ -953,16 +1190,21 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
       const tokenData = await ensureFreshGoogleToken();
       if (!tokenData) return c.json({ error: 'Google not connected' }, 401);
 
-      const res = await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/threads/${threadId}?format=full`, {
-        headers: { Authorization: `Bearer ${tokenData.accessToken}` },
-      });
-      const data = await res.json() as any;
-      if (!res.ok) return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
+      const res = await fetch(
+        `https://gmail.googleapis.com/gmail/v1/users/me/threads/${threadId}?format=full`,
+        {
+          headers: { Authorization: `Bearer ${tokenData.accessToken}` },
+        },
+      );
+      const data = (await res.json()) as any;
+      if (!res.ok)
+        return c.json({ error: data.error?.message || `Gmail API error: ${res.status}` }, 502);
 
       // Format each message in thread — text only, no HTML
       const messages = (data.messages || []).map((msg: any) => {
         const headers = msg.payload?.headers || [];
-        const getHeader = (name: string) => headers.find((h: any) => h.name.toLowerCase() === name.toLowerCase())?.value || '';
+        const getHeader = (name: string) =>
+          headers.find((h: any) => h.name.toLowerCase() === name.toLowerCase())?.value || '';
 
         let textBody = '';
         function extractText(part: any) {
@@ -992,8 +1234,6 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
     }
   });
 
-
-
   // Withings auto-sync daemon body — assigned to module-level forward-declared var.
   // initIntegrations() schedules setInterval/setTimeout against this assignment.
   // Withings daily auto-sync (T#523) — sync every 24h, first run 60s after boot
@@ -1002,11 +1242,15 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
 
   async function runWithingsAutoSync() {
     try {
-      const token = sqlite.prepare("SELECT * FROM oauth_tokens WHERE provider = 'withings' LIMIT 1").get() as any;
+      const token = sqlite
+        .prepare("SELECT * FROM oauth_tokens WHERE provider = 'withings' LIMIT 1")
+        .get() as any;
       if (!token) return; // Not connected, skip silently
-      const lastLog = sqlite.prepare(
-        "SELECT logged_at FROM routine_logs WHERE source = 'withings' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1"
-      ).get() as any;
+      const lastLog = sqlite
+        .prepare(
+          "SELECT logged_at FROM routine_logs WHERE source = 'withings' AND deleted_at IS NULL ORDER BY logged_at DESC LIMIT 1",
+        )
+        .get() as any;
       const now = Math.floor(Date.now() / 1000);
       const startdate = lastLog
         ? Math.floor(new Date(lastLog.logged_at).getTime() / 1000)
@@ -1022,5 +1266,4 @@ export function registerIntegrationsRoutes(app: OpenAPIHono, sqliteDb: Database,
   // ============================================================================
   // Supersede Log Routes (Issue #18, #19)
   // ============================================================================
-
 }

--- a/src/knowledge/routes.ts
+++ b/src/knowledge/routes.ts
@@ -15,335 +15,1125 @@ import type { ToolContext } from '../tools/types.ts';
 
 // Endpoint catalog — shared by /api/help and 404 handler
 export const HELP_ENDPOINTS = [
-    // Auth
-    { method: 'GET', path: '/api/auth/status', desc: 'Check if session is authenticated', params: null },
-    { method: 'POST', path: '/api/auth/login', desc: 'Login with password', params: 'body: { password }' },
-    { method: 'POST', path: '/api/auth/logout', desc: 'Logout current session', params: null },
-    // Health
-    { method: 'GET', path: '/api/health', desc: 'Server health check', params: null },
-    { method: 'GET', path: '/api/help', desc: 'This endpoint catalog', params: '?q=filter' },
-    // Threads (forum)
-    { method: 'GET', path: '/api/threads', desc: 'List all forum threads', params: '?status=&category=&limit=50&offset=0' },
-    { method: 'POST', path: '/api/thread', desc: 'Create thread or post message', params: 'body: { message, author, thread_id?, title?, reply_to_id?, visibility? }' },
-    { method: 'GET', path: '/api/thread/:id', desc: 'Get thread messages', params: '?limit=50&offset=0' },
-    { method: 'PATCH', path: '/api/thread/:id/category', desc: 'Update thread category', params: 'body: { category, beast }' },
-    { method: 'PATCH', path: '/api/thread/:id/lock', desc: 'Lock/unlock thread', params: 'body: { locked, beast }' },
-    { method: 'PATCH', path: '/api/thread/:id/archive', desc: 'Archive/unarchive thread', params: 'body: { archived, beast }' },
-    { method: 'PATCH', path: '/api/thread/:id/pin', desc: 'Pin/unpin thread', params: 'body: { pinned, beast }' },
-    { method: 'PATCH', path: '/api/thread/:id/title', desc: 'Rename thread title', params: 'body: { title, beast }' },
-    { method: 'PATCH', path: '/api/thread/:id/status', desc: 'Update thread status', params: 'body: { status, beast }' },
-    { method: 'PATCH', path: '/api/thread/:id/visibility', desc: 'Update thread visibility', params: 'body: { visibility, beast }' },
-    { method: 'DELETE', path: '/api/thread/:id', desc: 'Delete thread', params: 'body: { beast }' },
-    // Forum utilities
-    { method: 'POST', path: '/api/forum/read', desc: 'Mark thread as read', params: 'body: { beast, threadId, messageId }' },
-    { method: 'GET', path: '/api/forum/unread/:beast', desc: 'Get unread thread counts', params: null },
-    { method: 'GET', path: '/api/forum/mentions/:beast', desc: 'Get @mentions for a beast', params: '?limit=30' },
-    { method: 'GET', path: '/api/forum/search', desc: 'Search forum messages', params: '?q=query&limit=20' },
-    { method: 'GET', path: '/api/forum/activity', desc: 'Recent forum activity feed', params: '?limit=50' },
-    { method: 'POST', path: '/api/forum/mute', desc: 'Mute/unmute thread notifications', params: 'body: { beast, threadId, muted }' },
-    { method: 'GET', path: '/api/forum/muted/:beast', desc: 'Get muted threads', params: null },
-    { method: 'GET', path: '/api/forum/link-preview', desc: 'Get link preview metadata', params: '?url=' },
-    // Messages
-    { method: 'PATCH', path: '/api/message/:id', desc: 'Edit a message', params: 'body: { content, beast }' },
-    { method: 'GET', path: '/api/message/:id/history', desc: 'Get message edit history', params: null },
-    { method: 'POST', path: '/api/message/:id/react', desc: 'Add reaction to message', params: 'body: { beast, emoji }' },
-    { method: 'DELETE', path: '/api/message/:id/react', desc: 'Remove reaction', params: 'body: { beast, emoji }' },
-    { method: 'GET', path: '/api/message/:id/reactions', desc: 'Get message reactions', params: null },
-    { method: 'GET', path: '/api/message/:id/attachments', desc: 'Get message file attachments', params: null },
-    // Emojis
-    { method: 'GET', path: '/api/forum/emojis', desc: 'List custom emojis', params: null },
-    { method: 'POST', path: '/api/forum/emojis', desc: 'Add custom emoji', params: 'body: { emoji, name, category? }' },
-    { method: 'DELETE', path: '/api/forum/emojis/:emoji', desc: 'Remove custom emoji', params: null },
-    { method: 'GET', path: '/api/reactions/supported', desc: 'List all supported reactions', params: null },
-    // DMs
-    { method: 'GET', path: '/api/dm/:name', desc: 'List DM conversations for a beast', params: null },
-    { method: 'GET', path: '/api/dm/:name/:other', desc: 'Get DM conversation between two beasts', params: '?limit=30&offset=0&order=desc' },
-    { method: 'POST', path: '/api/dm', desc: 'Send a DM', params: 'body: { from, to, message }' },
-    { method: 'PATCH', path: '/api/dm/:name/:other/read', desc: 'Mark DM conversation as read', params: null },
-    { method: 'PATCH', path: '/api/dm/:name/:other/read-all', desc: 'Mark all DMs as read', params: null },
-    { method: 'DELETE', path: '/api/dm/messages/:id', desc: 'Delete a DM message', params: null },
-    { method: 'GET', path: '/api/dm/dashboard', desc: 'DM dashboard stats', params: null },
-    { method: 'GET', path: '/api/dm/unread-count', desc: 'Get unread DM count', params: null },
-    // Tasks (PM Board)
-    { method: 'GET', path: '/api/tasks', desc: 'List tasks (Spec #56: parent_id filter)', params: '?assignee=&reviewer=&status=&parent_id=&limit=100&offset=0&include_deleted=true' },
-    { method: 'GET', path: '/api/tasks/:id', desc: 'Get task by ID (includes subtasks summary if parent)', params: null },
-    { method: 'GET', path: '/api/tasks/:id/subtree', desc: 'Get parent task + all direct subtasks (Spec #56)', params: null },
-    { method: 'POST', path: '/api/tasks', desc: 'Create task (Spec #56: parent_task_id for subtasks)', params: 'body: { title, assigned_to, reviewer, project_id, description?, status?, parent_task_id? }' },
-    { method: 'PATCH', path: '/api/tasks/:id', desc: 'Update task (Spec #56: parent_task_id for reparent)', params: 'body: { title?, description?, assignee?, reviewer?, status?, parent_task_id? }' },
-    { method: 'DELETE', path: '/api/tasks/:id', desc: 'Delete task (orphans subtasks via SET NULL)', params: null },
-    { method: 'POST', path: '/api/tasks/:id/comments', desc: 'Add comment to task', params: 'body: { author, content }' },
-    { method: 'GET', path: '/api/tasks/:id/comments', desc: 'Get task comments', params: null },
-    // Pack / Beasts
-    { method: 'GET', path: '/api/pack', desc: 'Get all beast profiles with status', params: null },
-    { method: 'GET', path: '/api/beasts', desc: 'List all beast profiles', params: null },
-    { method: 'GET', path: '/api/beast/:name', desc: 'Get single beast profile', params: null },
-    { method: 'PUT', path: '/api/beast/:name', desc: 'Create/replace beast profile', params: 'body: { species, role, bio?, themeColor? }' },
-    { method: 'PATCH', path: '/api/beast/:name', desc: 'Update beast profile fields', params: 'body: { bio?, role?, themeColor?, ... }' },
-    { method: 'PATCH', path: '/api/beast/:name/avatar', desc: 'Upload beast avatar', params: 'body: FormData with avatar file' },
-    { method: 'GET', path: '/api/beast/:name/terminal', desc: 'Get beast tmux terminal output', params: null },
-    { method: 'POST', path: '/api/beast/:name/terminal/input', desc: 'Send text to beast terminal', params: 'body: { input }' },
-    { method: 'POST', path: '/api/beast/:name/terminal/key', desc: 'Send key event to beast terminal', params: 'body: { key }' },
-    // Schedules
-    { method: 'GET', path: '/api/schedules', desc: 'List schedules', params: '?beast=&enabled=' },
-    { method: 'GET', path: '/api/schedules/due', desc: 'Get due schedules', params: '?beast=' },
-    { method: 'POST', path: '/api/schedules', desc: 'Create schedule', params: 'body: { beast, task, command, interval, ... }' },
-    { method: 'PATCH', path: '/api/schedules/:id', desc: 'Update schedule', params: 'body: { task?, command?, interval?, enabled? }' },
-    { method: 'PATCH', path: '/api/schedules/:id/run', desc: 'Mark schedule as run', params: '?as=beast' },
-    { method: 'DELETE', path: '/api/schedules/:id', desc: 'Delete schedule', params: '?as=beast' },
-    // Upload
-    { method: 'POST', path: '/api/upload', desc: 'Upload file attachment', params: 'body: FormData with file' },
-    { method: 'GET', path: '/api/forum/file/:filename', desc: 'Get uploaded file', params: null },
-    { method: 'GET', path: '/api/files', desc: 'List all uploaded files', params: '?limit=50&offset=0' },
-    { method: 'GET', path: '/api/files/stats', desc: 'File storage statistics', params: null },
-    { method: 'GET', path: '/api/files/:id', desc: 'Get file metadata', params: null },
-    { method: 'GET', path: '/api/files/:id/download', desc: 'Download file by ID (owner/beast)', params: null },
-    { method: 'GET', path: '/api/f/:hash', desc: 'Download file by hash (public, unguessable)', params: null },
-    { method: 'DELETE', path: '/api/files/:id', desc: 'Delete file', params: null },
-    // Specs (SDD)
-    { method: 'GET', path: '/api/specs', desc: 'List all specs', params: '?status=&author=' },
-    { method: 'GET', path: '/api/specs/:id', desc: 'Get spec by ID', params: null },
-    { method: 'GET', path: '/api/specs/:id/content', desc: 'Get spec markdown content (Spec #57: ?version=vN for historical)', params: '?version=v1' },
-    { method: 'GET', path: '/api/specs/:id/versions', desc: 'List spec version snapshots (Spec #57)', params: null },
-    { method: 'GET', path: '/api/specs/:id/history', desc: 'Get spec review history', params: null },
-    { method: 'GET', path: '/api/specs/:id/diff', desc: 'Get spec version diff', params: '?v1=&v2=' },
-    { method: 'POST', path: '/api/specs', desc: 'Submit new spec', params: 'body: { title, content, author, task_ids?, thread_ids? }' },
-    { method: 'POST', path: '/api/specs/:id/review', desc: 'Review a spec', params: 'body: { reviewer, action, comment? }' },
-    { method: 'POST', path: '/api/specs/:id/resubmit', desc: 'Resubmit spec with changes', params: 'body: { content, author, change_summary? }' },
-    { method: 'POST', path: '/api/specs/:id/reopen', desc: 'Reopen approved spec for amendment (Spec #57)', params: 'body: { author, reason }' },
-    { method: 'DELETE', path: '/api/specs/:id', desc: 'Delete spec', params: 'body: { beast }' },
-    { method: 'GET', path: '/api/specs/:id/links', desc: 'Get linked tasks/threads', params: null },
-    { method: 'POST', path: '/api/specs/:id/link', desc: 'Link task or thread to spec', params: 'body: { type, target_id }' },
-    { method: 'DELETE', path: '/api/specs/:id/link', desc: 'Unlink task or thread', params: 'body: { type, target_id }' },
-    { method: 'GET', path: '/api/specs/:id/comments', desc: 'Get spec comments', params: null },
-    { method: 'POST', path: '/api/specs/:id/comments', desc: 'Add spec comment', params: 'body: { author, content, type? }' },
-    // Rules
-    { method: 'GET', path: '/api/rules', desc: 'List all active rules', params: null },
-    { method: 'GET', path: '/api/rules/decrees', desc: 'List decrees only', params: null },
-    { method: 'GET', path: '/api/rules/norms', desc: 'List norms only', params: null },
-    { method: 'GET', path: '/api/rules/markdown', desc: 'All rules as markdown (for /recap)', params: null },
-    { method: 'GET', path: '/api/rules/pending', desc: 'List rules pending approval', params: null },
-    { method: 'GET', path: '/api/rules/:id', desc: 'Get rule by ID', params: null },
-    { method: 'POST', path: '/api/rules', desc: 'Propose new rule', params: 'body: { title, content, type, proposed_by }' },
-    { method: 'PATCH', path: '/api/rules/:id', desc: 'Update rule', params: 'body: { title?, content?, type? }' },
-    { method: 'PATCH', path: '/api/rules/:id/archive', desc: 'Archive rule', params: 'body: { beast }' },
-    { method: 'POST', path: '/api/rules/:id/approve', desc: 'Approve pending rule', params: 'body: { beast }' },
-    { method: 'POST', path: '/api/rules/:id/reject', desc: 'Reject pending rule', params: 'body: { beast, reason? }' },
-    // Risks
-    { method: 'GET', path: '/api/risks', desc: 'List all risks', params: '?status=&severity=' },
-    { method: 'GET', path: '/api/risks/summary', desc: 'Risk summary stats', params: null },
-    { method: 'GET', path: '/api/risks/stale', desc: 'Risks not updated recently', params: null },
-    { method: 'GET', path: '/api/risks/:id', desc: 'Get risk by ID', params: null },
-    { method: 'POST', path: '/api/risks', desc: 'Create risk', params: 'body: { title, description, severity, status, owner }' },
-    { method: 'PATCH', path: '/api/risks/:id', desc: 'Update risk', params: 'body: { title?, severity?, status?, mitigation? }' },
-    { method: 'DELETE', path: '/api/risks/:id', desc: 'Delete risk', params: null },
-    // Prowl (Gorn tasks)
-    { method: 'GET', path: '/api/prowl', desc: 'List Gorn personal tasks', params: '?status=&category=&priority=' },
-    { method: 'GET', path: '/api/prowl/categories', desc: 'List Prowl categories', params: null },
-    { method: 'POST', path: '/api/prowl', desc: 'Create Prowl task', params: 'body: { title, due_date? (YYYY-MM-DD or YYYY-MM-DDTHH:MM), category?, priority?, source? }' },
-    { method: 'PATCH', path: '/api/prowl/:id', desc: 'Update Prowl task', params: 'body: { title?, due_date? (YYYY-MM-DD or YYYY-MM-DDTHH:MM), category?, priority?, notes? }' },
-    { method: 'PATCH', path: '/api/prowl/:id/status', desc: 'Update Prowl task status', params: 'body: { status }' },
-    { method: 'POST', path: '/api/prowl/:id/toggle', desc: 'Toggle Prowl task done/undone', params: null },
-    { method: 'DELETE', path: '/api/prowl/:id', desc: 'Delete Prowl task', params: null },
-    { method: 'GET', path: '/api/prowl/:id/checklist', desc: 'List checklist items for a Prowl task', params: null },
-    { method: 'POST', path: '/api/prowl/:id/checklist', desc: 'Add checklist item', params: 'body: { text }' },
-    { method: 'PATCH', path: '/api/prowl/:id/checklist/:itemId', desc: 'Update checklist item', params: 'body: { text?, checked?, sort_order? }' },
-    { method: 'POST', path: '/api/prowl/:id/checklist/:itemId/toggle', desc: 'Toggle checklist item checked', params: null },
-    { method: 'DELETE', path: '/api/prowl/:id/checklist/:itemId', desc: 'Delete checklist item', params: null },
-    { method: 'POST', path: '/api/prowl/notify-test', desc: 'Test Prowl notification pipeline (Gorn-only)', params: null },
-    // Telegram
-    { method: 'GET', path: '/api/telegram/status', desc: 'Telegram polling status (owner only)', params: null },
-    { method: 'GET', path: '/api/telegram/message/:id', desc: 'T#712 — cached inbound TG message by id (Gorn + Sable only)', params: null },
-    // Routine (Forge)
-    { method: 'GET', path: '/api/routine/logs', desc: 'List routine logs', params: '?type=&date=&limit=20&offset=0' },
-    { method: 'GET', path: '/api/routine/today', desc: 'Today routine summary', params: null },
-    { method: 'GET', path: '/api/routine/weight', desc: 'Weight history', params: '?limit=30' },
-    { method: 'GET', path: '/api/routine/blood-pressure', desc: 'BP history (Prowl #80)', params: '?range=week,month,year,3y,10y,all' },
-    { method: 'GET', path: '/api/routine/exercise-summary', desc: 'Single-exercise 4-dimension read: peak/recent/trend/frequency (Prowl #83)', params: '?exercise=<name>' },
-    { method: 'GET', path: '/api/routine/prs', desc: 'All-exercises peak summary, alias for /personal-records?grouped=true (Prowl #83)', params: '?range=month' },
-    { method: 'GET', path: '/api/routine/body-composition', desc: 'Body composition history from Withings', params: '?range=month (1w,1m,3m,1y,3y,all)' },
-    { method: 'GET', path: '/api/routine/stats', desc: 'Routine statistics', params: null },
-    { method: 'GET', path: '/api/routine/summary', desc: 'Routine summary with trends', params: null },
-    { method: 'GET', path: '/api/routine/exercises', desc: 'List exercises', params: null },
-    { method: 'POST', path: '/api/routine/exercises', desc: 'Add exercise', params: 'body: { name, equipment?, muscle_group? }' },
-    { method: 'GET', path: '/api/routine/personal-records', desc: 'Personal records', params: null },
-    { method: 'POST', path: '/api/routine/logs', desc: 'Create routine log (workout: exercises[].notes optional str, exercises[].sets[].rpe optional 1-10 per T#710)', params: 'body: { type, logged_at, data: { exercises?: [{name, notes?, sets: [{weight, reps, rpe?, unit?}]}], items?: [...meal], ... } }' },
-    { method: 'PATCH', path: '/api/routine/logs/:id', desc: 'Update routine log', params: 'body: { ... }' },
-    { method: 'DELETE', path: '/api/routine/logs/:id', desc: 'Soft-delete routine log', params: null },
-    { method: 'PATCH', path: '/api/routine/logs/:id/restore', desc: 'Restore deleted log', params: null },
-    // OAuth
-    { method: 'GET', path: '/api/oauth/withings/authorize', desc: 'Start Withings OAuth flow', params: null },
-    { method: 'GET', path: '/api/oauth/withings/callback', desc: 'OAuth callback (internal)', params: null },
-    { method: 'GET', path: '/api/oauth/withings/status', desc: 'Check Withings connection status', params: null },
-    { method: 'DELETE', path: '/api/oauth/withings/disconnect', desc: 'Disconnect Withings', params: null },
-    { method: 'GET', path: '/api/withings/devices', desc: 'List Withings devices', params: null },
-    // Google OAuth + Gmail
-    { method: 'GET', path: '/api/oauth/google/authorize', desc: 'Start Google OAuth flow', params: null },
-    { method: 'GET', path: '/api/oauth/google/callback', desc: 'Google OAuth callback (internal)', params: null },
-    { method: 'GET', path: '/api/oauth/google/status', desc: 'Check Google connection status', params: null },
-    { method: 'DELETE', path: '/api/oauth/google/disconnect', desc: 'Disconnect Google', params: null },
-    { method: 'GET', path: '/api/google/gmail/profile', desc: 'Get Gmail profile info', params: null },
-    { method: 'GET', path: '/api/google/gmail/labels', desc: 'List Gmail labels', params: null },
-    { method: 'GET', path: '/api/google/gmail/messages', desc: 'List Gmail messages', params: '?label=INBOX&maxResults=20&q=search&pageToken=' },
-    { method: 'GET', path: '/api/google/gmail/messages/:id', desc: 'Get Gmail message by ID', params: null },
-    { method: 'GET', path: '/api/google/gmail/threads/:id', desc: 'Get Gmail thread by ID', params: null },
-    // Google Access Control
-    { method: 'GET', path: '/api/google/access', desc: 'List Google OAuth Beast allowlist', params: null },
-    { method: 'POST', path: '/api/google/access', desc: 'Add Beast to Google OAuth allowlist', params: 'body: { beast }' },
-    { method: 'DELETE', path: '/api/google/access/:beast', desc: 'Remove Beast from Google OAuth allowlist', params: null },
-    { method: 'GET', path: '/api/google/audit', desc: 'Google OAuth audit log', params: null },
-    // Search
-    { method: 'GET', path: '/api/search', desc: 'Search documents and knowledge', params: '?q=query&type=all&limit=10' },
-    { method: 'GET', path: '/api/search/status', desc: 'Search index status', params: null },
-    { method: 'POST', path: '/api/search/reindex', desc: 'Trigger search reindex', params: null },
-    // Remote
-    { method: 'GET', path: '/api/remote/status', desc: 'Remote panel connection status', params: null },
-    { method: 'POST', path: '/api/remote/attach', desc: 'Attach to beast for remote control', params: 'body: { beast }' },
-    { method: 'POST', path: '/api/remote/detach', desc: 'Detach from remote control', params: null },
-    // Queue (Gorn)
-    { method: 'GET', path: '/api/queue/gorn', desc: 'Get Gorn review queue', params: null },
-    { method: 'POST', path: '/api/queue/gorn', desc: 'Add thread to Gorn queue', params: 'body: { threadId, reason, addedBy }' },
-    { method: 'PATCH', path: '/api/queue/gorn/:threadId', desc: 'Update queue item status', params: 'body: { status }' },
-    // Dashboard
-    { method: 'GET', path: '/api/dashboard', desc: 'Dashboard summary', params: null },
-    { method: 'GET', path: '/api/dashboard/summary', desc: 'Dashboard summary (alt)', params: null },
-    { method: 'GET', path: '/api/dashboard/activity', desc: 'Activity stats', params: null },
-    { method: 'GET', path: '/api/dashboard/growth', desc: 'Growth metrics', params: null },
-    { method: 'GET', path: '/api/session/stats', desc: 'Session statistics', params: null },
-    // Library
-    { method: 'GET', path: '/api/library', desc: 'List library entries', params: '?shelf=&limit=50' },
-    { method: 'GET', path: '/api/library/:id', desc: 'Get library entry by ID', params: null },
-    { method: 'POST', path: '/api/library', desc: 'Add library entry', params: 'body: { title, content, shelf?, author }' },
-    { method: 'PATCH', path: '/api/library/:id', desc: 'Update library entry', params: 'body: { title?, content?, shelf? }' },
-    { method: 'DELETE', path: '/api/library/:id', desc: 'Delete library entry', params: null },
-    { method: 'GET', path: '/api/library/search', desc: 'Search library entries', params: '?q=query' },
-    { method: 'GET', path: '/api/library/types', desc: 'List library entry types', params: null },
-    { method: 'GET', path: '/api/library/shelves', desc: 'List library shelves', params: null },
-    { method: 'GET', path: '/api/library/shelves/:id', desc: 'Get shelf by ID', params: null },
-    { method: 'POST', path: '/api/library/shelves', desc: 'Create shelf', params: 'body: { name, description? }' },
-    { method: 'PATCH', path: '/api/library/shelves/:id', desc: 'Update shelf', params: 'body: { name?, description? }' },
-    { method: 'DELETE', path: '/api/library/shelves/:id', desc: 'Delete shelf', params: null },
-    // Handoffs
-    { method: 'POST', path: '/api/handoff', desc: 'Submit session handoff', params: 'body: { oracle, summary, ... }' },
-    { method: 'GET', path: '/api/inbox', desc: 'Get inbox items', params: '?type=&limit=20' },
-    // Auth Tokens
-    { method: 'GET', path: '/api/auth/tokens', desc: 'List API tokens', params: null },
-    { method: 'POST', path: '/api/auth/tokens', desc: 'Create API token', params: 'body: { name }' },
-    { method: 'DELETE', path: '/api/auth/tokens/:id', desc: 'Delete API token', params: null },
-    { method: 'POST', path: '/api/auth/tokens/rotate', desc: 'Rotate API token (owner-driven)', params: null },
-    { method: 'POST', path: '/api/auth/rotate', desc: 'Beast-self chain-aware rotation (Spec #52)', params: 'header: Authorization: Bearer <current_token>' },
-    { method: 'GET', path: '/api/auth/me', desc: 'Beast-self token info — expires_at, refresh_window, self_rotate_door, rotated_at (Spec #51 Phase 3)', params: 'header: Authorization: Bearer <current_token>' },
-    // Guests
-    { method: 'GET', path: '/api/guests', desc: 'List guests', params: null },
-    { method: 'GET', path: '/api/guests/:id', desc: 'Get guest by ID', params: null },
-    { method: 'POST', path: '/api/guests', desc: 'Create guest account', params: 'body: { username, display_name, password }' },
-    { method: 'PATCH', path: '/api/guests/:id', desc: 'Update guest', params: 'body: { display_name?, ... }' },
-    { method: 'PATCH', path: '/api/guests/:id/password', desc: 'Change guest password', params: 'body: { password }' },
-    { method: 'DELETE', path: '/api/guests/:id', desc: 'Delete guest', params: null },
-    { method: 'POST', path: '/api/guests/:id/ban', desc: 'Ban guest', params: null },
-    { method: 'POST', path: '/api/guests/:id/unban', desc: 'Unban guest', params: null },
-    // Guest-facing endpoints
-    { method: 'GET', path: '/api/guest/threads', desc: 'List public threads (guest view)', params: null },
-    { method: 'GET', path: '/api/guest/thread/:id', desc: 'Get thread (guest view)', params: null },
-    { method: 'POST', path: '/api/guest/thread', desc: 'Create thread (guest)', params: 'body: { message, title }' },
-    { method: 'POST', path: '/api/guest/thread/:id/message', desc: 'Post message to thread (guest)', params: 'body: { message }' },
-    { method: 'GET', path: '/api/guest/dm/:from/:to', desc: 'Get DM conversation (guest view)', params: null },
-    { method: 'POST', path: '/api/guest/dm', desc: 'Send DM (guest)', params: 'body: { to, message }' },
-    { method: 'GET', path: '/api/guest/pack', desc: 'Get pack profiles (guest view)', params: null },
-    { method: 'GET', path: '/api/guest/profile', desc: 'Get own guest profile', params: null },
-    { method: 'PATCH', path: '/api/guest/profile', desc: 'Update own guest profile', params: 'body: { display_name?, bio? }' },
-    { method: 'POST', path: '/api/guest/avatar', desc: 'Upload guest avatar', params: 'body: FormData with file' },
-    { method: 'POST', path: '/api/guest/change-password', desc: 'Change guest password (self)', params: 'body: { old_password, new_password }' },
-    { method: 'POST', path: '/api/guest/reset-password', desc: 'Reset guest password', params: 'body: { username }' },
-    { method: 'GET', path: '/api/guest/dashboard', desc: 'Guest dashboard', params: null },
-    // Projects
-    { method: 'GET', path: '/api/projects', desc: 'List projects', params: null },
-    { method: 'GET', path: '/api/projects/:id', desc: 'Get project by ID', params: null },
-    { method: 'POST', path: '/api/projects', desc: 'Create project', params: 'body: { name, description? }' },
-    { method: 'PATCH', path: '/api/projects/:id', desc: 'Update project', params: 'body: { name?, description? }' },
-    { method: 'DELETE', path: '/api/projects/:id', desc: 'Delete project', params: null },
-    // Teams
-    { method: 'GET', path: '/api/teams', desc: 'List teams', params: null },
-    { method: 'GET', path: '/api/teams/:id', desc: 'Get team by ID', params: null },
-    { method: 'POST', path: '/api/teams', desc: 'Create team', params: 'body: { name, ... }' },
-    { method: 'PATCH', path: '/api/teams/:id', desc: 'Update team', params: 'body: { name?, ... }' },
-    { method: 'DELETE', path: '/api/teams/:id', desc: 'Delete team', params: null },
-    { method: 'POST', path: '/api/teams/:id/members', desc: 'Add member to team', params: 'body: { beast }' },
-    { method: 'DELETE', path: '/api/teams/:id/members/:beast', desc: 'Remove member from team', params: null },
-    { method: 'POST', path: '/api/teams/:id/projects', desc: 'Link project to team', params: 'body: { projectId }' },
-    { method: 'DELETE', path: '/api/teams/:id/projects/:projectId', desc: 'Unlink project from team', params: null },
-    { method: 'GET', path: '/api/teams/beast/:beast', desc: 'Get teams for a beast', params: null },
-    // Security
-    { method: 'GET', path: '/api/security/events', desc: 'Security event log', params: '?limit=50' },
-    { method: 'GET', path: '/api/security/events/stats', desc: 'Security event stats', params: null },
-    { method: 'GET', path: '/api/audit', desc: 'Audit log', params: '?limit=50' },
-    { method: 'GET', path: '/api/audit/stats', desc: 'Audit stats', params: null },
-    // Scheduler (additional)
-    { method: 'GET', path: '/api/schedules/:id', desc: 'Get schedule by ID', params: null },
-    { method: 'POST', path: '/api/schedules/:id/execute', desc: 'Execute schedule now', params: null },
-    { method: 'PATCH', path: '/api/schedules/:id/trigger', desc: 'Trigger schedule', params: null },
-    { method: 'GET', path: '/api/scheduler/health', desc: 'Scheduler health check', params: null },
-    // Tasks (additional)
-    { method: 'POST', path: '/api/tasks/bulk-status', desc: 'Bulk update task status', params: 'body: { ids, status }' },
-    // Specs (additional)
-    { method: 'GET', path: '/api/specs/by-task/:taskId', desc: 'Get specs linked to a task', params: null },
-    { method: 'GET', path: '/api/specs/by-thread/:threadId', desc: 'Get specs linked to a thread', params: null },
-    { method: 'GET', path: '/api/spec-comments/:commentId', desc: 'Get spec comment by ID', params: null },
-    // Risks (additional)
-    { method: 'GET', path: '/api/risks/:id/comments', desc: 'Get risk comments', params: null },
-    { method: 'POST', path: '/api/risks/:id/comments', desc: 'Add risk comment', params: 'body: { author, content }' },
-    // Messages (additional)
-    { method: 'DELETE', path: '/api/message/:id', desc: 'Delete message', params: 'body: { beast }' },
-    // Forum (additional)
-    { method: 'POST', path: '/api/forum/subscribe', desc: 'Subscribe to thread', params: 'body: { beast, threadId }' },
-    { method: 'GET', path: '/api/forum/subscriptions/:beast', desc: 'Get thread subscriptions', params: null },
-    { method: 'GET', path: '/api/thread/:id/subscribers', desc: 'Get thread subscribers', params: null },
-    // Files (additional)
-    { method: 'GET', path: '/api/files/archive/stats', desc: 'File archive stats', params: null },
-    { method: 'POST', path: '/api/files/archive/run', desc: 'Run file archival', params: null },
-    { method: 'POST', path: '/api/files/:id/restore', desc: 'Restore archived file', params: null },
-    // Routine (additional)
-    { method: 'GET', path: '/api/routine/workout-trends', desc: 'Workout trend data', params: null },
-    { method: 'GET', path: '/api/routine/photos', desc: 'List routine photos', params: null },
-    { method: 'POST', path: '/api/routine/photo/upload', desc: 'Upload routine photo', params: 'body: FormData with file' },
-    { method: 'GET', path: '/api/routine/photo/:filename', desc: 'Get routine photo', params: null },
-    { method: 'GET', path: '/api/routine/logs/deleted', desc: 'List deleted routine logs', params: null },
-    // Supersede (document versioning)
-    { method: 'GET', path: '/api/supersede', desc: 'List supersede records', params: null },
-    { method: 'POST', path: '/api/supersede', desc: 'Create supersede record', params: 'body: { path, content, author }' },
-    { method: 'GET', path: '/api/supersede/chain/:path', desc: 'Get supersede chain for path', params: null },
-    // Traces
-    { method: 'GET', path: '/api/traces', desc: 'List traces', params: null },
-    { method: 'GET', path: '/api/traces/:id', desc: 'Get trace by ID', params: null },
-    { method: 'GET', path: '/api/traces/:id/chain', desc: 'Get trace chain', params: null },
-    { method: 'GET', path: '/api/traces/:id/linked-chain', desc: 'Get linked trace chain', params: null },
-    { method: 'POST', path: '/api/traces/:prevId/link', desc: 'Link traces', params: null },
-    { method: 'DELETE', path: '/api/traces/:id/link', desc: 'Unlink trace', params: null },
-    // Settings
-    { method: 'GET', path: '/api/settings', desc: 'Get app settings', params: null },
-    { method: 'POST', path: '/api/settings', desc: 'Update app settings', params: 'body: { ... }' },
-    // Database
-    { method: 'GET', path: '/api/db/stats', desc: 'Database statistics', params: null },
-    { method: 'POST', path: '/api/db/maintenance', desc: 'Run database maintenance', params: null },
-    // Withings (additional)
-    { method: 'POST', path: '/api/oauth/withings/sync', desc: 'Sync Withings data', params: null },
-    { method: 'POST', path: '/api/webhooks/withings', desc: 'Withings webhook callback', params: null },
-    { method: 'POST', path: '/api/webhooks/hevy', desc: 'Hevy webhook callback (T#724) — workout creation push', params: 'body: { workoutId } | header: Authorization: <HEVY_WEBHOOK_TOKEN> (raw, no Bearer prefix)' },
-    // Telegram
-    { method: 'GET', path: '/api/telegram/status', desc: 'Telegram polling status (owner only)', params: null },
-    { method: 'GET', path: '/api/telegram/message/:id', desc: 'T#712 — cached inbound TG message by id (Gorn + Sable only)', params: null },
-    // Board / Pack
-    { method: 'GET', path: '/api/board', desc: 'Board overview (tasks summary)', params: null },
-    { method: 'GET', path: '/api/pack/spinner-verbs', desc: 'Pack spinner verb list', params: null },
-    // Knowledge / Docs
-    { method: 'GET', path: '/api/docs', desc: 'List knowledge documents', params: null },
-    { method: 'GET', path: '/api/doc/:id', desc: 'Get document by ID', params: null },
-    { method: 'GET', path: '/api/feed', desc: 'Activity feed', params: null },
-    { method: 'POST', path: '/api/learn', desc: 'Submit learn request', params: 'body: { ... }' },
-    { method: 'GET', path: '/api/oracles', desc: 'List oracles', params: null },
-    // Internal/legacy (included for 404 hint completeness)
-    { method: 'GET', path: '/api/stats', desc: 'Server stats', params: null },
-    { method: 'GET', path: '/api/logs', desc: 'Server logs', params: null },
-    { method: 'GET', path: '/api/beast/:name/avatar.svg', desc: 'Get beast avatar SVG', params: null },
+  // Auth
+  {
+    method: 'GET',
+    path: '/api/auth/status',
+    desc: 'Check if session is authenticated',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/auth/login',
+    desc: 'Login with password',
+    params: 'body: { password }',
+  },
+  { method: 'POST', path: '/api/auth/logout', desc: 'Logout current session', params: null },
+  // Health
+  { method: 'GET', path: '/api/health', desc: 'Server health check', params: null },
+  { method: 'GET', path: '/api/help', desc: 'This endpoint catalog', params: '?q=filter' },
+  // Threads (forum)
+  {
+    method: 'GET',
+    path: '/api/threads',
+    desc: 'List all forum threads',
+    params: '?status=&category=&limit=50&offset=0',
+  },
+  {
+    method: 'POST',
+    path: '/api/thread',
+    desc: 'Create thread or post message',
+    params: 'body: { message, author, thread_id?, title?, reply_to_id?, visibility? }',
+  },
+  {
+    method: 'GET',
+    path: '/api/thread/:id',
+    desc: 'Get thread messages',
+    params: '?limit=50&offset=0',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/thread/:id/category',
+    desc: 'Update thread category',
+    params: 'body: { category, beast }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/thread/:id/lock',
+    desc: 'Lock/unlock thread',
+    params: 'body: { locked, beast }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/thread/:id/archive',
+    desc: 'Archive/unarchive thread',
+    params: 'body: { archived, beast }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/thread/:id/pin',
+    desc: 'Pin/unpin thread',
+    params: 'body: { pinned, beast }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/thread/:id/title',
+    desc: 'Rename thread title',
+    params: 'body: { title, beast }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/thread/:id/status',
+    desc: 'Update thread status',
+    params: 'body: { status, beast }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/thread/:id/visibility',
+    desc: 'Update thread visibility',
+    params: 'body: { visibility, beast }',
+  },
+  { method: 'DELETE', path: '/api/thread/:id', desc: 'Delete thread', params: 'body: { beast }' },
+  // Forum utilities
+  {
+    method: 'POST',
+    path: '/api/forum/read',
+    desc: 'Mark thread as read',
+    params: 'body: { beast, threadId, messageId }',
+  },
+  {
+    method: 'GET',
+    path: '/api/forum/unread/:beast',
+    desc: 'Get unread thread counts',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/forum/mentions/:beast',
+    desc: 'Get @mentions for a beast',
+    params: '?limit=30',
+  },
+  {
+    method: 'GET',
+    path: '/api/forum/search',
+    desc: 'Search forum messages',
+    params: '?q=query&limit=20',
+  },
+  {
+    method: 'GET',
+    path: '/api/forum/activity',
+    desc: 'Recent forum activity feed',
+    params: '?limit=50',
+  },
+  {
+    method: 'POST',
+    path: '/api/forum/mute',
+    desc: 'Mute/unmute thread notifications',
+    params: 'body: { beast, threadId, muted }',
+  },
+  { method: 'GET', path: '/api/forum/muted/:beast', desc: 'Get muted threads', params: null },
+  {
+    method: 'GET',
+    path: '/api/forum/link-preview',
+    desc: 'Get link preview metadata',
+    params: '?url=',
+  },
+  // Messages
+  {
+    method: 'PATCH',
+    path: '/api/message/:id',
+    desc: 'Edit a message',
+    params: 'body: { content, beast }',
+  },
+  {
+    method: 'GET',
+    path: '/api/message/:id/history',
+    desc: 'Get message edit history',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/message/:id/react',
+    desc: 'Add reaction to message',
+    params: 'body: { beast, emoji }',
+  },
+  {
+    method: 'DELETE',
+    path: '/api/message/:id/react',
+    desc: 'Remove reaction',
+    params: 'body: { beast, emoji }',
+  },
+  {
+    method: 'GET',
+    path: '/api/message/:id/reactions',
+    desc: 'Get message reactions',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/message/:id/attachments',
+    desc: 'Get message file attachments',
+    params: null,
+  },
+  // Emojis
+  { method: 'GET', path: '/api/forum/emojis', desc: 'List custom emojis', params: null },
+  {
+    method: 'POST',
+    path: '/api/forum/emojis',
+    desc: 'Add custom emoji',
+    params: 'body: { emoji, name, category? }',
+  },
+  { method: 'DELETE', path: '/api/forum/emojis/:emoji', desc: 'Remove custom emoji', params: null },
+  {
+    method: 'GET',
+    path: '/api/reactions/supported',
+    desc: 'List all supported reactions',
+    params: null,
+  },
+  // DMs
+  { method: 'GET', path: '/api/dm/:name', desc: 'List DM conversations for a beast', params: null },
+  {
+    method: 'GET',
+    path: '/api/dm/:name/:other',
+    desc: 'Get DM conversation between two beasts',
+    params: '?limit=30&offset=0&order=desc',
+  },
+  { method: 'POST', path: '/api/dm', desc: 'Send a DM', params: 'body: { from, to, message }' },
+  {
+    method: 'PATCH',
+    path: '/api/dm/:name/:other/read',
+    desc: 'Mark DM conversation as read',
+    params: null,
+  },
+  {
+    method: 'PATCH',
+    path: '/api/dm/:name/:other/read-all',
+    desc: 'Mark all DMs as read',
+    params: null,
+  },
+  { method: 'DELETE', path: '/api/dm/messages/:id', desc: 'Delete a DM message', params: null },
+  { method: 'GET', path: '/api/dm/dashboard', desc: 'DM dashboard stats', params: null },
+  { method: 'GET', path: '/api/dm/unread-count', desc: 'Get unread DM count', params: null },
+  // Tasks (PM Board)
+  {
+    method: 'GET',
+    path: '/api/tasks',
+    desc: 'List tasks (Spec #56: parent_id filter)',
+    params: '?assignee=&reviewer=&status=&parent_id=&limit=100&offset=0&include_deleted=true',
+  },
+  {
+    method: 'GET',
+    path: '/api/tasks/:id',
+    desc: 'Get task by ID (includes subtasks summary if parent)',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/tasks/:id/subtree',
+    desc: 'Get parent task + all direct subtasks (Spec #56)',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/tasks',
+    desc: 'Create task (Spec #56: parent_task_id for subtasks)',
+    params:
+      'body: { title, assigned_to, reviewer, project_id, description?, status?, parent_task_id? }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/tasks/:id',
+    desc: 'Update task (Spec #56: parent_task_id for reparent)',
+    params: 'body: { title?, description?, assignee?, reviewer?, status?, parent_task_id? }',
+  },
+  {
+    method: 'DELETE',
+    path: '/api/tasks/:id',
+    desc: 'Delete task (orphans subtasks via SET NULL)',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/tasks/:id/comments',
+    desc: 'Add comment to task',
+    params: 'body: { author, content }',
+  },
+  { method: 'GET', path: '/api/tasks/:id/comments', desc: 'Get task comments', params: null },
+  // Pack / Beasts
+  { method: 'GET', path: '/api/pack', desc: 'Get all beast profiles with status', params: null },
+  { method: 'GET', path: '/api/beasts', desc: 'List all beast profiles', params: null },
+  { method: 'GET', path: '/api/beast/:name', desc: 'Get single beast profile', params: null },
+  {
+    method: 'PUT',
+    path: '/api/beast/:name',
+    desc: 'Create/replace beast profile',
+    params: 'body: { species, role, bio?, themeColor? }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/beast/:name',
+    desc: 'Update beast profile fields',
+    params: 'body: { bio?, role?, themeColor?, ... }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/beast/:name/avatar',
+    desc: 'Upload beast avatar',
+    params: 'body: FormData with avatar file',
+  },
+  {
+    method: 'GET',
+    path: '/api/beast/:name/terminal',
+    desc: 'Get beast tmux terminal output',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/beast/:name/terminal/input',
+    desc: 'Send text to beast terminal',
+    params: 'body: { input }',
+  },
+  {
+    method: 'POST',
+    path: '/api/beast/:name/terminal/key',
+    desc: 'Send key event to beast terminal',
+    params: 'body: { key }',
+  },
+  // Schedules
+  { method: 'GET', path: '/api/schedules', desc: 'List schedules', params: '?beast=&enabled=' },
+  { method: 'GET', path: '/api/schedules/due', desc: 'Get due schedules', params: '?beast=' },
+  {
+    method: 'POST',
+    path: '/api/schedules',
+    desc: 'Create schedule',
+    params: 'body: { beast, task, command, interval, ... }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/schedules/:id',
+    desc: 'Update schedule',
+    params: 'body: { task?, command?, interval?, enabled? }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/schedules/:id/run',
+    desc: 'Mark schedule as run',
+    params: '?as=beast',
+  },
+  { method: 'DELETE', path: '/api/schedules/:id', desc: 'Delete schedule', params: '?as=beast' },
+  // Upload
+  {
+    method: 'POST',
+    path: '/api/upload',
+    desc: 'Upload file attachment',
+    params: 'body: FormData with file',
+  },
+  { method: 'GET', path: '/api/forum/file/:filename', desc: 'Get uploaded file', params: null },
+  {
+    method: 'GET',
+    path: '/api/files',
+    desc: 'List all uploaded files',
+    params: '?limit=50&offset=0',
+  },
+  { method: 'GET', path: '/api/files/stats', desc: 'File storage statistics', params: null },
+  { method: 'GET', path: '/api/files/:id', desc: 'Get file metadata', params: null },
+  {
+    method: 'GET',
+    path: '/api/files/:id/download',
+    desc: 'Download file by ID (owner/beast)',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/f/:hash',
+    desc: 'Download file by hash (public, unguessable)',
+    params: null,
+  },
+  { method: 'DELETE', path: '/api/files/:id', desc: 'Delete file', params: null },
+  // Specs (SDD)
+  { method: 'GET', path: '/api/specs', desc: 'List all specs', params: '?status=&author=' },
+  { method: 'GET', path: '/api/specs/:id', desc: 'Get spec by ID', params: null },
+  {
+    method: 'GET',
+    path: '/api/specs/:id/content',
+    desc: 'Get spec markdown content (Spec #57: ?version=vN for historical)',
+    params: '?version=v1',
+  },
+  {
+    method: 'GET',
+    path: '/api/specs/:id/versions',
+    desc: 'List spec version snapshots (Spec #57)',
+    params: null,
+  },
+  { method: 'GET', path: '/api/specs/:id/history', desc: 'Get spec review history', params: null },
+  { method: 'GET', path: '/api/specs/:id/diff', desc: 'Get spec version diff', params: '?v1=&v2=' },
+  {
+    method: 'POST',
+    path: '/api/specs',
+    desc: 'Submit new spec',
+    params: 'body: { title, content, author, task_ids?, thread_ids? }',
+  },
+  {
+    method: 'POST',
+    path: '/api/specs/:id/review',
+    desc: 'Review a spec',
+    params: 'body: { reviewer, action, comment? }',
+  },
+  {
+    method: 'POST',
+    path: '/api/specs/:id/resubmit',
+    desc: 'Resubmit spec with changes',
+    params: 'body: { content, author, change_summary? }',
+  },
+  {
+    method: 'POST',
+    path: '/api/specs/:id/reopen',
+    desc: 'Reopen approved spec for amendment (Spec #57)',
+    params: 'body: { author, reason }',
+  },
+  { method: 'DELETE', path: '/api/specs/:id', desc: 'Delete spec', params: 'body: { beast }' },
+  { method: 'GET', path: '/api/specs/:id/links', desc: 'Get linked tasks/threads', params: null },
+  {
+    method: 'POST',
+    path: '/api/specs/:id/link',
+    desc: 'Link task or thread to spec',
+    params: 'body: { type, target_id }',
+  },
+  {
+    method: 'DELETE',
+    path: '/api/specs/:id/link',
+    desc: 'Unlink task or thread',
+    params: 'body: { type, target_id }',
+  },
+  { method: 'GET', path: '/api/specs/:id/comments', desc: 'Get spec comments', params: null },
+  {
+    method: 'POST',
+    path: '/api/specs/:id/comments',
+    desc: 'Add spec comment',
+    params: 'body: { author, content, type? }',
+  },
+  // Rules
+  { method: 'GET', path: '/api/rules', desc: 'List all active rules', params: null },
+  { method: 'GET', path: '/api/rules/decrees', desc: 'List decrees only', params: null },
+  { method: 'GET', path: '/api/rules/norms', desc: 'List norms only', params: null },
+  {
+    method: 'GET',
+    path: '/api/rules/markdown',
+    desc: 'All rules as markdown (for /recap)',
+    params: null,
+  },
+  { method: 'GET', path: '/api/rules/pending', desc: 'List rules pending approval', params: null },
+  { method: 'GET', path: '/api/rules/:id', desc: 'Get rule by ID', params: null },
+  {
+    method: 'POST',
+    path: '/api/rules',
+    desc: 'Propose new rule',
+    params: 'body: { title, content, type, proposed_by }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/rules/:id',
+    desc: 'Update rule',
+    params: 'body: { title?, content?, type? }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/rules/:id/archive',
+    desc: 'Archive rule',
+    params: 'body: { beast }',
+  },
+  {
+    method: 'POST',
+    path: '/api/rules/:id/approve',
+    desc: 'Approve pending rule',
+    params: 'body: { beast }',
+  },
+  {
+    method: 'POST',
+    path: '/api/rules/:id/reject',
+    desc: 'Reject pending rule',
+    params: 'body: { beast, reason? }',
+  },
+  // Risks
+  { method: 'GET', path: '/api/risks', desc: 'List all risks', params: '?status=&severity=' },
+  { method: 'GET', path: '/api/risks/summary', desc: 'Risk summary stats', params: null },
+  { method: 'GET', path: '/api/risks/stale', desc: 'Risks not updated recently', params: null },
+  { method: 'GET', path: '/api/risks/:id', desc: 'Get risk by ID', params: null },
+  {
+    method: 'POST',
+    path: '/api/risks',
+    desc: 'Create risk',
+    params: 'body: { title, description, severity, status, owner }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/risks/:id',
+    desc: 'Update risk',
+    params: 'body: { title?, severity?, status?, mitigation? }',
+  },
+  { method: 'DELETE', path: '/api/risks/:id', desc: 'Delete risk', params: null },
+  // Prowl (Gorn tasks)
+  {
+    method: 'GET',
+    path: '/api/prowl',
+    desc: 'List Gorn personal tasks',
+    params: '?status=&category=&priority=',
+  },
+  { method: 'GET', path: '/api/prowl/categories', desc: 'List Prowl categories', params: null },
+  {
+    method: 'POST',
+    path: '/api/prowl',
+    desc: 'Create Prowl task',
+    params:
+      'body: { title, due_date? (YYYY-MM-DD or YYYY-MM-DDTHH:MM), category?, priority?, source? }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/prowl/:id',
+    desc: 'Update Prowl task',
+    params:
+      'body: { title?, due_date? (YYYY-MM-DD or YYYY-MM-DDTHH:MM), category?, priority?, notes? }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/prowl/:id/status',
+    desc: 'Update Prowl task status',
+    params: 'body: { status }',
+  },
+  {
+    method: 'POST',
+    path: '/api/prowl/:id/toggle',
+    desc: 'Toggle Prowl task done/undone',
+    params: null,
+  },
+  { method: 'DELETE', path: '/api/prowl/:id', desc: 'Delete Prowl task', params: null },
+  {
+    method: 'GET',
+    path: '/api/prowl/:id/checklist',
+    desc: 'List checklist items for a Prowl task',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/prowl/:id/checklist',
+    desc: 'Add checklist item',
+    params: 'body: { text }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/prowl/:id/checklist/:itemId',
+    desc: 'Update checklist item',
+    params: 'body: { text?, checked?, sort_order? }',
+  },
+  {
+    method: 'POST',
+    path: '/api/prowl/:id/checklist/:itemId/toggle',
+    desc: 'Toggle checklist item checked',
+    params: null,
+  },
+  {
+    method: 'DELETE',
+    path: '/api/prowl/:id/checklist/:itemId',
+    desc: 'Delete checklist item',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/prowl/notify-test',
+    desc: 'Test Prowl notification pipeline (Gorn-only)',
+    params: null,
+  },
+  // Telegram
+  {
+    method: 'GET',
+    path: '/api/telegram/status',
+    desc: 'Telegram polling status (owner only)',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/telegram/message/:id',
+    desc: 'T#712 — cached inbound TG message by id (Gorn + Sable only)',
+    params: null,
+  },
+  // Routine (Forge)
+  {
+    method: 'GET',
+    path: '/api/routine/logs',
+    desc: 'List routine logs',
+    params: '?type=&date=&limit=20&offset=0',
+  },
+  { method: 'GET', path: '/api/routine/today', desc: 'Today routine summary', params: null },
+  { method: 'GET', path: '/api/routine/weight', desc: 'Weight history', params: '?limit=30' },
+  {
+    method: 'GET',
+    path: '/api/routine/blood-pressure',
+    desc: 'BP history (Prowl #80)',
+    params: '?range=week,month,year,3y,10y,all',
+  },
+  {
+    method: 'GET',
+    path: '/api/routine/exercise-summary',
+    desc: 'Single-exercise 4-dimension read: peak/recent/trend/frequency (Prowl #83)',
+    params: '?exercise=<name>',
+  },
+  {
+    method: 'GET',
+    path: '/api/routine/prs',
+    desc: 'All-exercises peak summary, alias for /personal-records?grouped=true (Prowl #83)',
+    params: '?range=month',
+  },
+  {
+    method: 'GET',
+    path: '/api/routine/body-composition',
+    desc: 'Body composition history from Withings',
+    params: '?range=month (1w,1m,3m,1y,3y,all)',
+  },
+  { method: 'GET', path: '/api/routine/stats', desc: 'Routine statistics', params: null },
+  {
+    method: 'GET',
+    path: '/api/routine/summary',
+    desc: 'Routine summary with trends',
+    params: null,
+  },
+  { method: 'GET', path: '/api/routine/exercises', desc: 'List exercises', params: null },
+  {
+    method: 'POST',
+    path: '/api/routine/exercises',
+    desc: 'Add exercise',
+    params: 'body: { name, equipment?, muscle_group? }',
+  },
+  { method: 'GET', path: '/api/routine/personal-records', desc: 'Personal records', params: null },
+  {
+    method: 'POST',
+    path: '/api/routine/logs',
+    desc: 'Create routine log (workout: exercises[].notes optional str, exercises[].sets[].rpe optional 1-10 per T#710)',
+    params:
+      'body: { type, logged_at, data: { exercises?: [{name, notes?, sets: [{weight, reps, rpe?, unit?}]}], items?: [...meal], ... } }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/routine/logs/:id',
+    desc: 'Update routine log',
+    params: 'body: { ... }',
+  },
+  {
+    method: 'DELETE',
+    path: '/api/routine/logs/:id',
+    desc: 'Soft-delete routine log',
+    params: null,
+  },
+  {
+    method: 'PATCH',
+    path: '/api/routine/logs/:id/restore',
+    desc: 'Restore deleted log',
+    params: null,
+  },
+  // OAuth
+  {
+    method: 'GET',
+    path: '/api/oauth/withings/authorize',
+    desc: 'Start Withings OAuth flow',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/oauth/withings/callback',
+    desc: 'OAuth callback (internal)',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/oauth/withings/status',
+    desc: 'Check Withings connection status',
+    params: null,
+  },
+  {
+    method: 'DELETE',
+    path: '/api/oauth/withings/disconnect',
+    desc: 'Disconnect Withings',
+    params: null,
+  },
+  { method: 'GET', path: '/api/withings/devices', desc: 'List Withings devices', params: null },
+  // Google OAuth + Gmail
+  {
+    method: 'GET',
+    path: '/api/oauth/google/authorize',
+    desc: 'Start Google OAuth flow',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/oauth/google/callback',
+    desc: 'Google OAuth callback (internal)',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/oauth/google/status',
+    desc: 'Check Google connection status',
+    params: null,
+  },
+  {
+    method: 'DELETE',
+    path: '/api/oauth/google/disconnect',
+    desc: 'Disconnect Google',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/google/gmail/profile',
+    desc: 'Get Gmail profile info',
+    params: null,
+  },
+  { method: 'GET', path: '/api/google/gmail/labels', desc: 'List Gmail labels', params: null },
+  {
+    method: 'GET',
+    path: '/api/google/gmail/messages',
+    desc: 'List Gmail messages',
+    params: '?label=INBOX&maxResults=20&q=search&pageToken=',
+  },
+  {
+    method: 'GET',
+    path: '/api/google/gmail/messages/:id',
+    desc: 'Get Gmail message by ID',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/google/gmail/threads/:id',
+    desc: 'Get Gmail thread by ID',
+    params: null,
+  },
+  // Google Access Control
+  {
+    method: 'GET',
+    path: '/api/google/access',
+    desc: 'List Google OAuth Beast allowlist',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/google/access',
+    desc: 'Add Beast to Google OAuth allowlist',
+    params: 'body: { beast }',
+  },
+  {
+    method: 'DELETE',
+    path: '/api/google/access/:beast',
+    desc: 'Remove Beast from Google OAuth allowlist',
+    params: null,
+  },
+  { method: 'GET', path: '/api/google/audit', desc: 'Google OAuth audit log', params: null },
+  // Search
+  {
+    method: 'GET',
+    path: '/api/search',
+    desc: 'Search documents and knowledge',
+    params: '?q=query&type=all&limit=10',
+  },
+  { method: 'GET', path: '/api/search/status', desc: 'Search index status', params: null },
+  { method: 'POST', path: '/api/search/reindex', desc: 'Trigger search reindex', params: null },
+  // Remote
+  {
+    method: 'GET',
+    path: '/api/remote/status',
+    desc: 'Remote panel connection status',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/remote/attach',
+    desc: 'Attach to beast for remote control',
+    params: 'body: { beast }',
+  },
+  { method: 'POST', path: '/api/remote/detach', desc: 'Detach from remote control', params: null },
+  // Queue (Gorn)
+  { method: 'GET', path: '/api/queue/gorn', desc: 'Get Gorn review queue', params: null },
+  {
+    method: 'POST',
+    path: '/api/queue/gorn',
+    desc: 'Add thread to Gorn queue',
+    params: 'body: { threadId, reason, addedBy }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/queue/gorn/:threadId',
+    desc: 'Update queue item status',
+    params: 'body: { status }',
+  },
+  // Dashboard
+  { method: 'GET', path: '/api/dashboard', desc: 'Dashboard summary', params: null },
+  { method: 'GET', path: '/api/dashboard/summary', desc: 'Dashboard summary (alt)', params: null },
+  { method: 'GET', path: '/api/dashboard/activity', desc: 'Activity stats', params: null },
+  { method: 'GET', path: '/api/dashboard/growth', desc: 'Growth metrics', params: null },
+  { method: 'GET', path: '/api/session/stats', desc: 'Session statistics', params: null },
+  // Library
+  { method: 'GET', path: '/api/library', desc: 'List library entries', params: '?shelf=&limit=50' },
+  { method: 'GET', path: '/api/library/:id', desc: 'Get library entry by ID', params: null },
+  {
+    method: 'POST',
+    path: '/api/library',
+    desc: 'Add library entry',
+    params: 'body: { title, content, shelf?, author }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/library/:id',
+    desc: 'Update library entry',
+    params: 'body: { title?, content?, shelf? }',
+  },
+  { method: 'DELETE', path: '/api/library/:id', desc: 'Delete library entry', params: null },
+  {
+    method: 'GET',
+    path: '/api/library/search',
+    desc: 'Search library entries',
+    params: '?q=query',
+  },
+  { method: 'GET', path: '/api/library/types', desc: 'List library entry types', params: null },
+  { method: 'GET', path: '/api/library/shelves', desc: 'List library shelves', params: null },
+  { method: 'GET', path: '/api/library/shelves/:id', desc: 'Get shelf by ID', params: null },
+  {
+    method: 'POST',
+    path: '/api/library/shelves',
+    desc: 'Create shelf',
+    params: 'body: { name, description? }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/library/shelves/:id',
+    desc: 'Update shelf',
+    params: 'body: { name?, description? }',
+  },
+  { method: 'DELETE', path: '/api/library/shelves/:id', desc: 'Delete shelf', params: null },
+  // Handoffs
+  {
+    method: 'POST',
+    path: '/api/handoff',
+    desc: 'Submit session handoff',
+    params: 'body: { oracle, summary, ... }',
+  },
+  { method: 'GET', path: '/api/inbox', desc: 'Get inbox items', params: '?type=&limit=20' },
+  // Auth Tokens
+  { method: 'GET', path: '/api/auth/tokens', desc: 'List API tokens', params: null },
+  { method: 'POST', path: '/api/auth/tokens', desc: 'Create API token', params: 'body: { name }' },
+  { method: 'DELETE', path: '/api/auth/tokens/:id', desc: 'Delete API token', params: null },
+  {
+    method: 'POST',
+    path: '/api/auth/tokens/rotate',
+    desc: 'Rotate API token (owner-driven)',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/auth/rotate',
+    desc: 'Beast-self chain-aware rotation (Spec #52)',
+    params: 'header: Authorization: Bearer <current_token>',
+  },
+  {
+    method: 'GET',
+    path: '/api/auth/me',
+    desc: 'Beast-self token info — expires_at, refresh_window, self_rotate_door, rotated_at (Spec #51 Phase 3)',
+    params: 'header: Authorization: Bearer <current_token>',
+  },
+  // Guests
+  { method: 'GET', path: '/api/guests', desc: 'List guests', params: null },
+  { method: 'GET', path: '/api/guests/:id', desc: 'Get guest by ID', params: null },
+  {
+    method: 'POST',
+    path: '/api/guests',
+    desc: 'Create guest account',
+    params: 'body: { username, display_name, password }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/guests/:id',
+    desc: 'Update guest',
+    params: 'body: { display_name?, ... }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/guests/:id/password',
+    desc: 'Change guest password',
+    params: 'body: { password }',
+  },
+  { method: 'DELETE', path: '/api/guests/:id', desc: 'Delete guest', params: null },
+  { method: 'POST', path: '/api/guests/:id/ban', desc: 'Ban guest', params: null },
+  { method: 'POST', path: '/api/guests/:id/unban', desc: 'Unban guest', params: null },
+  // Guest-facing endpoints
+  {
+    method: 'GET',
+    path: '/api/guest/threads',
+    desc: 'List public threads (guest view)',
+    params: null,
+  },
+  { method: 'GET', path: '/api/guest/thread/:id', desc: 'Get thread (guest view)', params: null },
+  {
+    method: 'POST',
+    path: '/api/guest/thread',
+    desc: 'Create thread (guest)',
+    params: 'body: { message, title }',
+  },
+  {
+    method: 'POST',
+    path: '/api/guest/thread/:id/message',
+    desc: 'Post message to thread (guest)',
+    params: 'body: { message }',
+  },
+  {
+    method: 'GET',
+    path: '/api/guest/dm/:from/:to',
+    desc: 'Get DM conversation (guest view)',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/guest/dm',
+    desc: 'Send DM (guest)',
+    params: 'body: { to, message }',
+  },
+  { method: 'GET', path: '/api/guest/pack', desc: 'Get pack profiles (guest view)', params: null },
+  { method: 'GET', path: '/api/guest/profile', desc: 'Get own guest profile', params: null },
+  {
+    method: 'PATCH',
+    path: '/api/guest/profile',
+    desc: 'Update own guest profile',
+    params: 'body: { display_name?, bio? }',
+  },
+  {
+    method: 'POST',
+    path: '/api/guest/avatar',
+    desc: 'Upload guest avatar',
+    params: 'body: FormData with file',
+  },
+  {
+    method: 'POST',
+    path: '/api/guest/change-password',
+    desc: 'Change guest password (self)',
+    params: 'body: { old_password, new_password }',
+  },
+  {
+    method: 'POST',
+    path: '/api/guest/reset-password',
+    desc: 'Reset guest password',
+    params: 'body: { username }',
+  },
+  { method: 'GET', path: '/api/guest/dashboard', desc: 'Guest dashboard', params: null },
+  // Projects
+  { method: 'GET', path: '/api/projects', desc: 'List projects', params: null },
+  { method: 'GET', path: '/api/projects/:id', desc: 'Get project by ID', params: null },
+  {
+    method: 'POST',
+    path: '/api/projects',
+    desc: 'Create project',
+    params: 'body: { name, description? }',
+  },
+  {
+    method: 'PATCH',
+    path: '/api/projects/:id',
+    desc: 'Update project',
+    params: 'body: { name?, description? }',
+  },
+  { method: 'DELETE', path: '/api/projects/:id', desc: 'Delete project', params: null },
+  // Teams
+  { method: 'GET', path: '/api/teams', desc: 'List teams', params: null },
+  { method: 'GET', path: '/api/teams/:id', desc: 'Get team by ID', params: null },
+  { method: 'POST', path: '/api/teams', desc: 'Create team', params: 'body: { name, ... }' },
+  { method: 'PATCH', path: '/api/teams/:id', desc: 'Update team', params: 'body: { name?, ... }' },
+  { method: 'DELETE', path: '/api/teams/:id', desc: 'Delete team', params: null },
+  {
+    method: 'POST',
+    path: '/api/teams/:id/members',
+    desc: 'Add member to team',
+    params: 'body: { beast }',
+  },
+  {
+    method: 'DELETE',
+    path: '/api/teams/:id/members/:beast',
+    desc: 'Remove member from team',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/teams/:id/projects',
+    desc: 'Link project to team',
+    params: 'body: { projectId }',
+  },
+  {
+    method: 'DELETE',
+    path: '/api/teams/:id/projects/:projectId',
+    desc: 'Unlink project from team',
+    params: null,
+  },
+  { method: 'GET', path: '/api/teams/beast/:beast', desc: 'Get teams for a beast', params: null },
+  // Security
+  { method: 'GET', path: '/api/security/events', desc: 'Security event log', params: '?limit=50' },
+  { method: 'GET', path: '/api/security/events/stats', desc: 'Security event stats', params: null },
+  { method: 'GET', path: '/api/audit', desc: 'Audit log', params: '?limit=50' },
+  { method: 'GET', path: '/api/audit/stats', desc: 'Audit stats', params: null },
+  // Scheduler (additional)
+  { method: 'GET', path: '/api/schedules/:id', desc: 'Get schedule by ID', params: null },
+  {
+    method: 'POST',
+    path: '/api/schedules/:id/execute',
+    desc: 'Execute schedule now',
+    params: null,
+  },
+  { method: 'PATCH', path: '/api/schedules/:id/trigger', desc: 'Trigger schedule', params: null },
+  { method: 'GET', path: '/api/scheduler/health', desc: 'Scheduler health check', params: null },
+  // Tasks (additional)
+  {
+    method: 'POST',
+    path: '/api/tasks/bulk-status',
+    desc: 'Bulk update task status',
+    params: 'body: { ids, status }',
+  },
+  // Specs (additional)
+  {
+    method: 'GET',
+    path: '/api/specs/by-task/:taskId',
+    desc: 'Get specs linked to a task',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/specs/by-thread/:threadId',
+    desc: 'Get specs linked to a thread',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/spec-comments/:commentId',
+    desc: 'Get spec comment by ID',
+    params: null,
+  },
+  // Risks (additional)
+  { method: 'GET', path: '/api/risks/:id/comments', desc: 'Get risk comments', params: null },
+  {
+    method: 'POST',
+    path: '/api/risks/:id/comments',
+    desc: 'Add risk comment',
+    params: 'body: { author, content }',
+  },
+  // Messages (additional)
+  { method: 'DELETE', path: '/api/message/:id', desc: 'Delete message', params: 'body: { beast }' },
+  // Forum (additional)
+  {
+    method: 'POST',
+    path: '/api/forum/subscribe',
+    desc: 'Subscribe to thread',
+    params: 'body: { beast, threadId }',
+  },
+  {
+    method: 'GET',
+    path: '/api/forum/subscriptions/:beast',
+    desc: 'Get thread subscriptions',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/thread/:id/subscribers',
+    desc: 'Get thread subscribers',
+    params: null,
+  },
+  // Files (additional)
+  { method: 'GET', path: '/api/files/archive/stats', desc: 'File archive stats', params: null },
+  { method: 'POST', path: '/api/files/archive/run', desc: 'Run file archival', params: null },
+  { method: 'POST', path: '/api/files/:id/restore', desc: 'Restore archived file', params: null },
+  // Routine (additional)
+  { method: 'GET', path: '/api/routine/workout-trends', desc: 'Workout trend data', params: null },
+  { method: 'GET', path: '/api/routine/photos', desc: 'List routine photos', params: null },
+  {
+    method: 'POST',
+    path: '/api/routine/photo/upload',
+    desc: 'Upload routine photo',
+    params: 'body: FormData with file',
+  },
+  { method: 'GET', path: '/api/routine/photo/:filename', desc: 'Get routine photo', params: null },
+  {
+    method: 'GET',
+    path: '/api/routine/logs/deleted',
+    desc: 'List deleted routine logs',
+    params: null,
+  },
+  // Supersede (document versioning)
+  { method: 'GET', path: '/api/supersede', desc: 'List supersede records', params: null },
+  {
+    method: 'POST',
+    path: '/api/supersede',
+    desc: 'Create supersede record',
+    params: 'body: { path, content, author }',
+  },
+  {
+    method: 'GET',
+    path: '/api/supersede/chain/:path',
+    desc: 'Get supersede chain for path',
+    params: null,
+  },
+  // Traces
+  { method: 'GET', path: '/api/traces', desc: 'List traces', params: null },
+  { method: 'GET', path: '/api/traces/:id', desc: 'Get trace by ID', params: null },
+  { method: 'GET', path: '/api/traces/:id/chain', desc: 'Get trace chain', params: null },
+  {
+    method: 'GET',
+    path: '/api/traces/:id/linked-chain',
+    desc: 'Get linked trace chain',
+    params: null,
+  },
+  { method: 'POST', path: '/api/traces/:prevId/link', desc: 'Link traces', params: null },
+  { method: 'DELETE', path: '/api/traces/:id/link', desc: 'Unlink trace', params: null },
+  // Settings
+  { method: 'GET', path: '/api/settings', desc: 'Get app settings', params: null },
+  { method: 'POST', path: '/api/settings', desc: 'Update app settings', params: 'body: { ... }' },
+  // Database
+  { method: 'GET', path: '/api/db/stats', desc: 'Database statistics', params: null },
+  { method: 'POST', path: '/api/db/maintenance', desc: 'Run database maintenance', params: null },
+  // Withings (additional)
+  { method: 'POST', path: '/api/oauth/withings/sync', desc: 'Sync Withings data', params: null },
+  {
+    method: 'POST',
+    path: '/api/webhooks/withings',
+    desc: 'Withings webhook callback',
+    params: null,
+  },
+  {
+    method: 'POST',
+    path: '/api/webhooks/hevy',
+    desc: 'Hevy webhook callback (T#724) — workout creation push',
+    params:
+      'body: { workoutId } | header: Authorization: <HEVY_WEBHOOK_TOKEN> (raw, no Bearer prefix)',
+  },
+  // Telegram
+  {
+    method: 'GET',
+    path: '/api/telegram/status',
+    desc: 'Telegram polling status (owner only)',
+    params: null,
+  },
+  {
+    method: 'GET',
+    path: '/api/telegram/message/:id',
+    desc: 'T#712 — cached inbound TG message by id (Gorn + Sable only)',
+    params: null,
+  },
+  // Board / Pack
+  { method: 'GET', path: '/api/board', desc: 'Board overview (tasks summary)', params: null },
+  { method: 'GET', path: '/api/pack/spinner-verbs', desc: 'Pack spinner verb list', params: null },
+  // Knowledge / Docs
+  { method: 'GET', path: '/api/docs', desc: 'List knowledge documents', params: null },
+  { method: 'GET', path: '/api/doc/:id', desc: 'Get document by ID', params: null },
+  { method: 'GET', path: '/api/feed', desc: 'Activity feed', params: null },
+  { method: 'POST', path: '/api/learn', desc: 'Submit learn request', params: 'body: { ... }' },
+  { method: 'GET', path: '/api/oracles', desc: 'List oracles', params: null },
+  // Internal/legacy (included for 404 hint completeness)
+  { method: 'GET', path: '/api/stats', desc: 'Server stats', params: null },
+  { method: 'GET', path: '/api/logs', desc: 'Server logs', params: null },
+  {
+    method: 'GET',
+    path: '/api/beast/:name/avatar.svg',
+    desc: 'Get beast avatar SVG',
+    params: null,
+  },
 ];
 
 const FEED_LOG = path.join(process.env.HOME || '/home/nat', '.oracle', 'feed.log');
@@ -352,12 +1142,20 @@ interface KnowledgeHelpers {
   repoRoot: string;
 }
 
-export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, helpers: KnowledgeHelpers) {
+export function registerKnowledgeRoutes(
+  app: OpenAPIHono,
+  sqlite: Database,
+  helpers: KnowledgeHelpers,
+) {
   const { repoRoot: REPO_ROOT } = helpers;
 
   // Playbook — serve den-playbook.md
   app.get('/api/playbook', (c) => {
-    const playbookPath = path.join(process.env.HOME || '/home/gorn', 'workspace', 'den-playbook.md');
+    const playbookPath = path.join(
+      process.env.HOME || '/home/gorn',
+      'workspace',
+      'den-playbook.md',
+    );
     if (fs.existsSync(playbookPath)) {
       return c.text(fs.readFileSync(playbookPath, 'utf-8'));
     }
@@ -371,19 +1169,52 @@ export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, help
       version: '0.5.0',
       endpoints: {
         beasts: {
-          'GET /api/beasts': { description: 'List all beast profiles', response: '{ beasts: BeastProfile[] }' },
-          'GET /api/beast/:name': { description: 'Get a beast profile by name', params: { name: 'lowercase beast name (e.g. karo, gnarl)' }, response: 'BeastProfile' },
-          'PUT /api/beast/:name': { description: 'Create or fully update a beast profile', response: 'BeastProfile' },
-          'PATCH /api/beast/:name': { description: 'Partial profile update', response: 'BeastProfile' },
+          'GET /api/beasts': {
+            description: 'List all beast profiles',
+            response: '{ beasts: BeastProfile[] }',
+          },
+          'GET /api/beast/:name': {
+            description: 'Get a beast profile by name',
+            params: { name: 'lowercase beast name (e.g. karo, gnarl)' },
+            response: 'BeastProfile',
+          },
+          'PUT /api/beast/:name': {
+            description: 'Create or fully update a beast profile',
+            response: 'BeastProfile',
+          },
+          'PATCH /api/beast/:name': {
+            description: 'Partial profile update',
+            response: 'BeastProfile',
+          },
           'PATCH /api/beast/:name/avatar': { description: 'Update avatar URL only' },
-          'GET /api/beast/:name/avatar.svg': { description: 'Generated SVG avatar based on animal theme', response: 'image/svg+xml' },
+          'GET /api/beast/:name/avatar.svg': {
+            description: 'Generated SVG avatar based on animal theme',
+            response: 'image/svg+xml',
+          },
           'POST /api/beasts/seed-avatars': { description: 'Seed default SVG avatars' },
         },
-        pack: { 'GET /api/pack': { description: 'List all beasts with online/offline status (from tmux)' } },
-        forum: { 'GET /api/threads': {}, 'POST /api/thread': {}, 'PATCH /api/thread/:id/status': {} },
-        dms: { 'POST /api/dm': {}, 'GET /api/dm/:name': {}, 'GET /api/dm/:name/:other': {}, 'GET /api/dm/dashboard': {} },
+        pack: {
+          'GET /api/pack': {
+            description: 'List all beasts with online/offline status (from tmux)',
+          },
+        },
+        forum: {
+          'GET /api/threads': {},
+          'POST /api/thread': {},
+          'PATCH /api/thread/:id/status': {},
+        },
+        dms: {
+          'POST /api/dm': {},
+          'GET /api/dm/:name': {},
+          'GET /api/dm/:name/:other': {},
+          'GET /api/dm/dashboard': {},
+        },
         types: {
-          BeastProfile: { name: 'string (primary key, lowercase)', display_name: 'string', animal: 'string' },
+          BeastProfile: {
+            name: 'string (primary key, lowercase)',
+            display_name: 'string',
+            animal: 'string',
+          },
         },
       },
       note: 'Full machine-readable catalog at /api/help (327 endpoints).',
@@ -399,19 +1230,19 @@ export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, help
     let result = HELP_ENDPOINTS;
     if (role === 'guest') {
       const allowlist = getGuestAllowlist();
-      result = HELP_ENDPOINTS.filter(e =>
-        allowlist.some(a =>
-          (a.method === '*' || a.method === e.method) &&
-          new RegExp(a.pattern).test(e.path)
-        )
+      result = HELP_ENDPOINTS.filter((e) =>
+        allowlist.some(
+          (a) => (a.method === '*' || a.method === e.method) && new RegExp(a.pattern).test(e.path),
+        ),
       );
     }
 
     if (filter) {
-      result = result.filter(e =>
-        e.path.toLowerCase().includes(filter) ||
-        e.desc.toLowerCase().includes(filter) ||
-        e.method.toLowerCase().includes(filter)
+      result = result.filter(
+        (e) =>
+          e.path.toLowerCase().includes(filter) ||
+          e.desc.toLowerCase().includes(filter) ||
+          e.method.toLowerCase().includes(filter),
       );
     }
 
@@ -455,8 +1286,11 @@ export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, help
         const posts = sqlite.prepare(forumQuery).all(...forumParams) as any[];
         for (const p of posts) {
           events.push({
-            type: 'forum', id: p.id, timestamp: p.created_at,
-            actor: p.author, title: p.thread_title,
+            type: 'forum',
+            id: p.id,
+            timestamp: p.created_at,
+            actor: p.author,
+            title: p.thread_title,
             message: p.content.slice(0, 200),
             url: `/forum?thread=${p.thread_id}`,
           });
@@ -471,8 +1305,11 @@ export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, help
         const tasks = sqlite.prepare(taskQuery).all(...taskParams) as any[];
         for (const t of tasks) {
           events.push({
-            type: 'task', id: t.id, timestamp: t.updated_at,
-            actor: t.assigned_to || t.created_by, title: `T#${t.id}: ${t.title}`,
+            type: 'task',
+            id: t.id,
+            timestamp: t.updated_at,
+            actor: t.assigned_to || t.created_by,
+            title: `T#${t.id}: ${t.title}`,
             message: `Status: ${t.status}${t.project_name ? ` | ${t.project_name}` : ''}`,
             url: `/board?task=${t.id}`,
           });
@@ -487,8 +1324,11 @@ export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, help
         const specs = sqlite.prepare(specQuery).all(...specParams) as any[];
         for (const s of specs) {
           events.push({
-            type: 'spec', id: s.id, timestamp: s.updated_at,
-            actor: s.author, title: `Spec #${s.id}: ${s.title}`,
+            type: 'spec',
+            id: s.id,
+            timestamp: s.updated_at,
+            actor: s.author,
+            title: `Spec #${s.id}: ${s.title}`,
             message: `Status: ${s.status}`,
             url: `/specs?spec=${s.id}`,
           });
@@ -509,15 +1349,16 @@ export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, help
   app.get('/api/logs', (c) => {
     try {
       const limit = parseInt(c.req.query('limit') || '20');
-      const logs = db.select({
-        query: searchLog.query,
-        type: searchLog.type,
-        mode: searchLog.mode,
-        results_count: searchLog.resultsCount,
-        search_time_ms: searchLog.searchTimeMs,
-        created_at: searchLog.createdAt,
-        project: searchLog.project
-      })
+      const logs = db
+        .select({
+          query: searchLog.query,
+          type: searchLog.type,
+          mode: searchLog.mode,
+          results_count: searchLog.resultsCount,
+          search_time_ms: searchLog.searchTimeMs,
+          created_at: searchLog.createdAt,
+          project: searchLog.project,
+        })
         .from(searchLog)
         .orderBy(desc(searchLog.createdAt))
         .limit(limit)
@@ -532,12 +1373,14 @@ export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, help
   app.get('/api/doc/:id', (c) => {
     const docId = c.req.param('id');
     try {
-      const row = sqlite.prepare(`
+      const row = sqlite
+        .prepare(`
         SELECT d.id, d.type, d.source_file, d.concepts, d.project, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
         WHERE d.id = ?
-      `).get(docId) as any;
+      `)
+        .get(docId) as any;
 
       if (!row) {
         return c.json({ error: 'Document not found' }, 404);
@@ -549,7 +1392,7 @@ export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, help
         content: row.content,
         source_file: row.source_file,
         concepts: JSON.parse(row.concepts || '[]'),
-        project: row.project
+        project: row.project,
       });
     } catch (e: any) {
       return c.json({ error: e.message }, 500);
@@ -638,7 +1481,10 @@ export function registerKnowledgeRoutes(app: OpenAPIHono, sqlite: Database, help
     if (!file && !id) {
       return c.json({ error: 'Provide file or id parameter' }, 400);
     }
-    const ctx = { db, sqlite, repoRoot: REPO_ROOT } as Pick<ToolContext, 'db' | 'sqlite' | 'repoRoot'>;
+    const ctx = { db, sqlite, repoRoot: REPO_ROOT } as Pick<
+      ToolContext,
+      'db' | 'sqlite' | 'repoRoot'
+    >;
     const result = await handleRead(ctx as ToolContext, {
       file: file || undefined,
       id: id || undefined,

--- a/src/library/routes.ts
+++ b/src/library/routes.ts
@@ -5,13 +5,27 @@ import type { Database } from 'bun:sqlite';
 interface LibraryHelpers {
   hasSessionAuth: (c: Context) => boolean;
   requireBeastIdentity: (c: Context) => string | null;
-  searchIndexUpsert: (sourceType: string, sourceId: number, title: string, content: string, author: string, createdAt: string, url?: string) => void;
+  searchIndexUpsert: (
+    sourceType: string,
+    sourceId: number,
+    title: string,
+    content: string,
+    author: string,
+    createdAt: string,
+    url?: string,
+  ) => void;
   searchIndexDelete: (sourceType: string, sourceId: number) => void;
   wsBroadcast: (event: string, data: any) => void;
 }
 
 export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helpers: LibraryHelpers) {
-  const { hasSessionAuth, requireBeastIdentity, searchIndexUpsert, searchIndexDelete, wsBroadcast } = helpers;
+  const {
+    hasSessionAuth,
+    requireBeastIdentity,
+    searchIndexUpsert,
+    searchIndexDelete,
+    wsBroadcast,
+  } = helpers;
 
   // --- Shelf CRUD ---
 
@@ -44,7 +58,9 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
     const shelf = sqlite.prepare('SELECT * FROM library_shelves WHERE id = ?').get(id) as any;
     if (!shelf) return c.json({ error: 'Shelf not found' }, 404);
     if (isGuest && shelf.visibility !== 'public') return c.json({ error: 'Shelf not found' }, 404);
-    const entryCount = (sqlite.prepare('SELECT COUNT(*) as c FROM library WHERE shelf_id = ?').get(id) as any).c;
+    const entryCount = (
+      sqlite.prepare('SELECT COUNT(*) as c FROM library WHERE shelf_id = ?').get(id) as any
+    ).c;
     return c.json({ ...shelf, entry_count: entryCount });
   });
 
@@ -56,25 +72,57 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
       // T#718 — derive author from auth, reject client-asserted mismatch
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       const claimed = (c.req.query('as') || data.created_by || '').toLowerCase();
       if (claimed && claimed !== caller) {
-        return c.json({ error: 'Identity spoof blocked. ?as=/body.created_by must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Identity spoof blocked. ?as=/body.created_by must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const author = caller;
 
       // Check duplicate
-      const existing = sqlite.prepare('SELECT id FROM library_shelves WHERE name = ?').get(data.name.trim());
+      const existing = sqlite
+        .prepare('SELECT id FROM library_shelves WHERE name = ?')
+        .get(data.name.trim());
       if (existing) return c.json({ error: 'A shelf with this name already exists' }, 409);
 
       const now = new Date().toISOString();
-      const visibility = (data.visibility === 'public') ? 'public' : 'internal';
-      const result = sqlite.prepare(
-        'INSERT INTO library_shelves (name, description, icon, color, created_by, created_at, updated_at, visibility) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
-      ).run(data.name.trim(), data.description || null, data.icon || null, data.color || null, author, now, now, visibility);
-      const shelf = sqlite.prepare('SELECT * FROM library_shelves WHERE id = ?').get((result as any).lastInsertRowid) as any;
-      searchIndexUpsert('shelf', shelf.id, shelf.name, shelf.description || '', author, now, '/library');
+      const visibility = data.visibility === 'public' ? 'public' : 'internal';
+      const result = sqlite
+        .prepare(
+          'INSERT INTO library_shelves (name, description, icon, color, created_by, created_at, updated_at, visibility) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        )
+        .run(
+          data.name.trim(),
+          data.description || null,
+          data.icon || null,
+          data.color || null,
+          author,
+          now,
+          now,
+          visibility,
+        );
+      const shelf = sqlite
+        .prepare('SELECT * FROM library_shelves WHERE id = ?')
+        .get((result as any).lastInsertRowid) as any;
+      searchIndexUpsert(
+        'shelf',
+        shelf.id,
+        shelf.name,
+        shelf.description || '',
+        author,
+        now,
+        '/library',
+      );
       return c.json(shelf, 201);
     } catch (e: any) {
       return c.json({ error: e?.message || 'Invalid request' }, 400);
@@ -95,11 +143,14 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
       for (const field of allowed) {
         if (field in data) {
           if (field === 'name' && data.name?.trim()) {
-            const dup = sqlite.prepare('SELECT id FROM library_shelves WHERE name = ? AND id != ?').get(data.name.trim(), id);
+            const dup = sqlite
+              .prepare('SELECT id FROM library_shelves WHERE name = ? AND id != ?')
+              .get(data.name.trim(), id);
             if (dup) return c.json({ error: 'A shelf with this name already exists' }, 409);
           }
           if (field === 'visibility') {
-            if (!hasSessionAuth(c)) return c.json({ error: 'Only Gorn can change shelf visibility' }, 403);
+            if (!hasSessionAuth(c))
+              return c.json({ error: 'Only Gorn can change shelf visibility' }, 403);
             const val = data[field] === 'public' ? 'public' : 'internal';
             updates.push(`${field} = ?`);
             values.push(val);
@@ -113,9 +164,20 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
       updates.push('updated_at = ?');
       values.push(new Date().toISOString());
       values.push(id);
-      sqlite.prepare(`UPDATE library_shelves SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+      sqlite
+        .prepare(`UPDATE library_shelves SET ${updates.join(', ')} WHERE id = ?`)
+        .run(...values);
       const shelf = sqlite.prepare('SELECT * FROM library_shelves WHERE id = ?').get(id) as any;
-      if (shelf) searchIndexUpsert('shelf', id, shelf.name, shelf.description || '', shelf.created_by, shelf.created_at, '/library');
+      if (shelf)
+        searchIndexUpsert(
+          'shelf',
+          id,
+          shelf.name,
+          shelf.description || '',
+          shelf.created_by,
+          shelf.created_at,
+          '/library',
+        );
       return c.json(shelf);
     } catch {
       return c.json({ error: 'Invalid request' }, 400);
@@ -151,7 +213,7 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
 
     // T#623: guests only see entries in public shelves
     if (isGuest) {
-      query += ' INNER JOIN library_shelves s ON s.id = l.shelf_id AND s.visibility = \'public\'';
+      query += " INNER JOIN library_shelves s ON s.id = l.shelf_id AND s.visibility = 'public'";
     }
 
     query += ' WHERE 1=1';
@@ -190,14 +252,23 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
     const rows = sqlite.prepare(query).all(...params) as any[];
 
     return c.json({
-      entries: rows.map(r => ({
+      entries: rows.map((r) => ({
         id: r.id,
         title: r.title,
         content: r.content,
         type: r.type,
         category: r.type,
         author: r.author,
-        tags: (() => { try { const t = JSON.parse(r.tags || '[]'); return Array.isArray(t) ? t : []; } catch { return typeof r.tags === 'string' && r.tags ? r.tags.split(',').map((s: string) => s.trim()) : []; } })(),
+        tags: (() => {
+          try {
+            const t = JSON.parse(r.tags || '[]');
+            return Array.isArray(t) ? t : [];
+          } catch {
+            return typeof r.tags === 'string' && r.tags
+              ? r.tags.split(',').map((s: string) => s.trim())
+              : [];
+          }
+        })(),
         shelf_id: r.shelf_id || null,
         created_at: new Date(r.created_at).toISOString(),
         updated_at: new Date(r.updated_at).toISOString(),
@@ -226,15 +297,30 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
 
     return c.json({
       suggestions: [
-        ...shelves.map(s => ({ id: s.id, label: s.name, icon: s.icon, color: s.color, type: 'shelf' as const })),
-        ...entries.map(e => ({ id: e.id, label: e.title, type: 'entry' as const, entryType: e.type, author: e.author, shelf_id: e.shelf_id })),
+        ...shelves.map((s) => ({
+          id: s.id,
+          label: s.name,
+          icon: s.icon,
+          color: s.color,
+          type: 'shelf' as const,
+        })),
+        ...entries.map((e) => ({
+          id: e.id,
+          label: e.title,
+          type: 'entry' as const,
+          entryType: e.type,
+          author: e.author,
+          shelf_id: e.shelf_id,
+        })),
       ],
     });
   });
 
   // GET /api/library/types — list available types and counts (must be before /:id)
   app.get('/api/library/types', (c) => {
-    const rows = sqlite.prepare('SELECT type, COUNT(*) as count FROM library GROUP BY type ORDER BY count DESC').all() as any[];
+    const rows = sqlite
+      .prepare('SELECT type, COUNT(*) as count FROM library GROUP BY type ORDER BY count DESC')
+      .all() as any[];
     return c.json({ types: rows });
   });
 
@@ -246,7 +332,9 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
     if (!row) return c.json({ error: 'Entry not found' }, 404);
     // T#623: guests can only see entries in public shelves
     if (isGuest && row.shelf_id) {
-      const shelf = sqlite.prepare('SELECT visibility FROM library_shelves WHERE id = ?').get(row.shelf_id) as any;
+      const shelf = sqlite
+        .prepare('SELECT visibility FROM library_shelves WHERE id = ?')
+        .get(row.shelf_id) as any;
       if (!shelf || shelf.visibility !== 'public') return c.json({ error: 'Entry not found' }, 404);
     } else if (isGuest && !row.shelf_id) {
       return c.json({ error: 'Entry not found' }, 404); // unshelved entries hidden from guests
@@ -275,10 +363,19 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
       // T#718 — derive author from auth, reject client-asserted mismatch
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       if (data.author && data.author.toLowerCase() !== caller) {
-        return c.json({ error: 'Author impersonation blocked. body.author must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Author impersonation blocked. body.author must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const author = caller;
 
@@ -288,13 +385,23 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
       const now = Date.now();
 
       const shelfId = data.shelf_id ? Number(data.shelf_id) : null;
-      if (!shelfId) return c.json({ error: 'shelf_id required — every entry must belong to a shelf' }, 400);
-      const result = sqlite.prepare(
-        'INSERT INTO library (title, content, type, author, tags, shelf_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
-      ).run(data.title, data.content, type, author, tags, shelfId, now, now);
+      if (!shelfId)
+        return c.json({ error: 'shelf_id required — every entry must belong to a shelf' }, 400);
+      const result = sqlite
+        .prepare(
+          'INSERT INTO library (title, content, type, author, tags, shelf_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        )
+        .run(data.title, data.content, type, author, tags, shelfId, now, now);
 
       const newId = (result as any).lastInsertRowid;
-      searchIndexUpsert('library', newId, data.title, data.content, author, new Date(now).toISOString());
+      searchIndexUpsert(
+        'library',
+        newId,
+        data.title,
+        data.content,
+        author,
+        new Date(now).toISOString(),
+      );
       return c.json({ id: newId, title: data.title, type, author }, 201);
     } catch (e) {
       return c.json({ error: 'Invalid JSON' }, 400);
@@ -310,19 +417,47 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
       const updates: string[] = ['updated_at = ?'];
       const params: any[] = [now];
 
-      if (data.title) { updates.push('title = ?'); params.push(data.title); }
-      if (data.content) { updates.push('content = ?'); params.push(data.content); }
-      if (data.type) { updates.push('type = ?'); params.push(data.type); }
-      if (data.tags) { updates.push('tags = ?'); params.push(JSON.stringify(data.tags)); }
-      if ('shelf_id' in data) { updates.push('shelf_id = ?'); params.push(data.shelf_id || null); }
+      if (data.title) {
+        updates.push('title = ?');
+        params.push(data.title);
+      }
+      if (data.content) {
+        updates.push('content = ?');
+        params.push(data.content);
+      }
+      if (data.type) {
+        updates.push('type = ?');
+        params.push(data.type);
+      }
+      if (data.tags) {
+        updates.push('tags = ?');
+        params.push(JSON.stringify(data.tags));
+      }
+      if ('shelf_id' in data) {
+        updates.push('shelf_id = ?');
+        params.push(data.shelf_id || null);
+      }
 
       params.push(id);
       sqlite.prepare(`UPDATE library SET ${updates.join(', ')} WHERE id = ?`).run(...params);
 
       const updated = sqlite.prepare('SELECT * FROM library WHERE id = ?').get(id) as any;
       if (updated) {
-        searchIndexUpsert('library', id, updated.title, updated.content, updated.author, new Date(updated.created_at).toISOString());
-        if (updated.tags) { try { updated.tags = JSON.parse(updated.tags); } catch { updated.tags = []; } }
+        searchIndexUpsert(
+          'library',
+          id,
+          updated.title,
+          updated.content,
+          updated.author,
+          new Date(updated.created_at).toISOString(),
+        );
+        if (updated.tags) {
+          try {
+            updated.tags = JSON.parse(updated.tags);
+          } catch {
+            updated.tags = [];
+          }
+        }
       }
       return c.json(updated);
     } catch (e) {
@@ -335,11 +470,17 @@ export function registerLibraryRoutes(app: OpenAPIHono, sqlite: Database, helper
     // T#718 — derive requester from auth, reject client-asserted mismatch
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const claimedAs = c.req.query('as')?.toLowerCase();
     if (claimedAs && claimedAs !== caller) {
-      return c.json({ error: 'Identity spoof blocked. ?as= must match authenticated caller or be omitted.' }, 403);
+      return c.json(
+        { error: 'Identity spoof blocked. ?as= must match authenticated caller or be omitted.' },
+        403,
+      );
     }
     const requester = caller;
     if (requester !== 'gorn' && requester !== 'pip') {

--- a/src/pack/routes.ts
+++ b/src/pack/routes.ts
@@ -5,7 +5,14 @@ import { eq } from 'drizzle-orm';
 import type { Context } from 'hono';
 import type { OpenAPIHono } from '@hono/zod-openapi';
 import type { Database } from 'bun:sqlite';
-import { db, beastProfiles, getBeastProfile, getAllBeastProfiles, upsertBeastProfile, updateBeastAvatar } from '../db/index.ts';
+import {
+  db,
+  beastProfiles,
+  getBeastProfile,
+  getAllBeastProfiles,
+  upsertBeastProfile,
+  updateBeastAvatar,
+} from '../db/index.ts';
 import { packListRoute, packSpinnerVerbsRoute } from '../server/openapi.ts';
 
 // ============================================================================
@@ -23,23 +30,38 @@ interface PackHelpers {
   WEB_PRESENCE_TIMEOUT_MS: number;
 }
 
-export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: PackHelpers): void {
-  const { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast, getTmuxStatus, normalizeAvatarUrl, webPresence, WEB_PRESENCE_TIMEOUT_MS } = helpers;
+export function registerPackRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: PackHelpers,
+): void {
+  const {
+    hasSessionAuth,
+    requireBeastIdentity,
+    isTrustedRequest,
+    wsBroadcast,
+    getTmuxStatus,
+    normalizeAvatarUrl,
+    webPresence,
+    WEB_PRESENCE_TIMEOUT_MS,
+  } = helpers;
   const sqlite: Database = sqliteDb;
 
   app.openapi(packListRoute, ((c: Context) => {
     const profiles = getAllBeastProfiles();
     const { tmuxStatus, contextPctMap } = getTmuxStatus();
 
-    const beasts = profiles.map(p => {
+    const beasts = profiles.map((p) => {
       const sessionName = p.name.charAt(0).toUpperCase() + p.name.slice(1);
-      const rawStatus = tmuxStatus.get(sessionName.toLowerCase()) || tmuxStatus.get(p.name) || 'offline';
+      const rawStatus =
+        tmuxStatus.get(sessionName.toLowerCase()) || tmuxStatus.get(p.name) || 'offline';
       return {
         ...p,
         avatarUrl: normalizeAvatarUrl(p.avatarUrl),
         online: rawStatus === 'processing' || rawStatus === 'idle' || rawStatus === 'waiting',
         status: rawStatus, // 'processing' | 'idle' | 'waiting' | 'shell' | 'offline'
-        contextPct: contextPctMap.get(sessionName.toLowerCase()) ?? contextPctMap.get(p.name) ?? null,
+        contextPct:
+          contextPctMap.get(sessionName.toLowerCase()) ?? contextPctMap.get(p.name) ?? null,
         sessionName,
       };
     });
@@ -47,7 +69,7 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
     // Owner (Gorn) presence from WS heartbeat map
     const now = Date.now();
     const ownerPresence = webPresence.get('gorn');
-    const ownerOnline = !!ownerPresence && (now - ownerPresence.lastSeen) < WEB_PRESENCE_TIMEOUT_MS;
+    const ownerOnline = !!ownerPresence && now - ownerPresence.lastSeen < WEB_PRESENCE_TIMEOUT_MS;
     const owner = {
       name: 'gorn',
       online: ownerOnline,
@@ -64,31 +86,41 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
     const allVerbs = new Set<string>();
 
     try {
-      const dirs = fs.readdirSync(workspaceDir, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name);
+      const dirs = fs
+        .readdirSync(workspaceDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
       for (const dir of dirs) {
         try {
           const configPath = path.join(workspaceDir, dir, '.claude', 'settings.local.json');
           const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
           const sv = config.spinnerVerbs;
           if (sv) {
-            const verbList = (Array.isArray(sv) ? sv : (sv.verbs || [])).filter((v: unknown) => typeof v === 'string');
+            const verbList = (Array.isArray(sv) ? sv : sv.verbs || []).filter(
+              (v: unknown) => typeof v === 'string',
+            );
             if (verbList.length > 0) {
               beastVerbs[dir] = verbList;
               for (const v of verbList) allVerbs.add(v);
             }
           }
-        } catch { /* skip */ }
+        } catch {
+          /* skip */
+        }
       }
-    } catch { /* workspace not readable */ }
+    } catch {
+      /* workspace not readable */
+    }
 
-    return c.json({
-      beasts: beastVerbs,
-      allVerbs: [...allVerbs].sort(),
-      totalUnique: allVerbs.size,
-      totalBeasts: Object.keys(beastVerbs).length,
-    }, 200);
+    return c.json(
+      {
+        beasts: beastVerbs,
+        allVerbs: [...allVerbs].sort(),
+        totalUnique: allVerbs.size,
+        totalBeasts: Object.keys(beastVerbs).length,
+      },
+      200,
+    );
   }) as any);
 
   app.get('/api/beast/:name/terminal', (c) => {
@@ -104,20 +136,25 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
       // Capture pane with ANSI escape codes
       const output = execSync(
         `tmux capture-pane -t ${JSON.stringify(sessionName)} -p -e -S -${rows}`,
-        { timeout: 3000, maxBuffer: 1024 * 1024 }
+        { timeout: 3000, maxBuffer: 1024 * 1024 },
       ).toString();
 
       // Get pane dimensions
-      let cols = 80, paneRows = 24;
+      let cols = 80,
+        paneRows = 24;
       try {
         const info = execSync(
           `tmux display-message -t ${JSON.stringify(sessionName)} -p "#{pane_width} #{pane_height}"`,
-          { timeout: 2000 }
-        ).toString().trim();
+          { timeout: 2000 },
+        )
+          .toString()
+          .trim();
         const [w, h] = info.split(' ').map(Number);
         if (w) cols = w;
         if (h) paneRows = h;
-      } catch { /* use defaults */ }
+      } catch {
+        /* use defaults */
+      }
 
       return c.json({
         name,
@@ -183,7 +220,20 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
       const { key } = body;
 
       // Whitelist of allowed special keys
-      const ALLOWED_KEYS = ['Enter', 'Escape', 'BSpace', 'Tab', 'Up', 'Down', 'Left', 'Right', 'C-c', 'C-d', 'C-z', 'C-l'];
+      const ALLOWED_KEYS = [
+        'Enter',
+        'Escape',
+        'BSpace',
+        'Tab',
+        'Up',
+        'Down',
+        'Left',
+        'Right',
+        'C-c',
+        'C-d',
+        'C-z',
+        'C-l',
+      ];
       if (!key || !ALLOWED_KEYS.includes(key)) {
         return c.json({ error: `Invalid key. Allowed: ${ALLOWED_KEYS.join(', ')}` }, 400);
       }
@@ -207,19 +257,40 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
     const profile = getBeastProfile(name);
 
     const BEAST_COLORS: Record<string, string> = {
-      hyena: '#d97706', horse: '#7c3aed', alligator: '#059669',
-      bear: '#92400e', kangaroo: '#dc2626', lion: '#ca8a04',
-      raccoon: '#6366f1', otter: '#0d9488', crow: '#475569',
-      octopus: '#9b59b6', ferret: '#8b6834',
-      wolf: '#64748b', porcupine: '#a3a3a3', mongoose: '#f59e0b',
-      owl: '#8b5cf6', hawk: '#ef4444',
+      hyena: '#d97706',
+      horse: '#7c3aed',
+      alligator: '#059669',
+      bear: '#92400e',
+      kangaroo: '#dc2626',
+      lion: '#ca8a04',
+      raccoon: '#6366f1',
+      otter: '#0d9488',
+      crow: '#475569',
+      octopus: '#9b59b6',
+      ferret: '#8b6834',
+      wolf: '#64748b',
+      porcupine: '#a3a3a3',
+      mongoose: '#f59e0b',
+      owl: '#8b5cf6',
+      hawk: '#ef4444',
     };
     const ANIMAL_EMOJI: Record<string, string> = {
-      hyena: '🐾', horse: '🐴', alligator: '🐊', bear: '🐻',
-      kangaroo: '🦘', lion: '🦁', raccoon: '🦝', otter: '🦦', crow: '🐦‍⬛',
-      octopus: '🐙', ferret: '🐾',
-      wolf: '🐺', porcupine: '🦔', mongoose: '🐿️',
-      owl: '🦉', hawk: '🦅',
+      hyena: '🐾',
+      horse: '🐴',
+      alligator: '🐊',
+      bear: '🐻',
+      kangaroo: '🦘',
+      lion: '🦁',
+      raccoon: '🦝',
+      otter: '🦦',
+      crow: '🐦‍⬛',
+      octopus: '🐙',
+      ferret: '🐾',
+      wolf: '🐺',
+      porcupine: '🦔',
+      mongoose: '🐿️',
+      owl: '🦉',
+      hawk: '🦅',
     };
 
     const animal = profile?.animal?.toLowerCase() || 'unknown';
@@ -249,7 +320,10 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
     // T#793 PACK-1 — Gorn-only (mass-mutate across all profiles).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn') {
       return c.json({ error: 'Gorn-only — mass profile mutation' }, 403);
@@ -284,7 +358,10 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
       // T#793 PACK-1 — owner-or-Gorn-only profile create/replace.
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       const name = c.req.param('name');
       if (caller !== name.toLowerCase() && caller !== 'gorn') {
@@ -319,7 +396,10 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
       // T#793 PACK-1 — owner-or-Gorn-only profile update.
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       const name = c.req.param('name');
       if (caller !== name.toLowerCase() && caller !== 'gorn') {
@@ -342,10 +422,7 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
       if (body.birthdate !== undefined) updates.birthdate = body.birthdate;
       if (body.sex !== undefined) updates.sex = body.sex;
 
-      db.update(beastProfiles)
-        .set(updates)
-        .where(eq(beastProfiles.name, name.toLowerCase()))
-        .run();
+      db.update(beastProfiles).set(updates).where(eq(beastProfiles.name, name.toLowerCase())).run();
 
       const updated = getBeastProfile(name);
       return c.json(updated);
@@ -359,7 +436,10 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
       // T#793 PACK-1 — owner-or-Gorn-only avatar update.
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       const name = c.req.param('name');
       if (caller !== name.toLowerCase() && caller !== 'gorn') {
@@ -367,7 +447,10 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
       }
       const profile = getBeastProfile(name);
       if (!profile) {
-        return c.json({ error: 'Beast not found. Create profile first with PUT /api/beast/:name' }, 404);
+        return c.json(
+          { error: 'Beast not found. Create profile first with PUT /api/beast/:name' },
+          404,
+        );
       }
 
       const body = await c.req.json();
@@ -393,10 +476,15 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
         return c.json({ error: 'forbidden' }, 403);
       }
       if (asParam && asParam !== name && asParam !== 'gorn') {
-        return c.json({ error: 'Cross-Beast wake denied. You can only wake yourself or be Gorn.' }, 403);
+        return c.json(
+          { error: 'Cross-Beast wake denied. You can only wake yourself or be Gorn.' },
+          403,
+        );
       }
 
-      const beastRow = sqlite.prepare('SELECT name, rest_status FROM beast_profiles WHERE name = ?').get(name) as any;
+      const beastRow = sqlite
+        .prepare('SELECT name, rest_status FROM beast_profiles WHERE name = ?')
+        .get(name) as any;
       if (!beastRow) {
         return c.json({ error: `Beast '${name}' not found` }, 404);
       }
@@ -406,21 +494,26 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
       // Schedule storm cap — drop schedules overdue by more than the cap
       const stormCapHours = parseInt(process.env.SCHEDULER_STORM_CAP_HOURS || '24');
       const cutoff = new Date(Date.now() - stormCapHours * 3600 * 1000).toISOString();
-      const dropResult = sqlite.prepare(
-        `UPDATE beast_schedules
+      const dropResult = sqlite
+        .prepare(
+          `UPDATE beast_schedules
          SET next_due_at = datetime('now', '+' || CAST(interval_seconds AS TEXT) || ' seconds'),
              trigger_status = 'pending',
              updated_at = datetime('now')
          WHERE beast = ?
            AND enabled = 1
-           AND datetime(next_due_at) < datetime(?)`
-      ).run(name, cutoff);
+           AND datetime(next_due_at) < datetime(?)`,
+        )
+        .run(name, cutoff);
 
       // Set rest_status back to active
-      sqlite.prepare("UPDATE beast_profiles SET rest_status = 'active', updated_at = ? WHERE name = ?")
+      sqlite
+        .prepare("UPDATE beast_profiles SET rest_status = 'active', updated_at = ? WHERE name = ?")
         .run(Date.now(), name);
 
-      console.log(`[Wake] ${name}: rest_status ${previousStatus} → active. Dropped ${dropResult.changes} schedules overdue by >${stormCapHours}h.`);
+      console.log(
+        `[Wake] ${name}: rest_status ${previousStatus} → active. Dropped ${dropResult.changes} schedules overdue by >${stormCapHours}h.`,
+      );
       wsBroadcast('beast_state_change', { beast: name, rest_status: 'active' });
 
       return c.json({
@@ -432,11 +525,12 @@ export function registerPackRoutes(app: OpenAPIHono, sqliteDb: Database, helpers
         resumed_at: new Date().toISOString(),
       });
     } catch (error) {
-      return c.json({
-        error: error instanceof Error ? error.message : 'Unknown error'
-      }, 500);
+      return c.json(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        500,
+      );
     }
   });
-
-
 }

--- a/src/process-manager/GracefulShutdown.ts
+++ b/src/process-manager/GracefulShutdown.ts
@@ -16,7 +16,7 @@ import {
   getChildProcesses,
   forceKillProcess,
   waitForProcessesExit,
-  removePidFile
+  removePidFile,
 } from './ProcessManager.ts';
 
 export interface ShutdownableService {
@@ -57,17 +57,17 @@ async function closeHttpServer(server: http.Server): Promise<void> {
 
   // Give Windows time to close connections before closing server
   if (process.platform === 'win32') {
-    await new Promise(r => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, 500));
   }
 
   // Close the server
   await new Promise<void>((resolve, reject) => {
-    server.close(err => err ? reject(err) : resolve());
+    server.close((err) => (err ? reject(err) : resolve()));
   });
 
   // Extra delay on Windows to ensure port is fully released
   if (process.platform === 'win32') {
-    await new Promise(r => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, 500));
     logger.info('SYSTEM', 'Waited for Windows port cleanup');
   }
 }
@@ -87,7 +87,7 @@ export async function performGracefulShutdown(config: GracefulShutdownConfig): P
     cleanup,
     removePid = true,
     killChildren = true,
-    childExitTimeout = 5000
+    childExitTimeout = 5000,
   } = config;
 
   logger.info('SYSTEM', 'Shutdown initiated');

--- a/src/process-manager/HealthMonitor.ts
+++ b/src/process-manager/HealthMonitor.ts
@@ -27,7 +27,7 @@ const defaultOptions: Required<HealthCheckOptions> = {
   baseUrl: 'http://127.0.0.1',
   healthPath: '/health',
   readinessPath: '/readiness',
-  shutdownPath: '/shutdown'
+  shutdownPath: '/shutdown',
 };
 
 /**
@@ -35,7 +35,7 @@ const defaultOptions: Required<HealthCheckOptions> = {
  */
 export async function isPortInUse(
   port: number,
-  options: HealthCheckOptions = {}
+  options: HealthCheckOptions = {},
 ): Promise<boolean> {
   const opts = { ...defaultOptions, ...options };
   try {
@@ -55,7 +55,7 @@ export async function isPortInUse(
 export async function waitForHealth(
   port: number,
   timeoutMs: number = 30000,
-  options: HealthCheckOptions = {}
+  options: HealthCheckOptions = {},
 ): Promise<boolean> {
   const opts = { ...defaultOptions, ...options };
   const start = Date.now();
@@ -67,7 +67,7 @@ export async function waitForHealth(
     } catch {
       logger.debug('SYSTEM', 'Service not ready yet, will retry', { port });
     }
-    await new Promise(r => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, 500));
   }
   return false;
 }
@@ -79,13 +79,13 @@ export async function waitForHealth(
 export async function waitForPortFree(
   port: number,
   timeoutMs: number = 10000,
-  options: HealthCheckOptions = {}
+  options: HealthCheckOptions = {},
 ): Promise<boolean> {
   const start = Date.now();
 
   while (Date.now() - start < timeoutMs) {
     if (!(await isPortInUse(port, options))) return true;
-    await new Promise(r => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, 500));
   }
   return false;
 }
@@ -97,13 +97,13 @@ export async function waitForPortFree(
  */
 export async function httpShutdown(
   port: number,
-  options: HealthCheckOptions = {}
+  options: HealthCheckOptions = {},
 ): Promise<boolean> {
   const opts = { ...defaultOptions, ...options };
 
   try {
     const response = await fetch(`${opts.baseUrl}:${port}${opts.shutdownPath}`, {
-      method: 'POST'
+      method: 'POST',
     });
     if (!response.ok) {
       logger.warn('SYSTEM', 'Shutdown request returned error', { port, status: response.status });
@@ -125,7 +125,7 @@ export async function httpShutdown(
  */
 export async function getWorkerStatus(
   port: number,
-  options: HealthCheckOptions = {}
+  options: HealthCheckOptions = {},
 ): Promise<{ running: boolean; healthy: boolean }> {
   const opts = { ...defaultOptions, ...options };
 
@@ -148,14 +148,14 @@ export async function getWorkerStatus(
 export async function getWorkerVersion(
   port: number,
   versionPath: string = '/version',
-  options: HealthCheckOptions = {}
+  options: HealthCheckOptions = {},
 ): Promise<string | null> {
   const opts = { ...defaultOptions, ...options };
 
   try {
     const response = await fetch(`${opts.baseUrl}:${port}${versionPath}`);
     if (!response.ok) return null;
-    const data = await response.json() as { version: string };
+    const data = (await response.json()) as { version: string };
     return data.version;
   } catch {
     return null;

--- a/src/process-manager/ProcessManager.ts
+++ b/src/process-manager/ProcessManager.ts
@@ -132,11 +132,11 @@ export async function getChildProcesses(parentPid: number): Promise<number[]> {
     return stdout
       .trim()
       .split('\n')
-      .map(line => {
+      .map((line) => {
         const match = line.match(/ProcessId=(\d+)/i);
         return match ? parseInt(match[1], 10) : NaN;
       })
-      .filter(n => !isNaN(n) && Number.isInteger(n) && n > 0);
+      .filter((n) => !isNaN(n) && Number.isInteger(n) && n > 0);
   } catch (error) {
     logger.warn('SYSTEM', 'Failed to enumerate child processes', { parentPid }, error as Error);
     return [];
@@ -175,7 +175,7 @@ export async function waitForProcessesExit(pids: number[], timeoutMs: number): P
   const start = Date.now();
 
   while (Date.now() - start < timeoutMs) {
-    const stillAlive = pids.filter(pid => isProcessAlive(pid));
+    const stillAlive = pids.filter((pid) => isProcessAlive(pid));
 
     if (stillAlive.length === 0) {
       logger.info('SYSTEM', 'All processes exited');
@@ -183,7 +183,7 @@ export async function waitForProcessesExit(pids: number[], timeoutMs: number): P
     }
 
     logger.debug('SYSTEM', 'Waiting for processes to exit', { stillAlive });
-    await new Promise(r => setTimeout(r, 100));
+    await new Promise((r) => setTimeout(r, 100));
   }
 
   logger.warn('SYSTEM', 'Timeout waiting for processes to exit');
@@ -294,7 +294,7 @@ export function spawnDaemon(options: SpawnDaemonOptions): number | undefined {
     portEnvVar = 'WORKER_PORT',
     env = {},
     args = ['--daemon'],
-    spawnOptions = {}
+    spawnOptions = {},
   } = options;
 
   const envVars: Record<string, string | undefined> = { ...process.env, ...env };
@@ -307,7 +307,7 @@ export function spawnDaemon(options: SpawnDaemonOptions): number | undefined {
     stdio: 'ignore',
     windowsHide: true,
     env: envVars,
-    ...spawnOptions
+    ...spawnOptions,
   });
 
   if (child.pid === undefined) {
@@ -324,7 +324,7 @@ export function spawnDaemon(options: SpawnDaemonOptions): number | undefined {
  */
 export function createSignalHandler(
   shutdownFn: () => Promise<void>,
-  isShuttingDownRef: { value: boolean }
+  isShuttingDownRef: { value: boolean },
 ): (signal: string) => Promise<void> {
   return async (signal: string) => {
     if (isShuttingDownRef.value) {
@@ -347,9 +347,9 @@ export function createSignalHandler(
 /**
  * Register common signal handlers
  */
-export function registerSignalHandlers(
-  shutdownFn: () => Promise<void>
-): { isShuttingDown: { value: boolean } } {
+export function registerSignalHandlers(shutdownFn: () => Promise<void>): {
+  isShuttingDown: { value: boolean };
+} {
   const isShuttingDown = { value: false };
   const handler = createSignalHandler(shutdownFn, isShuttingDown);
 

--- a/src/process-manager/index.ts
+++ b/src/process-manager/index.ts
@@ -27,7 +27,7 @@ export {
   createSignalHandler,
   registerSignalHandlers,
   type PidInfo,
-  type SpawnDaemonOptions
+  type SpawnDaemonOptions,
 } from './ProcessManager.ts';
 
 // Health Monitoring
@@ -38,7 +38,7 @@ export {
   httpShutdown,
   getWorkerStatus,
   getWorkerVersion,
-  type HealthCheckOptions
+  type HealthCheckOptions,
 } from './HealthMonitor.ts';
 
 // Graceful Shutdown
@@ -47,5 +47,5 @@ export {
   createShutdownHandler,
   type GracefulShutdownConfig,
   type ShutdownableService,
-  type CloseableResource
+  type CloseableResource,
 } from './GracefulShutdown.ts';

--- a/src/process-manager/logger.ts
+++ b/src/process-manager/logger.ts
@@ -40,7 +40,7 @@ export const logger: Logger = {
   },
   success(category, message, data) {
     console.log(`[OK] [${category}] ${message}${formatData(data)}`);
-  }
+  },
 };
 
 // Allow users to replace the logger

--- a/src/prowl/routes.ts
+++ b/src/prowl/routes.ts
@@ -14,7 +14,13 @@ interface ProwlHelpers {
 }
 
 export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers: ProwlHelpers) {
-  const { hasSessionAuth, isTrustedRequest, requireBeastIdentity, wsBroadcast, enqueueNotification } = helpers;
+  const {
+    hasSessionAuth,
+    isTrustedRequest,
+    requireBeastIdentity,
+    wsBroadcast,
+    enqueueNotification,
+  } = helpers;
 
   // GET /api/prowl — list tasks with filters
   app.get('/api/prowl', (c) => {
@@ -22,10 +28,16 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // then restrict to gorn + ALLOWED_PROWL_MANAGERS (mirrors the write-side allowlist).
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && !ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can view Prowl tasks` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can view Prowl tasks` },
+        403,
+      );
     }
     const status = c.req.query('status') || 'pending';
     const priority = c.req.query('priority');
@@ -52,28 +64,68 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     } else if (due === 'today') {
       query += " AND date(due_date) = date('now', 'localtime')";
     } else if (due === 'week') {
-      query += " AND date(due_date) BETWEEN date('now', 'localtime') AND date('now', 'localtime', '+7 days')";
+      query +=
+        " AND date(due_date) BETWEEN date('now', 'localtime') AND date('now', 'localtime', '+7 days')";
     }
 
-    query += ' ORDER BY CASE priority WHEN \'high\' THEN 0 WHEN \'medium\' THEN 1 WHEN \'low\' THEN 2 END, created_at DESC';
+    query +=
+      " ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 WHEN 'low' THEN 2 END, created_at DESC";
 
     const rawTasks = sqlite.prepare(query).all(...params) as any[];
 
-    const tasks = rawTasks.map(t => {
-      const checklist = sqlite.prepare('SELECT * FROM checklist_items WHERE task_id = ? ORDER BY sort_order, id').all(t.id);
+    const tasks = rawTasks.map((t) => {
+      const checklist = sqlite
+        .prepare('SELECT * FROM checklist_items WHERE task_id = ? ORDER BY sort_order, id')
+        .all(t.id);
       return { ...t, checklist };
     });
 
     const counts = {
-      pending: (sqlite.prepare("SELECT COUNT(*) as c FROM prowl_tasks WHERE status = 'pending'").get() as any).c,
-      done: (sqlite.prepare("SELECT COUNT(*) as c FROM prowl_tasks WHERE status = 'done'").get() as any).c,
-      overdue: (sqlite.prepare("SELECT COUNT(*) as c FROM prowl_tasks WHERE due_date < datetime('now', 'localtime') AND status = 'pending'").get() as any).c,
-      high: (sqlite.prepare("SELECT COUNT(*) as c FROM prowl_tasks WHERE priority = 'high' AND status = 'pending'").get() as any).c,
-      medium: (sqlite.prepare("SELECT COUNT(*) as c FROM prowl_tasks WHERE priority = 'medium' AND status = 'pending'").get() as any).c,
-      low: (sqlite.prepare("SELECT COUNT(*) as c FROM prowl_tasks WHERE priority = 'low' AND status = 'pending'").get() as any).c,
+      pending: (
+        sqlite
+          .prepare("SELECT COUNT(*) as c FROM prowl_tasks WHERE status = 'pending'")
+          .get() as any
+      ).c,
+      done: (
+        sqlite.prepare("SELECT COUNT(*) as c FROM prowl_tasks WHERE status = 'done'").get() as any
+      ).c,
+      overdue: (
+        sqlite
+          .prepare(
+            "SELECT COUNT(*) as c FROM prowl_tasks WHERE due_date < datetime('now', 'localtime') AND status = 'pending'",
+          )
+          .get() as any
+      ).c,
+      high: (
+        sqlite
+          .prepare(
+            "SELECT COUNT(*) as c FROM prowl_tasks WHERE priority = 'high' AND status = 'pending'",
+          )
+          .get() as any
+      ).c,
+      medium: (
+        sqlite
+          .prepare(
+            "SELECT COUNT(*) as c FROM prowl_tasks WHERE priority = 'medium' AND status = 'pending'",
+          )
+          .get() as any
+      ).c,
+      low: (
+        sqlite
+          .prepare(
+            "SELECT COUNT(*) as c FROM prowl_tasks WHERE priority = 'low' AND status = 'pending'",
+          )
+          .get() as any
+      ).c,
     };
 
-    const categories = (sqlite.prepare("SELECT DISTINCT category FROM prowl_tasks WHERE category IS NOT NULL ORDER BY category").all() as any[]).map(r => r.category);
+    const categories = (
+      sqlite
+        .prepare(
+          'SELECT DISTINCT category FROM prowl_tasks WHERE category IS NOT NULL ORDER BY category',
+        )
+        .all() as any[]
+    ).map((r) => r.category);
 
     return c.json({ tasks, counts, categories });
   });
@@ -84,12 +136,22 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // then restrict to gorn + ALLOWED_PROWL_MANAGERS.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && !ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can view Prowl tasks` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can view Prowl tasks` },
+        403,
+      );
     }
-    const rows = sqlite.prepare("SELECT category, COUNT(*) as count FROM prowl_tasks WHERE category IS NOT NULL GROUP BY category ORDER BY count DESC").all();
+    const rows = sqlite
+      .prepare(
+        'SELECT category, COUNT(*) as count FROM prowl_tasks WHERE category IS NOT NULL GROUP BY category ORDER BY count DESC',
+      )
+      .all();
     return c.json({ categories: rows });
   });
 
@@ -98,18 +160,30 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#788 — derive requester from auth-layer (T#718 pattern), reject body-asserted mismatch.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     try {
       const data = await c.req.json();
       if (!data.title?.trim()) return c.json({ error: 'title required' }, 400);
 
       if (data.created_by && data.created_by.toLowerCase() !== caller) {
-        return c.json({ error: 'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const requester = caller;
       if (!ALLOWED_PROWL_CREATORS.includes(requester)) {
-        return c.json({ error: `Only ${ALLOWED_PROWL_CREATORS.join(', ')} can create Prowl tasks` }, 403);
+        return c.json(
+          { error: `Only ${ALLOWED_PROWL_CREATORS.join(', ')} can create Prowl tasks` },
+          403,
+        );
       }
 
       const priority = ['high', 'medium', 'low'].includes(data.priority) ? data.priority : 'medium';
@@ -118,24 +192,28 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       const validReminders = [null, '1m', '5m', '15m', '30m', '1h', '1d'];
       const remindBefore = validReminders.includes(data.remind_before) ? data.remind_before : null;
 
-      const result = sqlite.prepare(
-        'INSERT INTO prowl_tasks (title, priority, category, due_date, status, notes, source, source_id, created_by, remind_before, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-      ).run(
-        data.title.trim(),
-        priority,
-        data.category || 'general',
-        data.due_date || null,
-        'pending',
-        data.notes || null,
-        data.source || 'manual',
-        data.source_id ?? null,
-        requester,
-        remindBefore,
-        now,
-        now
-      );
+      const result = sqlite
+        .prepare(
+          'INSERT INTO prowl_tasks (title, priority, category, due_date, status, notes, source, source_id, created_by, remind_before, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        )
+        .run(
+          data.title.trim(),
+          priority,
+          data.category || 'general',
+          data.due_date || null,
+          'pending',
+          data.notes || null,
+          data.source || 'manual',
+          data.source_id ?? null,
+          requester,
+          remindBefore,
+          now,
+          now,
+        );
 
-      const task = sqlite.prepare('SELECT * FROM prowl_tasks WHERE id = ?').get((result as any).lastInsertRowid);
+      const task = sqlite
+        .prepare('SELECT * FROM prowl_tasks WHERE id = ?')
+        .get((result as any).lastInsertRowid);
       wsBroadcast('prowl_update', { action: 'create' });
       return c.json(task, 201);
     } catch (e: any) {
@@ -148,10 +226,16 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#788 — derive caller from auth-layer.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can update Prowl tasks` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can update Prowl tasks` },
+        403,
+      );
     }
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
@@ -160,7 +244,8 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
     try {
       const data = await c.req.json();
-      if ('status' in data) return c.json({ error: 'Use PATCH /api/prowl/:id/status to change status' }, 400);
+      if ('status' in data)
+        return c.json({ error: 'Use PATCH /api/prowl/:id/status to change status' }, 400);
 
       const allowed = ['title', 'priority', 'category', 'due_date', 'notes', 'remind_before'];
       const updates: string[] = [];
@@ -173,7 +258,7 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       }
       if (updates.length === 0) return c.json({ error: 'No valid fields to update' }, 400);
 
-      updates.push("updated_at = ?");
+      updates.push('updated_at = ?');
       values.push(new Date().toISOString());
       values.push(id);
 
@@ -191,10 +276,16 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#788 — derive caller from auth-layer.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can change Prowl task status` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can change Prowl task status` },
+        403,
+      );
     }
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
@@ -204,12 +295,14 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     try {
       const data = await c.req.json();
       const newStatus = data.status;
-      if (!['pending', 'done'].includes(newStatus)) return c.json({ error: 'status must be pending or done' }, 400);
+      if (!['pending', 'done'].includes(newStatus))
+        return c.json({ error: 'status must be pending or done' }, 400);
 
       const now = new Date().toISOString();
       const completedAt = newStatus === 'done' ? now : null;
 
-      sqlite.prepare('UPDATE prowl_tasks SET status = ?, completed_at = ?, updated_at = ? WHERE id = ?')
+      sqlite
+        .prepare('UPDATE prowl_tasks SET status = ?, completed_at = ?, updated_at = ? WHERE id = ?')
         .run(newStatus, completedAt, now, id);
       const task = sqlite.prepare('SELECT * FROM prowl_tasks WHERE id = ?').get(id);
       wsBroadcast('prowl_update', { action: 'status' });
@@ -224,10 +317,16 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#788 — derive caller from auth-layer.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can toggle Prowl tasks` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can toggle Prowl tasks` },
+        403,
+      );
     }
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
@@ -238,7 +337,8 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const newStatus = existing.status === 'pending' ? 'done' : 'pending';
     const completedAt = newStatus === 'done' ? now : null;
 
-    sqlite.prepare('UPDATE prowl_tasks SET status = ?, completed_at = ?, updated_at = ? WHERE id = ?')
+    sqlite
+      .prepare('UPDATE prowl_tasks SET status = ?, completed_at = ?, updated_at = ? WHERE id = ?')
       .run(newStatus, completedAt, now, id);
     const task = sqlite.prepare('SELECT * FROM prowl_tasks WHERE id = ?').get(id);
     wsBroadcast('prowl_update', { action: 'toggle' });
@@ -250,10 +350,16 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#788 — derive caller from auth-layer.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can delete Prowl tasks` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can delete Prowl tasks` },
+        403,
+      );
     }
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
@@ -274,16 +380,24 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // then restrict to gorn + ALLOWED_PROWL_MANAGERS.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (caller !== 'gorn' && !ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can view Prowl tasks` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can view Prowl tasks` },
+        403,
+      );
     }
     const taskId = parseInt(c.req.param('id'), 10);
     if (isNaN(taskId)) return c.json({ error: 'Invalid ID' }, 400);
     const task = sqlite.prepare('SELECT id FROM prowl_tasks WHERE id = ?').get(taskId);
     if (!task) return c.json({ error: 'Task not found' }, 404);
-    const items = sqlite.prepare('SELECT * FROM checklist_items WHERE task_id = ? ORDER BY sort_order, id').all(taskId);
+    const items = sqlite
+      .prepare('SELECT * FROM checklist_items WHERE task_id = ? ORDER BY sort_order, id')
+      .all(taskId);
     return c.json({ items });
   });
 
@@ -292,10 +406,16 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#788 — derive caller from auth-layer.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` },
+        403,
+      );
     }
     const taskId = parseInt(c.req.param('id'), 10);
     if (isNaN(taskId)) return c.json({ error: 'Invalid ID' }, 400);
@@ -305,11 +425,20 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       const data = await c.req.json();
       if (!data.text?.trim()) return c.json({ error: 'text required' }, 400);
       const now = new Date().toISOString();
-      const maxOrder = (sqlite.prepare('SELECT MAX(sort_order) as m FROM checklist_items WHERE task_id = ?').get(taskId) as any)?.m || 0;
-      const result = sqlite.prepare(
-        'INSERT INTO checklist_items (task_id, text, checked, sort_order, created_at, updated_at) VALUES (?, ?, 0, ?, ?, ?)'
-      ).run(taskId, data.text.trim(), maxOrder + 1, now, now);
-      const item = sqlite.prepare('SELECT * FROM checklist_items WHERE id = ?').get((result as any).lastInsertRowid);
+      const maxOrder =
+        (
+          sqlite
+            .prepare('SELECT MAX(sort_order) as m FROM checklist_items WHERE task_id = ?')
+            .get(taskId) as any
+        )?.m || 0;
+      const result = sqlite
+        .prepare(
+          'INSERT INTO checklist_items (task_id, text, checked, sort_order, created_at, updated_at) VALUES (?, ?, 0, ?, ?, ?)',
+        )
+        .run(taskId, data.text.trim(), maxOrder + 1, now, now);
+      const item = sqlite
+        .prepare('SELECT * FROM checklist_items WHERE id = ?')
+        .get((result as any).lastInsertRowid);
       wsBroadcast('prowl_update', { action: 'checklist' });
       return c.json(item, 201);
     } catch {
@@ -322,15 +451,23 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#788 — derive caller from auth-layer.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` },
+        403,
+      );
     }
     const taskId = parseInt(c.req.param('id'), 10);
     const itemId = parseInt(c.req.param('itemId'), 10);
     if (isNaN(taskId) || isNaN(itemId)) return c.json({ error: 'Invalid ID' }, 400);
-    const existing = sqlite.prepare('SELECT * FROM checklist_items WHERE id = ? AND task_id = ?').get(itemId, taskId);
+    const existing = sqlite
+      .prepare('SELECT * FROM checklist_items WHERE id = ? AND task_id = ?')
+      .get(itemId, taskId);
     if (!existing) return c.json({ error: 'Checklist item not found' }, 404);
     try {
       const data = await c.req.json();
@@ -347,7 +484,9 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       updates.push('updated_at = ?');
       values.push(new Date().toISOString());
       values.push(itemId);
-      sqlite.prepare(`UPDATE checklist_items SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+      sqlite
+        .prepare(`UPDATE checklist_items SET ${updates.join(', ')} WHERE id = ?`)
+        .run(...values);
       const item = sqlite.prepare('SELECT * FROM checklist_items WHERE id = ?').get(itemId);
       wsBroadcast('prowl_update', { action: 'checklist' });
       return c.json(item);
@@ -361,19 +500,29 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#788 — derive caller from auth-layer.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` },
+        403,
+      );
     }
     const taskId = parseInt(c.req.param('id'), 10);
     const itemId = parseInt(c.req.param('itemId'), 10);
     if (isNaN(taskId) || isNaN(itemId)) return c.json({ error: 'Invalid ID' }, 400);
-    const existing = sqlite.prepare('SELECT * FROM checklist_items WHERE id = ? AND task_id = ?').get(itemId, taskId) as any;
+    const existing = sqlite
+      .prepare('SELECT * FROM checklist_items WHERE id = ? AND task_id = ?')
+      .get(itemId, taskId) as any;
     if (!existing) return c.json({ error: 'Checklist item not found' }, 404);
     const now = new Date().toISOString();
     const newChecked = existing.checked ? 0 : 1;
-    sqlite.prepare('UPDATE checklist_items SET checked = ?, updated_at = ? WHERE id = ?').run(newChecked, now, itemId);
+    sqlite
+      .prepare('UPDATE checklist_items SET checked = ?, updated_at = ? WHERE id = ?')
+      .run(newChecked, now, itemId);
     const item = sqlite.prepare('SELECT * FROM checklist_items WHERE id = ?').get(itemId);
     wsBroadcast('prowl_update', { action: 'checklist' });
     return c.json(item);
@@ -384,15 +533,23 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     // T#788 — derive caller from auth-layer.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     if (!ALLOWED_PROWL_MANAGERS.includes(caller)) {
-      return c.json({ error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` }, 403);
+      return c.json(
+        { error: `Only ${ALLOWED_PROWL_MANAGERS.join(', ')} can modify Prowl checklists` },
+        403,
+      );
     }
     const taskId = parseInt(c.req.param('id'), 10);
     const itemId = parseInt(c.req.param('itemId'), 10);
     if (isNaN(taskId) || isNaN(itemId)) return c.json({ error: 'Invalid ID' }, 400);
-    const existing = sqlite.prepare('SELECT * FROM checklist_items WHERE id = ? AND task_id = ?').get(itemId, taskId);
+    const existing = sqlite
+      .prepare('SELECT * FROM checklist_items WHERE id = ? AND task_id = ?')
+      .get(itemId, taskId);
     if (!existing) return c.json({ error: 'Checklist item not found' }, 404);
     sqlite.prepare('DELETE FROM checklist_items WHERE id = ?').run(itemId);
     wsBroadcast('prowl_update', { action: 'checklist' });
@@ -407,7 +564,8 @@ export function registerProwlRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     if (hasSession.exitCode !== 0) {
       return c.json({ error: 'Sable tmux session not found' }, 503);
     }
-    const notification = '[Prowl] TEST: This is a test notification — if Sable receives this and sends Telegram, the pipeline works';
+    const notification =
+      '[Prowl] TEST: This is a test notification — if Sable receives this and sends Telegram, the pipeline works';
     enqueueNotification('sable', notification);
     return c.json({ success: true, message: 'Test notification sent to Sable' });
   });

--- a/src/queue/routes.ts
+++ b/src/queue/routes.ts
@@ -14,28 +14,33 @@ export function registerQueueRoutes(app: OpenAPIHono, sqlite: Database, helpers:
   // GET /api/queue/gorn — list queue items
   app.openapi(queueListRoute, ((c: Context) => {
     const status = c.req.query('status') || 'pending'; // pending, decided, deferred, withdrawn
-    const rows = sqlite.prepare(`
+    const rows = sqlite
+      .prepare(`
       SELECT id, title, status, category, queue_status, queue_tagged_by, queue_tagged_at, queue_summary, created_at,
         (SELECT COUNT(*) FROM forum_messages WHERE thread_id = forum_threads.id) as message_count
       FROM forum_threads
       WHERE category = 'gorn-queue' AND queue_status = ?
       ORDER BY CASE WHEN queue_status = 'deferred' THEN 1 ELSE 0 END, queue_tagged_at ASC
-    `).all(status) as any[];
+    `)
+      .all(status) as any[];
 
-    return c.json({
-      items: rows.map(r => ({
-        thread_id: r.id,
-        title: r.title,
-        thread_status: r.status,
-        queue_status: r.queue_status,
-        tagged_by: r.queue_tagged_by,
-        tagged_at: r.queue_tagged_at ? new Date(r.queue_tagged_at).toISOString() : null,
-        summary: r.queue_summary,
-        message_count: r.message_count,
-        created_at: new Date(r.created_at).toISOString(),
-      })),
-      total: rows.length,
-    }, 200);
+    return c.json(
+      {
+        items: rows.map((r) => ({
+          thread_id: r.id,
+          title: r.title,
+          thread_status: r.status,
+          queue_status: r.queue_status,
+          tagged_by: r.queue_tagged_by,
+          tagged_at: r.queue_tagged_at ? new Date(r.queue_tagged_at).toISOString() : null,
+          summary: r.queue_summary,
+          message_count: r.message_count,
+          created_at: new Date(r.created_at).toISOString(),
+        })),
+        total: rows.length,
+      },
+      200,
+    );
   }) as any);
 
   // POST /api/queue/gorn — add thread to queue (any Beast can tag)
@@ -49,11 +54,13 @@ export function registerQueueRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       if (!data.thread_id) return c.json({ error: 'thread_id required' }, 400);
 
       const now = Date.now();
-      sqlite.prepare(`
+      sqlite
+        .prepare(`
         UPDATE forum_threads
         SET category = 'gorn-queue', queue_status = 'pending', queue_tagged_by = ?, queue_tagged_at = ?, queue_summary = ?
         WHERE id = ?
-      `).run(data.tagged_by || 'unknown', now, data.summary || null, data.thread_id);
+      `)
+        .run(data.tagged_by || 'unknown', now, data.summary || null, data.thread_id);
 
       return c.json({ success: true, thread_id: data.thread_id, queue_status: 'pending' }, 200);
     } catch (e) {
@@ -77,7 +84,8 @@ export function registerQueueRoutes(app: OpenAPIHono, sqlite: Database, helpers:
         if (as !== 'gorn') return c.json({ error: 'Only Gorn can update queue items' }, 403);
       }
 
-      sqlite.prepare('UPDATE forum_threads SET queue_status = ? WHERE id = ? AND category = ?')
+      sqlite
+        .prepare('UPDATE forum_threads SET queue_status = ? WHERE id = ? AND category = ?')
         .run(data.status, threadId, 'gorn-queue');
 
       return c.json({ success: true, thread_id: threadId, queue_status: data.status }, 200);

--- a/src/reachability.test.ts
+++ b/src/reachability.test.ts
@@ -99,22 +99,26 @@ const FORBIDDEN: ForbiddenPattern[] = [
   {
     name: 'sql.identifier() call',
     needle: 'sql.identifier(',
-    reason: 'GHSA-gpj5-g38j-94v9 — drizzle <0.45.2 SQL injection via unescaped identifiers. Any new use requires reachability re-analysis.',
+    reason:
+      'GHSA-gpj5-g38j-94v9 — drizzle <0.45.2 SQL injection via unescaped identifiers. Any new use requires reachability re-analysis.',
   },
   {
     name: 'sql.raw() call',
     needle: 'sql.raw(',
-    reason: 'Raw SQL construction — if the string comes from user input, identifier or value injection is trivial. Any new use requires a security comment.',
+    reason:
+      'Raw SQL construction — if the string comes from user input, identifier or value injection is trivial. Any new use requires a security comment.',
   },
   {
     name: 'getTableColumns() call',
     needle: 'getTableColumns(',
-    reason: 'Drizzle programmatic column introspection. Safe on static schema, risky if table object comes from user input. Any new use requires review.',
+    reason:
+      'Drizzle programmatic column introspection. Safe on static schema, risky if table object comes from user input. Any new use requires review.',
   },
   {
     name: 'getTableConfig() call',
     needle: 'getTableConfig(',
-    reason: 'Same as getTableColumns — drizzle programmatic table metadata access. Any new use requires review.',
+    reason:
+      'Same as getTableColumns — drizzle programmatic table metadata access. Any new use requires review.',
   },
   // MCP SDK transport surface — locks stdio-only (per Bertus extension msg #8118
   // and review extension msg #8122). Block every HTTP-ish transport the SDK
@@ -123,7 +127,8 @@ const FORBIDDEN: ForbiddenPattern[] = [
   {
     name: 'MCP streamableHttp import',
     needle: '@modelcontextprotocol/sdk/server/streamableHttp',
-    reason: 'HTTP streamable transport. Importing loads @hono/node-server and makes hono CVEs reachable. Oracle-v2 is stdio-only per the T#663 reachability sweep.',
+    reason:
+      'HTTP streamable transport. Importing loads @hono/node-server and makes hono CVEs reachable. Oracle-v2 is stdio-only per the T#663 reachability sweep.',
   },
   {
     name: 'MCP web-standard streamable HTTP import',
@@ -138,17 +143,20 @@ const FORBIDDEN: ForbiddenPattern[] = [
   {
     name: 'MCP express transport import',
     needle: '@modelcontextprotocol/sdk/server/express',
-    reason: 'Express transport. Importing loads express, express-rate-limit, path-to-regexp. Oracle-v2 is stdio-only.',
+    reason:
+      'Express transport. Importing loads express, express-rate-limit, path-to-regexp. Oracle-v2 is stdio-only.',
   },
   {
     name: 'MCP auth router import',
     needle: '@modelcontextprotocol/sdk/server/auth/router',
-    reason: 'MCP auth router. Loads the same express chain as above. Oracle-v2 does not use MCP auth.',
+    reason:
+      'MCP auth router. Loads the same express chain as above. Oracle-v2 does not use MCP auth.',
   },
   {
     name: 'MCP auth handlers import',
     needle: '@modelcontextprotocol/sdk/server/auth/handlers',
-    reason: 'MCP auth handlers (register / authorize / revoke / token / metadata). Each imports express. Oracle-v2 does not use MCP auth.',
+    reason:
+      'MCP auth handlers (register / authorize / revoke / token / metadata). Each imports express. Oracle-v2 does not use MCP auth.',
   },
 ];
 
@@ -207,7 +215,10 @@ test('T#664: no vulnerable-surface API calls in src/ (reachability lock)', () =>
   const matches = findMatches();
 
   const report = matches
-    .map((m) => `  ${m.file}:${m.line} — ${m.pattern.name}\n    ${m.lineText}\n    reason: ${m.pattern.reason}`)
+    .map(
+      (m) =>
+        `  ${m.file}:${m.line} — ${m.pattern.name}\n    ${m.lineText}\n    reason: ${m.pattern.reason}`,
+    )
     .join('\n\n');
 
   const failMessage =

--- a/src/remote/routes.ts
+++ b/src/remote/routes.ts
@@ -26,8 +26,11 @@ export function registerRemoteRoutes(app: OpenAPIHono, helpers: RemoteHelpers) {
         // Check if window 1 still exists (beast is still linked)
         const windows = execSync(
           `tmux list-windows -t ${JSON.stringify(REMOTE_SESSION)} -F "#{window_index}"`,
-          { timeout: 2000 }
-        ).toString().trim().split('\n');
+          { timeout: 2000 },
+        )
+          .toString()
+          .trim()
+          .split('\n');
         if (!windows.includes('1')) {
           attachedBeastName = null; // Window was unlinked externally
         }
@@ -69,11 +72,16 @@ export function registerRemoteRoutes(app: OpenAPIHono, helpers: RemoteHelpers) {
       try {
         const windows = execSync(
           `tmux list-windows -t ${JSON.stringify(sessionName)} -F "#{window_index}:#{pane_current_command}"`,
-          { timeout: 2000 }
-        ).toString().trim().split('\n');
-        const claudeWin = windows.find(w => w.includes(':claude'));
+          { timeout: 2000 },
+        )
+          .toString()
+          .trim()
+          .split('\n');
+        const claudeWin = windows.find((w) => w.includes(':claude'));
         if (claudeWin) claudeWindow = claudeWin.split(':')[0];
-      } catch { /* default to 1 */ }
+      } catch {
+        /* default to 1 */
+      }
 
       // Ensure Remote session exists
       try {
@@ -85,12 +93,14 @@ export function registerRemoteRoutes(app: OpenAPIHono, helpers: RemoteHelpers) {
       // Unlink any existing beast window (window index 1)
       try {
         execSync(`tmux unlink-window -k -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
-      } catch { /* no window to unlink */ }
+      } catch {
+        /* no window to unlink */
+      }
 
       // Link the beast's claude window
       execSync(
         `tmux link-window -s ${JSON.stringify(sessionName)}:${claudeWindow} -t ${JSON.stringify(REMOTE_SESSION)}:1`,
-        { timeout: 2000 }
+        { timeout: 2000 },
       );
 
       // Switch to the linked window
@@ -107,7 +117,9 @@ export function registerRemoteRoutes(app: OpenAPIHono, helpers: RemoteHelpers) {
   app.openapi(remoteDetachRoute, ((c: Context) => {
     try {
       execSync(`tmux unlink-window -k -t ${JSON.stringify(REMOTE_SESSION)}:1`, { timeout: 2000 });
-    } catch { /* already detached */ }
+    } catch {
+      /* already detached */
+    }
     attachedBeastName = null;
     return c.json({ detached: true as const }, 200);
   }) as any);

--- a/src/risk/routes.ts
+++ b/src/risk/routes.ts
@@ -29,12 +29,30 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
     if (!includeDeleted) {
       query += ' AND deleted_at IS NULL';
     }
-    if (status) { query += ' AND status = ?'; params.push(status); }
-    if (category) { query += ' AND category = ?'; params.push(category); }
-    if (severity) { query += ' AND severity = ?'; params.push(severity); }
-    if (likelihood) { query += ' AND likelihood = ?'; params.push(likelihood); }
-    if (owner) { query += ' AND owner = ?'; params.push(owner); }
-    if (risk_type) { query += ' AND risk_type = ?'; params.push(risk_type); }
+    if (status) {
+      query += ' AND status = ?';
+      params.push(status);
+    }
+    if (category) {
+      query += ' AND category = ?';
+      params.push(category);
+    }
+    if (severity) {
+      query += ' AND severity = ?';
+      params.push(severity);
+    }
+    if (likelihood) {
+      query += ' AND likelihood = ?';
+      params.push(likelihood);
+    }
+    if (owner) {
+      query += ' AND owner = ?';
+      params.push(owner);
+    }
+    if (risk_type) {
+      query += ' AND risk_type = ?';
+      params.push(risk_type);
+    }
 
     query += ' ORDER BY risk_score DESC, updated_at DESC';
 
@@ -49,7 +67,9 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
 
     const bySeverity: any = {};
     for (const s of ['critical', 'high', 'medium', 'low', 'info']) {
-      bySeverity[s] = (sqlite.prepare(`SELECT COUNT(*) as c ${base} AND severity = ?`).get(s) as any).c;
+      bySeverity[s] = (
+        sqlite.prepare(`SELECT COUNT(*) as c ${base} AND severity = ?`).get(s) as any
+      ).c;
     }
 
     const byStatus: any = {};
@@ -58,26 +78,43 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
     }
 
     const byCategory: any = {};
-    const catRows = sqlite.prepare(`SELECT category, COUNT(*) as c ${base} GROUP BY category`).all() as any[];
+    const catRows = sqlite
+      .prepare(`SELECT category, COUNT(*) as c ${base} GROUP BY category`)
+      .all() as any[];
     for (const r of catRows) byCategory[r.category] = r.c;
 
-    const staleCount = (sqlite.prepare(
-      `SELECT COUNT(*) as c ${base} AND status IN ('open','mitigating') AND (reviewed_at IS NULL OR reviewed_at < datetime('now', '-7 days'))`
-    ).get() as any).c;
+    const staleCount = (
+      sqlite
+        .prepare(
+          `SELECT COUNT(*) as c ${base} AND status IN ('open','mitigating') AND (reviewed_at IS NULL OR reviewed_at < datetime('now', '-7 days'))`,
+        )
+        .get() as any
+    ).c;
 
     // Matrix data: count of risks per severity × likelihood
-    const matrixRows = sqlite.prepare(
-      `SELECT severity, likelihood, COUNT(*) as count ${base} AND status NOT IN ('closed','mitigated') GROUP BY severity, likelihood`
-    ).all() as any[];
+    const matrixRows = sqlite
+      .prepare(
+        `SELECT severity, likelihood, COUNT(*) as count ${base} AND status NOT IN ('closed','mitigated') GROUP BY severity, likelihood`,
+      )
+      .all() as any[];
 
-    return c.json({ total, by_severity: bySeverity, by_status: byStatus, by_category: byCategory, stale_count: staleCount, matrix: matrixRows });
+    return c.json({
+      total,
+      by_severity: bySeverity,
+      by_status: byStatus,
+      by_category: byCategory,
+      stale_count: staleCount,
+      matrix: matrixRows,
+    });
   });
 
   // GET /api/risks/stale — risks not reviewed in >7 days
   app.get('/api/risks/stale', (c) => {
-    const risks = sqlite.prepare(
-      "SELECT * FROM risks WHERE deleted_at IS NULL AND status IN ('open','mitigating') AND (reviewed_at IS NULL OR reviewed_at < datetime('now', '-7 days')) ORDER BY risk_score DESC"
-    ).all();
+    const risks = sqlite
+      .prepare(
+        "SELECT * FROM risks WHERE deleted_at IS NULL AND status IN ('open','mitigating') AND (reviewed_at IS NULL OR reviewed_at < datetime('now', '-7 days')) ORDER BY risk_score DESC",
+      )
+      .all();
     return c.json({ risks });
   });
 
@@ -95,7 +132,10 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
     // T#814 — auth-first ordering: 401 fires before body-validation leaks endpoint shape.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     try {
       const data = await c.req.json();
@@ -103,7 +143,13 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
 
       // T#788 — reject body-asserted mismatch.
       if (data.created_by && data.created_by.toLowerCase() !== caller) {
-        return c.json({ error: 'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Sender impersonation blocked. body.created_by must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const requester = caller;
       if (!ALLOWED_RISK_CREATORS.includes(requester)) {
@@ -117,28 +163,33 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
       const validRiskType = ['vulnerability', 'threat', 'operational', 'compliance', 'project'];
 
       const now = new Date().toISOString();
-      const result = sqlite.prepare(
-        `INSERT INTO risks (title, description, category, severity, likelihood, impact_notes, status, mitigation, owner, source, source_type, risk_type, thread_id, created_by, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      ).run(
-        data.title.trim(),
-        data.description || null,
-        data.category || 'security',
-        validSeverity.includes(data.severity) ? data.severity : 'medium',
-        validLikelihood.includes(data.likelihood) ? data.likelihood : 'possible',
-        data.impact_notes || null,
-        validStatus.includes(data.status) ? data.status : 'open',
-        data.mitigation || null,
-        data.owner || null,
-        data.source || null,
-        validSourceType.includes(data.source_type) ? data.source_type : 'scan',
-        validRiskType.includes(data.risk_type) ? data.risk_type : 'threat',
-        data.thread_id ?? null,
-        requester,
-        now, now
-      );
+      const result = sqlite
+        .prepare(
+          `INSERT INTO risks (title, description, category, severity, likelihood, impact_notes, status, mitigation, owner, source, source_type, risk_type, thread_id, created_by, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          data.title.trim(),
+          data.description || null,
+          data.category || 'security',
+          validSeverity.includes(data.severity) ? data.severity : 'medium',
+          validLikelihood.includes(data.likelihood) ? data.likelihood : 'possible',
+          data.impact_notes || null,
+          validStatus.includes(data.status) ? data.status : 'open',
+          data.mitigation || null,
+          data.owner || null,
+          data.source || null,
+          validSourceType.includes(data.source_type) ? data.source_type : 'scan',
+          validRiskType.includes(data.risk_type) ? data.risk_type : 'threat',
+          data.thread_id ?? null,
+          requester,
+          now,
+          now,
+        );
 
-      const risk = sqlite.prepare('SELECT * FROM risks WHERE id = ?').get((result as any).lastInsertRowid) as any;
+      const risk = sqlite
+        .prepare('SELECT * FROM risks WHERE id = ?')
+        .get((result as any).lastInsertRowid) as any;
       wsBroadcast('risk_update', { action: 'create', id: risk.id });
       return c.json(risk, 201);
     } catch (e: any) {
@@ -150,13 +201,18 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
   app.patch('/api/risks/:id', async (c) => {
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
-    const existing = sqlite.prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL').get(id) as any;
+    const existing = sqlite
+      .prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL')
+      .get(id) as any;
     if (!existing) return c.json({ error: 'Risk not found' }, 404);
 
     // T#788 — derive requester from auth-layer.
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const requester = caller;
 
@@ -171,7 +227,22 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
         }
       }
 
-      const allowed = ['title', 'description', 'category', 'severity', 'likelihood', 'impact_notes', 'status', 'mitigation', 'owner', 'source', 'source_type', 'risk_type', 'thread_id', 'reviewed_at'];
+      const allowed = [
+        'title',
+        'description',
+        'category',
+        'severity',
+        'likelihood',
+        'impact_notes',
+        'status',
+        'mitigation',
+        'owner',
+        'source',
+        'source_type',
+        'risk_type',
+        'thread_id',
+        'reviewed_at',
+      ];
       const updates: string[] = [];
       const values: any[] = [];
 
@@ -210,11 +281,15 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
     if (!hasSessionAuth(c)) return c.json({ error: 'Gorn-only' }, 403);
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
-    const existing = sqlite.prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL').get(id) as any;
+    const existing = sqlite
+      .prepare('SELECT * FROM risks WHERE id = ? AND deleted_at IS NULL')
+      .get(id) as any;
     if (!existing) return c.json({ error: 'Risk not found' }, 404);
 
     const now = new Date().toISOString();
-    sqlite.prepare('UPDATE risks SET deleted_at = ?, updated_at = ? WHERE id = ?').run(now, now, id);
+    sqlite
+      .prepare('UPDATE risks SET deleted_at = ?, updated_at = ? WHERE id = ?')
+      .run(now, now, id);
     wsBroadcast('risk_update', { action: 'delete', id: (existing as any).id });
     return c.json({ deleted: true, id });
   });
@@ -227,7 +302,9 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
     const risk = sqlite.prepare('SELECT id FROM risks WHERE id = ? AND deleted_at IS NULL').get(id);
     if (!risk) return c.json({ error: 'Risk not found' }, 404);
-    const comments = sqlite.prepare('SELECT * FROM risk_comments WHERE risk_id = ? ORDER BY created_at ASC').all(id);
+    const comments = sqlite
+      .prepare('SELECT * FROM risk_comments WHERE risk_id = ? ORDER BY created_at ASC')
+      .all(id);
     return c.json({ comments });
   });
 
@@ -243,40 +320,56 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
       // T#788 — derive author from auth-layer, reject body-asserted mismatch.
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       if (data.author && data.author.toLowerCase() !== caller) {
-        return c.json({ error: 'Sender impersonation blocked. body.author must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Sender impersonation blocked. body.author must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const author = caller;
       if (!data.content?.trim()) return c.json({ error: 'content required' }, 400);
 
       const contentText = data.content.trim();
-      const result = sqlite.prepare(
-        'INSERT INTO risk_comments (risk_id, author, content) VALUES (?, ?, ?)'
-      ).run(id, author, contentText);
+      const result = sqlite
+        .prepare('INSERT INTO risk_comments (risk_id, author, content) VALUES (?, ?, ?)')
+        .run(id, author, contentText);
 
-      const comment = sqlite.prepare('SELECT * FROM risk_comments WHERE id = ?').get((result as any).lastInsertRowid);
+      const comment = sqlite
+        .prepare('SELECT * FROM risk_comments WHERE id = ?')
+        .get((result as any).lastInsertRowid);
       wsBroadcast('risk_update', { action: 'comment', risk_id: id });
 
       // Notify risk owner + previous commenters
       try {
-        const riskData = sqlite.prepare('SELECT title, owner FROM risks WHERE id = ?').get(id) as any;
+        const riskData = sqlite
+          .prepare('SELECT title, owner FROM risks WHERE id = ?')
+          .get(id) as any;
         if (riskData) {
           const { parseMentions, notifyMentioned } = await import('../forum/mentions.ts');
           const toNotify = new Set<string>();
           // Risk owner
-          if (riskData.owner && riskData.owner.toLowerCase() !== author) toNotify.add(riskData.owner.toLowerCase());
+          if (riskData.owner && riskData.owner.toLowerCase() !== author)
+            toNotify.add(riskData.owner.toLowerCase());
           // Previous commenters
-          const prevCommenters = sqlite.prepare(
-            'SELECT DISTINCT author FROM risk_comments WHERE risk_id = ? AND author != ?'
-          ).all(id, author) as any[];
+          const prevCommenters = sqlite
+            .prepare('SELECT DISTINCT author FROM risk_comments WHERE risk_id = ? AND author != ?')
+            .all(id, author) as any[];
           for (const pc of prevCommenters) toNotify.add(pc.author.toLowerCase());
           // @mentions in comment content
           const mentions = parseMentions(contentText, 0);
           for (const m of mentions) toNotify.add(m.toLowerCase());
           toNotify.delete(author);
-          toNotify.delete('gorn'); toNotify.delete('human'); toNotify.delete('user');
+          toNotify.delete('gorn');
+          toNotify.delete('human');
+          toNotify.delete('user');
           if (toNotify.size > 0) {
             notifyMentioned(
               [...toNotify],
@@ -284,11 +377,17 @@ export function registerRiskRoutes(app: OpenAPIHono, sqlite: Database, helpers: 
               `Risk #${id}: ${riskData.title || 'Untitled'}`,
               author,
               `New comment on risk #${id}: ${contentText.slice(0, 100)}`,
-              { type: 'Risk comment', label: `risk #${id}`, hint: `View at /risk and expand risk #${id} to see comments.` }
+              {
+                type: 'Risk comment',
+                label: `risk #${id}`,
+                hint: `View at /risk and expand risk #${id} to see comments.`,
+              },
             );
           }
         }
-      } catch { /* notification failure is non-critical */ }
+      } catch {
+        /* notification failure is non-critical */
+      }
 
       return c.json(comment, 201);
     } catch {

--- a/src/scheduler/routes.ts
+++ b/src/scheduler/routes.ts
@@ -126,8 +126,6 @@ function computeNextWeekdayFixedTime(
   throw new Error('Failed to compute next weekday-anchored due time');
 }
 
-
-
 // ============================================================================
 // Auto-trigger daemon
 // ============================================================================
@@ -135,7 +133,6 @@ function computeNextWeekdayFixedTime(
 // ============================================================================
 // Scheduler Auto-Trigger Daemon (10s polling)
 // ============================================================================
-
 
 function runSchedulerCycle() {
   if (!moduleSqlite) return;
@@ -152,8 +149,9 @@ function runSchedulerCycle() {
     // - 'triggered': already notified, waiting for beast — do NOT re-trigger (beast will /run when ready)
     // - 'completed': one-time schedule finished — never re-trigger
     // T#658 — Norm #65 — skip beasts at rest (rest_status = 'rest')
-    const overdue = sqlite.prepare(
-      `SELECT * FROM beast_schedules
+    const overdue = sqlite
+      .prepare(
+        `SELECT * FROM beast_schedules
        WHERE enabled = 1 AND datetime(next_due_at) <= datetime(?)
        AND trigger_status IS NOT 'completed'
        AND trigger_status IS NOT 'triggered'
@@ -163,8 +161,9 @@ function runSchedulerCycle() {
          OR trigger_status = 'pending'
          OR (trigger_status = 'failed' AND datetime(last_triggered_at) <= datetime(?, '-' || CAST(interval_seconds AS TEXT) || ' seconds'))
        )
-       ORDER BY next_due_at`
-    ).all(now, now) as any[];
+       ORDER BY next_due_at`,
+      )
+      .all(now, now) as any[];
 
     for (const schedule of overdue) {
       const sessionName = schedule.beast.charAt(0).toUpperCase() + schedule.beast.slice(1);
@@ -172,7 +171,9 @@ function runSchedulerCycle() {
       // Check if Beast tmux session exists
       const hasSession = Bun.spawnSync(['tmux', 'has-session', '-t', sessionName]);
       if (hasSession.exitCode !== 0) {
-        console.log(`[Scheduler] Skip ${schedule.beast}/${schedule.task}: tmux session '${sessionName}' not found`);
+        console.log(
+          `[Scheduler] Skip ${schedule.beast}/${schedule.task}: tmux session '${sessionName}' not found`,
+        );
         continue;
       }
 
@@ -183,9 +184,11 @@ function runSchedulerCycle() {
         enqueueNotification(schedule.beast, notification);
 
         // Mark as triggered
-        sqlite.prepare(
-          `UPDATE beast_schedules SET last_triggered_at = ?, trigger_status = 'triggered', updated_at = datetime('now') WHERE id = ?`
-        ).run(now, schedule.id);
+        sqlite
+          .prepare(
+            `UPDATE beast_schedules SET last_triggered_at = ?, trigger_status = 'triggered', updated_at = datetime('now') WHERE id = ?`,
+          )
+          .run(now, schedule.id);
 
         wsBroadcast('schedule_update', { action: 'triggered', id: schedule.id });
         console.log(`[Scheduler] Triggered: ${schedule.beast}/${schedule.task} (#${schedule.id})`);
@@ -197,9 +200,10 @@ function runSchedulerCycle() {
     // Also re-notify daily for overdue tasks (T#473)
     // Note: Prowl due_date is stored in local time (from datetime-local picker), so compare with local time
     const d = new Date();
-    const localNow = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}T${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}:${String(d.getSeconds()).padStart(2,'0')}`;
-    const dueProwl = sqlite.prepare(
-      `SELECT * FROM prowl_tasks WHERE due_date IS NOT NULL AND status = 'pending'
+    const localNow = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}T${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
+    const dueProwl = sqlite
+      .prepare(
+        `SELECT * FROM prowl_tasks WHERE due_date IS NOT NULL AND status = 'pending'
        AND (
          (notified_at IS NULL AND (
            (remind_before IS NULL AND datetime(due_date) <= datetime(?))
@@ -211,28 +215,56 @@ function runSchedulerCycle() {
            OR (remind_before = '1d' AND datetime(due_date, '-1 days') <= datetime(?))
          ))
          OR (notified_at IS NOT NULL AND datetime(due_date) < datetime(?) AND datetime(notified_at) <= datetime(?, '-1 days'))
-       )`
-    ).all(localNow, localNow, localNow, localNow, localNow, localNow, localNow, localNow, localNow) as any[];
+       )`,
+      )
+      .all(
+        localNow,
+        localNow,
+        localNow,
+        localNow,
+        localNow,
+        localNow,
+        localNow,
+        localNow,
+        localNow,
+      ) as any[];
 
     for (const task of dueProwl) {
       const sessionName = 'Sable';
       const hasSession = Bun.spawnSync(['tmux', 'has-session', '-t', sessionName]);
       if (hasSession.exitCode !== 0) {
-        console.log(`[Prowl] Skip notification for task #${task.id}: tmux session 'Sable' not found`);
+        console.log(
+          `[Prowl] Skip notification for task #${task.id}: tmux session 'Sable' not found`,
+        );
         continue;
       }
 
-      const priorityEmoji = task.priority === 'high' ? '🔴' : task.priority === 'medium' ? '🟡' : '🟢';
-      const reminderLabels: Record<string, string> = { '1m': '1 min', '5m': '5 min', '15m': '15 min', '30m': '30 min', '1h': '1 hour', '1d': '1 day' };
-      const isReminder = task.remind_before && !task.notified_at && new Date(task.due_date) > new Date(now);
+      const priorityEmoji =
+        task.priority === 'high' ? '🔴' : task.priority === 'medium' ? '🟡' : '🟢';
+      const reminderLabels: Record<string, string> = {
+        '1m': '1 min',
+        '5m': '5 min',
+        '15m': '15 min',
+        '30m': '30 min',
+        '1h': '1 hour',
+        '1d': '1 day',
+      };
+      const isReminder =
+        task.remind_before && !task.notified_at && new Date(task.due_date) > new Date(now);
       const isOverdueRenotify = task.notified_at && new Date(task.due_date) < new Date(now);
-      const prefix = isOverdueRenotify ? 'OVERDUE (daily reminder)' : isReminder ? `Reminder (${reminderLabels[task.remind_before] || task.remind_before} before)` : 'Task due';
+      const prefix = isOverdueRenotify
+        ? 'OVERDUE (daily reminder)'
+        : isReminder
+          ? `Reminder (${reminderLabels[task.remind_before] || task.remind_before} before)`
+          : 'Task due';
       const notification = `[Prowl] ${prefix}: ${task.title} (Prowl ${priorityEmoji}${task.id}) — Priority: ${task.priority} — send Telegram to Gorn`;
 
       try {
         enqueueNotification('sable', notification);
 
-        sqlite.prepare(`UPDATE prowl_tasks SET notified_at = ? WHERE id = ?`).run(localNow, task.id);
+        sqlite
+          .prepare(`UPDATE prowl_tasks SET notified_at = ? WHERE id = ?`)
+          .run(localNow, task.id);
         console.log(`[Prowl] Notified Sable: task #${task.id} "${task.title}" is due`);
       } catch (err) {
         console.log(`[Prowl] Failed to notify for task #${task.id}: ${err}`);
@@ -245,7 +277,6 @@ function runSchedulerCycle() {
 
 // Startup reset + daemon start happen inside initScheduler() — see below.
 
-
 // ============================================================================
 // initScheduler — server startup entry
 // ============================================================================
@@ -257,7 +288,7 @@ export function initScheduler(
   deps: {
     wsBroadcast: (event: string, data: any) => void;
     enqueueNotification: (beast: string, notification: any) => void;
-  }
+  },
 ): void {
   moduleSqlite = sqliteDb;
   dbDrizzle = drizzleDb;
@@ -272,12 +303,16 @@ export function initScheduler(
   // Prevents the repeat-fire bug (T#383) where old triggered status + expired cooldown
   // causes schedules to fire multiple times on restart.
   try {
-    const resetCount = sqliteDb.prepare(
-      `UPDATE beast_schedules SET trigger_status = 'pending', updated_at = datetime('now')
-       WHERE trigger_status = 'triggered' AND enabled = 1`
-    ).run();
+    const resetCount = sqliteDb
+      .prepare(
+        `UPDATE beast_schedules SET trigger_status = 'pending', updated_at = datetime('now')
+       WHERE trigger_status = 'triggered' AND enabled = 1`,
+      )
+      .run();
     if (resetCount.changes > 0) {
-      console.log(`[Scheduler] Reset ${resetCount.changes} triggered schedules to pending on startup`);
+      console.log(
+        `[Scheduler] Reset ${resetCount.changes} triggered schedules to pending on startup`,
+      );
     }
   } catch (err) {
     console.error(`[Scheduler] Startup reset error: ${err}`);
@@ -297,7 +332,11 @@ interface SchedulerHelpers {
   requireBeastIdentity: (c: Context) => string | null;
 }
 
-export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: SchedulerHelpers): void {
+export function registerSchedulerRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: SchedulerHelpers,
+): void {
   const { hasSessionAuth, requireBeastIdentity } = helpers;
   const db = dbDrizzle;
   const REPO_ROOT = repoRoot;
@@ -319,7 +358,10 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
   });
 
   app.get('/api/schedule', async (c) => {
-    const ctx = { db, sqlite: sqliteDb, repoRoot: REPO_ROOT } as Pick<ToolContext, 'db' | 'sqlite' | 'repoRoot'>;
+    const ctx = { db, sqlite: sqliteDb, repoRoot: REPO_ROOT } as Pick<
+      ToolContext,
+      'db' | 'sqlite' | 'repoRoot'
+    >;
     const result = await handleScheduleList(ctx as ToolContext, {
       date: c.req.query('date'),
       from: c.req.query('from'),
@@ -334,7 +376,10 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
 
   app.post('/api/schedule', async (c) => {
     const body = await c.req.json();
-    const ctx = { db, sqlite: sqliteDb, repoRoot: REPO_ROOT } as Pick<ToolContext, 'db' | 'sqlite' | 'repoRoot'>;
+    const ctx = { db, sqlite: sqliteDb, repoRoot: REPO_ROOT } as Pick<
+      ToolContext,
+      'db' | 'sqlite' | 'repoRoot'
+    >;
     const result = await handleScheduleAdd(ctx as ToolContext, body);
     const text = result.content[0]?.text || '{}';
     return c.json(JSON.parse(text));
@@ -361,9 +406,15 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     let query = 'SELECT * FROM beast_schedules';
     const conditions: string[] = [];
     const params: any[] = [];
-    if (beast) { conditions.push('beast = ?'); params.push(beast); }
-    if (type === 'once') { conditions.push('once = 1'); }
-    else if (type === 'recurring') { conditions.push('(once = 0 OR once IS NULL)'); }
+    if (beast) {
+      conditions.push('beast = ?');
+      params.push(beast);
+    }
+    if (type === 'once') {
+      conditions.push('once = 1');
+    } else if (type === 'recurring') {
+      conditions.push('(once = 0 OR once IS NULL)');
+    }
     if (conditions.length) query += ' WHERE ' + conditions.join(' AND ');
     query += ' ORDER BY beast, next_due_at';
     const rows = sqlite.prepare(query).all(...params) as any[];
@@ -375,9 +426,11 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     const beast = c.req.query('beast');
     if (!beast) return c.json({ error: 'beast parameter required' }, 400);
     const now = new Date().toISOString();
-    const rows = sqlite.prepare(
-      'SELECT * FROM beast_schedules WHERE beast = ? AND enabled = 1 AND next_due_at <= ? ORDER BY next_due_at'
-    ).all(beast, now) as any[];
+    const rows = sqlite
+      .prepare(
+        'SELECT * FROM beast_schedules WHERE beast = ? AND enabled = 1 AND next_due_at <= ? ORDER BY next_due_at',
+      )
+      .all(beast, now) as any[];
     return c.json({ schedules: rows, total: rows.length });
   });
 
@@ -402,11 +455,20 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
       return c.json({ error: 'beast and task are required' }, 400);
     }
     if (!isOnce && !data.interval) {
-      return c.json({ error: 'beast, task, and interval are required (or set once: true with run_at)' }, 400);
+      return c.json(
+        { error: 'beast, task, and interval are required (or set once: true with run_at)' },
+        400,
+      );
     }
     // Validate task name — only safe characters (alphanumeric, spaces, basic punctuation)
     if (typeof task !== 'string' || task.length > 100 || /[`$\\{}<>|;&]/.test(task)) {
-      return c.json({ error: 'Task name contains invalid characters or is too long (max 100 chars, no shell metacharacters)' }, 400);
+      return c.json(
+        {
+          error:
+            'Task name contains invalid characters or is too long (max 100 chars, no shell metacharacters)',
+        },
+        400,
+      );
     }
     // Validate beast name
     if (typeof beast !== 'string' || !/^[a-z][a-z0-9_-]{0,29}$/.test(beast)) {
@@ -427,7 +489,10 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
       }
       // schedule_time not compatible with once
       if (data.schedule_time) {
-        return c.json({ error: 'schedule_time cannot be used with one-off schedules (use run_at instead)' }, 400);
+        return c.json(
+          { error: 'schedule_time cannot be used with one-off schedules (use run_at instead)' },
+          400,
+        );
       }
       interval = 'once';
       intervalSeconds = 0;
@@ -435,28 +500,49 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
       // Recurring schedule: validate interval
       const parsed = parseInterval(interval);
       if (!parsed) {
-        return c.json({ error: 'Invalid interval. Use format: Nm (minutes), Nh (hours), or Nd (days). Examples: 540m, 8h, 2d' }, 400);
+        return c.json(
+          {
+            error:
+              'Invalid interval. Use format: Nm (minutes), Nh (hours), or Nd (days). Examples: 540m, 8h, 2d',
+          },
+          400,
+        );
       }
       intervalSeconds = parsed;
     }
 
     // Prevent duplicate: same beast + same task name + enabled
-    const duplicate = sqlite.prepare(
-      'SELECT id FROM beast_schedules WHERE beast = ? AND task = ? AND enabled = 1'
-    ).get(beast, task) as any;
+    const duplicate = sqlite
+      .prepare('SELECT id FROM beast_schedules WHERE beast = ? AND task = ? AND enabled = 1')
+      .get(beast, task) as any;
     if (duplicate) {
-      return c.json({ error: `Schedule '${task}' already exists for ${beast} (id: ${duplicate.id}). Disable or delete it first.` }, 409);
+      return c.json(
+        {
+          error: `Schedule '${task}' already exists for ${beast} (id: ${duplicate.id}). Disable or delete it first.`,
+        },
+        409,
+      );
     }
     // Fixed-time scheduling (recurring only)
     const scheduleTime = data.schedule_time || null;
     const tz = data.timezone || 'Asia/Bangkok';
-    const VALID_TIMEZONES = ['Asia/Bangkok', 'UTC', 'America/New_York', 'Europe/London', 'Asia/Tokyo', 'Asia/Singapore'];
+    const VALID_TIMEZONES = [
+      'Asia/Bangkok',
+      'UTC',
+      'America/New_York',
+      'Europe/London',
+      'Asia/Tokyo',
+      'Asia/Singapore',
+    ];
     if (scheduleTime) {
       if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(scheduleTime)) {
         return c.json({ error: 'schedule_time must be HH:MM format (00:00-23:59)' }, 400);
       }
       if (data.interval !== '1d' && data.interval !== '7d') {
-        return c.json({ error: 'schedule_time requires interval of 1d (daily) or 7d (weekly)' }, 400);
+        return c.json(
+          { error: 'schedule_time requires interval of 1d (daily) or 7d (weekly)' },
+          400,
+        );
       }
     }
     if (data.timezone && !VALID_TIMEZONES.includes(data.timezone)) {
@@ -470,14 +556,23 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
         return c.json({ error: 'days_of_week cannot be used with one-off schedules' }, 400);
       }
       if (data.interval !== '7d') {
-        return c.json({ error: "days_of_week requires interval='7d' (weekly cadence with explicit days)" }, 400);
+        return c.json(
+          { error: "days_of_week requires interval='7d' (weekly cadence with explicit days)" },
+          400,
+        );
       }
       if (!scheduleTime) {
         return c.json({ error: 'days_of_week requires schedule_time (HH:MM)' }, 400);
       }
       const parsed = parseDaysOfWeek(data.days_of_week);
       if (!parsed) {
-        return c.json({ error: 'days_of_week must be a non-empty array of ISO weekday integers (1=Mon..7=Sun), max length 7' }, 400);
+        return c.json(
+          {
+            error:
+              'days_of_week must be a non-empty array of ISO weekday integers (1=Mon..7=Sun), max length 7',
+          },
+          400,
+        );
       }
       daysOfWeek = parsed;
     }
@@ -496,11 +591,28 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
       nextDue = new Date(now.getTime() + intervalSeconds * 1000).toISOString();
     }
 
-    const result = sqlite.prepare(
-      `INSERT INTO beast_schedules (beast, task, command, interval, interval_seconds, next_due_at, schedule_time, timezone, source, once, run_at, days_of_week)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(beast, task, command || null, interval, intervalSeconds, nextDue, scheduleTime, tz, source || null, isOnce ? 1 : 0, runAt, daysOfWeek ? JSON.stringify(daysOfWeek) : null);
-    const created = sqlite.prepare('SELECT * FROM beast_schedules WHERE id = ?').get(result.lastInsertRowid) as any;
+    const result = sqlite
+      .prepare(
+        `INSERT INTO beast_schedules (beast, task, command, interval, interval_seconds, next_due_at, schedule_time, timezone, source, once, run_at, days_of_week)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        beast,
+        task,
+        command || null,
+        interval,
+        intervalSeconds,
+        nextDue,
+        scheduleTime,
+        tz,
+        source || null,
+        isOnce ? 1 : 0,
+        runAt,
+        daysOfWeek ? JSON.stringify(daysOfWeek) : null,
+      );
+    const created = sqlite
+      .prepare('SELECT * FROM beast_schedules WHERE id = ?')
+      .get(result.lastInsertRowid) as any;
     wsBroadcast('schedule_update', { action: 'created', id: (created as any).id });
     return c.json(created, 201);
   });
@@ -512,7 +624,12 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     const existing = sqlite.prepare('SELECT * FROM beast_schedules WHERE id = ?').get(id) as any;
     if (!existing) return c.json({ error: 'Schedule not found' }, 404);
     const data = await c.req.json();
-    const requester = (c.req.query('as') || data.as || data.beast || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
+    const requester = (
+      c.req.query('as') ||
+      data.as ||
+      data.beast ||
+      (hasSessionAuth(c) ? 'gorn' : '')
+    ).toLowerCase();
     if (!requester) {
       return c.json({ error: 'Identity required: pass ?as=beast or beast in body' }, 400);
     }
@@ -521,52 +638,89 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     }
     const updates: string[] = [];
     const params: any[] = [];
-    if (data.task !== undefined) { updates.push('task = ?'); params.push(data.task); }
-    if (data.command !== undefined) { updates.push('command = ?'); params.push(data.command); }
+    if (data.task !== undefined) {
+      updates.push('task = ?');
+      params.push(data.task);
+    }
+    if (data.command !== undefined) {
+      updates.push('command = ?');
+      params.push(data.command);
+    }
     if (data.interval !== undefined) {
       const secs = parseInterval(data.interval);
-      if (!secs) return c.json({ error: 'Invalid interval. Use format: Nm (minutes), Nh (hours), or Nd (days). Examples: 540m, 8h, 2d' }, 400);
+      if (!secs)
+        return c.json(
+          {
+            error:
+              'Invalid interval. Use format: Nm (minutes), Nh (hours), or Nd (days). Examples: 540m, 8h, 2d',
+          },
+          400,
+        );
       updates.push('interval = ?', 'interval_seconds = ?');
       params.push(data.interval, secs);
     }
-    if (data.enabled !== undefined) { updates.push('enabled = ?'); params.push(data.enabled ? 1 : 0); }
-    if (data.source !== undefined) { updates.push('source = ?'); params.push(data.source); }
+    if (data.enabled !== undefined) {
+      updates.push('enabled = ?');
+      params.push(data.enabled ? 1 : 0);
+    }
+    if (data.source !== undefined) {
+      updates.push('source = ?');
+      params.push(data.source);
+    }
     if (data.schedule_time !== undefined) {
       if (data.schedule_time !== null && !/^([01]\d|2[0-3]):[0-5]\d$/.test(data.schedule_time)) {
-        return c.json({ error: 'schedule_time must be HH:MM format (00:00-23:59) or null to clear' }, 400);
+        return c.json(
+          { error: 'schedule_time must be HH:MM format (00:00-23:59) or null to clear' },
+          400,
+        );
       }
       const effectiveInterval = data.interval || existing.interval;
       if (data.schedule_time !== null && effectiveInterval !== '1d' && effectiveInterval !== '7d') {
-        return c.json({ error: 'schedule_time requires interval of 1d (daily) or 7d (weekly)' }, 400);
+        return c.json(
+          { error: 'schedule_time requires interval of 1d (daily) or 7d (weekly)' },
+          400,
+        );
       }
       if (existing.once && data.schedule_time !== null) {
         return c.json({ error: 'schedule_time cannot be used with one-off schedules' }, 400);
       }
-      updates.push('schedule_time = ?'); params.push(data.schedule_time);
+      updates.push('schedule_time = ?');
+      params.push(data.schedule_time);
       // Recompute next_due_at if setting a new schedule_time
       if (data.schedule_time !== null) {
         const intervalDays = (data.interval || existing.interval) === '7d' ? 7 : 1;
         const nextDue = computeNextFixedTime(data.schedule_time, intervalDays);
-        updates.push('next_due_at = ?'); params.push(nextDue);
+        updates.push('next_due_at = ?');
+        params.push(nextDue);
       }
     }
     if (data.timezone !== undefined) {
-      const VALID_TIMEZONES = ['Asia/Bangkok', 'UTC', 'America/New_York', 'Europe/London', 'Asia/Tokyo', 'Asia/Singapore'];
+      const VALID_TIMEZONES = [
+        'Asia/Bangkok',
+        'UTC',
+        'America/New_York',
+        'Europe/London',
+        'Asia/Tokyo',
+        'Asia/Singapore',
+      ];
       if (!VALID_TIMEZONES.includes(data.timezone)) {
         return c.json({ error: `Invalid timezone. Valid: ${VALID_TIMEZONES.join(', ')}` }, 400);
       }
-      updates.push('timezone = ?'); params.push(data.timezone);
+      updates.push('timezone = ?');
+      params.push(data.timezone);
     }
     // T#706: days_of_week update path
     if (data.days_of_week !== undefined) {
       if (data.days_of_week === null) {
-        updates.push('days_of_week = ?'); params.push(null);
+        updates.push('days_of_week = ?');
+        params.push(null);
       } else {
         if (existing.once) {
           return c.json({ error: 'days_of_week cannot be used with one-off schedules' }, 400);
         }
         const effectiveInterval = data.interval || existing.interval;
-        const effectiveScheduleTime = data.schedule_time !== undefined ? data.schedule_time : existing.schedule_time;
+        const effectiveScheduleTime =
+          data.schedule_time !== undefined ? data.schedule_time : existing.schedule_time;
         if (effectiveInterval !== '7d') {
           return c.json({ error: "days_of_week requires interval='7d'" }, 400);
         }
@@ -575,12 +729,20 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
         }
         const parsed = parseDaysOfWeek(data.days_of_week);
         if (!parsed) {
-          return c.json({ error: 'days_of_week must be a non-empty array of ISO weekday integers (1=Mon..7=Sun), max length 7' }, 400);
+          return c.json(
+            {
+              error:
+                'days_of_week must be a non-empty array of ISO weekday integers (1=Mon..7=Sun), max length 7',
+            },
+            400,
+          );
         }
-        updates.push('days_of_week = ?'); params.push(JSON.stringify(parsed));
+        updates.push('days_of_week = ?');
+        params.push(JSON.stringify(parsed));
         // Recompute next_due_at to honor the new weekday set immediately
         const newNext = computeNextWeekdayFixedTime(effectiveScheduleTime, parsed, true);
-        updates.push('next_due_at = ?'); params.push(newNext);
+        updates.push('next_due_at = ?');
+        params.push(newNext);
       }
     }
     if (updates.length === 0) return c.json({ error: 'No fields to update' }, 400);
@@ -602,11 +764,20 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     // T#718 — derive requester from auth, reject client-asserted mismatch
     const caller = requireBeastIdentity(c);
     if (!caller) {
-      return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+      return c.json(
+        { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+        401,
+      );
     }
     const claimedAs = (c.req.query('as') || data.as || data.beast || '').toLowerCase();
     if (claimedAs && claimedAs !== caller) {
-      return c.json({ error: 'Identity spoof blocked. ?as=/body.as/body.beast must match authenticated caller or be omitted.' }, 403);
+      return c.json(
+        {
+          error:
+            'Identity spoof blocked. ?as=/body.as/body.beast must match authenticated caller or be omitted.',
+        },
+        403,
+      );
     }
     const requester = caller;
     if (requester !== existing.beast && requester !== 'gorn') {
@@ -614,17 +785,25 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     }
     // If task failed, don't update last_run (Pip's edge case)
     if (data.failed) {
-      sqlite.prepare(`UPDATE beast_schedules SET trigger_status = 'failed', updated_at = datetime('now') WHERE id = ?`).run(id);
-      const failedState = sqlite.prepare('SELECT * FROM beast_schedules WHERE id = ?').get(id) as any;
+      sqlite
+        .prepare(
+          `UPDATE beast_schedules SET trigger_status = 'failed', updated_at = datetime('now') WHERE id = ?`,
+        )
+        .run(id);
+      const failedState = sqlite
+        .prepare('SELECT * FROM beast_schedules WHERE id = ?')
+        .get(id) as any;
       return c.json({ ...failedState, message: 'Failed run — not updating last_run_at' });
     }
     const now = new Date();
 
     // One-off schedules: disable after run instead of advancing
     if (existing.once === 1) {
-      sqlite.prepare(
-        `UPDATE beast_schedules SET last_run_at = ?, enabled = 0, trigger_status = 'completed', last_triggered_at = ?, updated_at = datetime('now') WHERE id = ?`
-      ).run(now.toISOString(), now.toISOString(), id);
+      sqlite
+        .prepare(
+          `UPDATE beast_schedules SET last_run_at = ?, enabled = 0, trigger_status = 'completed', last_triggered_at = ?, updated_at = datetime('now') WHERE id = ?`,
+        )
+        .run(now.toISOString(), now.toISOString(), id);
       const updated = sqlite.prepare('SELECT * FROM beast_schedules WHERE id = ?').get(id) as any;
       wsBroadcast('schedule_update', { action: 'run', id: (updated as any).id });
       return c.json(updated);
@@ -637,7 +816,9 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
       try {
         const arr = JSON.parse(existing.days_of_week);
         parsedDays = parseDaysOfWeek(arr);
-      } catch { /* invalid stored value, fall through */ }
+      } catch {
+        /* invalid stored value, fall through */
+      }
       if (parsedDays) {
         // After-run advance: never include "today" — must move to a strictly-future qualifying weekday
         nextDue = computeNextWeekdayFixedTime(existing.schedule_time, parsedDays, false);
@@ -651,9 +832,11 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     } else {
       nextDue = new Date(now.getTime() + existing.interval_seconds * 1000).toISOString();
     }
-    sqlite.prepare(
-      `UPDATE beast_schedules SET last_run_at = ?, next_due_at = ?, trigger_status = 'pending', last_triggered_at = ?, updated_at = datetime('now') WHERE id = ?`
-    ).run(now.toISOString(), nextDue, now.toISOString(), id);
+    sqlite
+      .prepare(
+        `UPDATE beast_schedules SET last_run_at = ?, next_due_at = ?, trigger_status = 'pending', last_triggered_at = ?, updated_at = datetime('now') WHERE id = ?`,
+      )
+      .run(now.toISOString(), nextDue, now.toISOString(), id);
     const updated = sqlite.prepare('SELECT * FROM beast_schedules WHERE id = ?').get(id) as any;
     wsBroadcast('schedule_update', { action: 'run', id: (updated as any).id });
     return c.json(updated);
@@ -667,7 +850,12 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     if (!existing) return c.json({ error: 'Schedule not found' }, 404);
     // Parse body for identity (DELETE can have body)
     const body = await c.req.json().catch(() => ({}));
-    const requester = (c.req.query('as') || body.as || body.beast || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
+    const requester = (
+      c.req.query('as') ||
+      body.as ||
+      body.beast ||
+      (hasSessionAuth(c) ? 'gorn' : '')
+    ).toLowerCase();
     if (!requester) {
       return c.json({ error: 'Identity required: pass ?as=beast or beast in body' }, 400);
     }
@@ -691,7 +879,10 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     // Check if Beast tmux session exists
     const hasSession = Bun.spawnSync(['tmux', 'has-session', '-t', sessionName]);
     if (hasSession.exitCode !== 0) {
-      return c.json({ error: `tmux session '${sessionName}' not found — Beast may be offline` }, 503);
+      return c.json(
+        { error: `tmux session '${sessionName}' not found — Beast may be offline` },
+        503,
+      );
     }
 
     // Send notification to Beast via queue
@@ -701,9 +892,11 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
       enqueueNotification(schedule.beast, notification);
 
       const now = new Date().toISOString();
-      sqlite.prepare(
-        `UPDATE beast_schedules SET last_triggered_at = ?, trigger_status = 'triggered', updated_at = datetime('now') WHERE id = ?`
-      ).run(now, id);
+      sqlite
+        .prepare(
+          `UPDATE beast_schedules SET last_triggered_at = ?, trigger_status = 'triggered', updated_at = datetime('now') WHERE id = ?`,
+        )
+        .run(now, id);
 
       wsBroadcast('schedule_update', { action: 'triggered', id });
       return c.json({ success: true, message: `Triggered ${schedule.beast}/${schedule.task}` });
@@ -719,7 +912,12 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
     const existing = sqlite.prepare('SELECT * FROM beast_schedules WHERE id = ?').get(id) as any;
     if (!existing) return c.json({ error: 'Schedule not found' }, 404);
     const data = await c.req.json().catch(() => ({}));
-    const requester = (c.req.query('as') || data.as || data.beast || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
+    const requester = (
+      c.req.query('as') ||
+      data.as ||
+      data.beast ||
+      (hasSessionAuth(c) ? 'gorn' : '')
+    ).toLowerCase();
     if (!requester) {
       return c.json({ error: 'Identity required: pass ?as=beast or beast in body' }, 400);
     }
@@ -727,14 +925,15 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
       return c.json({ error: `Only ${existing.beast} or Gorn can trigger this schedule` }, 403);
     }
     const now = new Date().toISOString();
-    sqlite.prepare(
-      `UPDATE beast_schedules SET last_triggered_at = ?, trigger_status = 'triggered', updated_at = datetime('now') WHERE id = ?`
-    ).run(now, id);
+    sqlite
+      .prepare(
+        `UPDATE beast_schedules SET last_triggered_at = ?, trigger_status = 'triggered', updated_at = datetime('now') WHERE id = ?`,
+      )
+      .run(now, id);
     const updated = sqlite.prepare('SELECT * FROM beast_schedules WHERE id = ?').get(id) as any;
     wsBroadcast('schedule_update', { action: 'triggered', id: (updated as any).id });
     return c.json(updated);
   });
-
 
   // ============================================================================
   // /api/scheduler/health
@@ -742,7 +941,10 @@ export function registerSchedulerRoutes(app: OpenAPIHono, sqliteDb: Database, he
 
   // GET /api/scheduler/health — daemon status
   app.get('/api/scheduler/health', (c) => {
-    return c.json({ status: 'running', interval_seconds: SCHEDULER_INTERVAL / 1000, last_check: schedulerLastCheck });
+    return c.json({
+      status: 'running',
+      interval_seconds: SCHEDULER_INTERVAL / 1000,
+      last_check: schedulerLastCheck,
+    });
   });
-
 }

--- a/src/scripts/fix-oracle-learn-project.ts
+++ b/src/scripts/fix-oracle-learn-project.ts
@@ -13,16 +13,17 @@ import fs from 'fs';
 const REPO_ROOT = path.join(homedir(), 'Code/github.com/Soul-Brews-Studio/oracle-v2');
 
 // Find all oracle_learn docs without project using Drizzle
-const docs = db.select({
-  id: oracleDocuments.id,
-  sourceFile: oracleDocuments.sourceFile
-})
+const docs = db
+  .select({
+    id: oracleDocuments.id,
+    sourceFile: oracleDocuments.sourceFile,
+  })
   .from(oracleDocuments)
   .where(
     and(
       eq(oracleDocuments.createdBy, 'oracle_learn'),
-      or(isNull(oracleDocuments.project), eq(oracleDocuments.project, ''))
-    )
+      or(isNull(oracleDocuments.project), eq(oracleDocuments.project, '')),
+    ),
   )
   .all();
 
@@ -47,9 +48,9 @@ for (const doc of docs) {
 
     // Method 2: Try FTS content if file not found
     if (!project) {
-      const ftsResult = sqlite.prepare(
-        'SELECT content FROM oracle_fts WHERE id = ?'
-      ).get(doc.id) as { content: string } | undefined;
+      const ftsResult = sqlite.prepare('SELECT content FROM oracle_fts WHERE id = ?').get(doc.id) as
+        | { content: string }
+        | undefined;
 
       if (ftsResult?.content) {
         project = extractProjectFromSource(ftsResult.content);
@@ -59,10 +60,7 @@ for (const doc of docs) {
 
     if (project) {
       // Update using Drizzle
-      db.update(oracleDocuments)
-        .set({ project })
-        .where(eq(oracleDocuments.id, doc.id))
-        .run();
+      db.update(oracleDocuments).set({ project }).where(eq(oracleDocuments.id, doc.id)).run();
 
       console.log(`✓ Fixed ${doc.id} → ${project}`);
       fixed++;

--- a/src/scripts/index-model.ts
+++ b/src/scripts/index-model.ts
@@ -50,17 +50,21 @@ async function main() {
   await store.connect();
 
   // Fresh index
-  try { await store.deleteCollection(); } catch {}
+  try {
+    await store.deleteCollection();
+  } catch {}
   await store.ensureCollection();
 
   // FTS5 join requires raw SQL — Drizzle doesn't support virtual tables
-  const rows = sqlite.prepare(`
+  const rows = sqlite
+    .prepare(`
     SELECT d.id, d.type, GROUP_CONCAT(f.content, '\n') as content, d.source_file, d.concepts, d.project, d.created_at
     FROM oracle_documents d
     JOIN oracle_fts f ON d.id = f.id
     GROUP BY d.id
     ORDER BY d.created_at DESC
-  `).all() as Array<{
+  `)
+    .all() as Array<{
     id: string;
     type: string;
     content: string;
@@ -79,7 +83,7 @@ async function main() {
     const batch = rows.slice(i, i + BATCH_SIZE);
     const batchNum = Math.floor(i / BATCH_SIZE) + 1;
 
-    const docs = batch.map(row => ({
+    const docs = batch.map((row) => ({
       id: row.id,
       document: row.content,
       metadata: {
@@ -97,7 +101,9 @@ async function main() {
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
       const rate = (indexed / Number(elapsed)).toFixed(1);
       const eta = ((rows.length - indexed) / Number(rate)).toFixed(0);
-      console.log(`  Batch ${batchNum}/${totalBatches} — ${indexed}/${rows.length} docs — ${rate}/s — ETA ${eta}s`);
+      console.log(
+        `  Batch ${batchNum}/${totalBatches} — ${indexed}/${rows.length} docs — ${rate}/s — ETA ${eta}s`,
+      );
     } catch (e) {
       errors++;
       console.error(`  Batch ${batchNum} FAILED:`, e instanceof Error ? e.message : String(e));
@@ -116,7 +122,7 @@ async function main() {
   sqlite.close();
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Indexer failed:', e);
   process.exit(1);
 });

--- a/src/scripts/index-qwen3.ts
+++ b/src/scripts/index-qwen3.ts
@@ -24,7 +24,9 @@ async function main() {
 
   // Open oracle.db to read documents
   const db = new Database(DB_PATH, { readonly: true });
-  const total = db.query('SELECT COUNT(*) as count FROM oracle_documents').get() as { count: number };
+  const total = db.query('SELECT COUNT(*) as count FROM oracle_documents').get() as {
+    count: number;
+  };
   console.log(`Documents: ${total.count}`);
 
   // Create LanceDB store with qwen3
@@ -38,17 +40,21 @@ async function main() {
   await store.connect();
 
   // Fresh index
-  try { await store.deleteCollection(); } catch {}
+  try {
+    await store.deleteCollection();
+  } catch {}
   await store.ensureCollection();
 
   // Read all docs (join oracle_documents + oracle_fts for content, GROUP BY to dedupe FTS chunks)
-  const rows = db.query(`
+  const rows = db
+    .query(`
     SELECT d.id, d.type, GROUP_CONCAT(f.content, '\n') as content, d.source_file, d.concepts, d.project, d.created_at
     FROM oracle_documents d
     JOIN oracle_fts f ON d.id = f.id
     GROUP BY d.id
     ORDER BY d.created_at DESC
-  `).all() as Array<{
+  `)
+    .all() as Array<{
     id: string;
     type: string;
     content: string;
@@ -67,7 +73,7 @@ async function main() {
     const batch = rows.slice(i, i + BATCH_SIZE);
     const batchNum = Math.floor(i / BATCH_SIZE) + 1;
 
-    const docs = batch.map(row => ({
+    const docs = batch.map((row) => ({
       id: row.id,
       document: row.content,
       metadata: {
@@ -85,7 +91,9 @@ async function main() {
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
       const rate = (indexed / Number(elapsed)).toFixed(1);
       const eta = ((rows.length - indexed) / Number(rate)).toFixed(0);
-      console.log(`  Batch ${batchNum}/${totalBatches} — ${indexed}/${rows.length} docs — ${rate}/s — ETA ${eta}s`);
+      console.log(
+        `  Batch ${batchNum}/${totalBatches} — ${indexed}/${rows.length} docs — ${rate}/s — ETA ${eta}s`,
+      );
     } catch (e) {
       errors++;
       console.error(`  Batch ${batchNum} FAILED:`, e instanceof Error ? e.message : String(e));
@@ -104,7 +112,7 @@ async function main() {
   db.close();
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Indexer failed:', e);
   process.exit(1);
 });

--- a/src/search/routes.ts
+++ b/src/search/routes.ts
@@ -37,7 +37,10 @@ function searchUrlFor(sourceType: string, sourceId: number, extraUrl?: string): 
 // ============================================================================
 
 async function initMeilisearch(): Promise<void> {
-  if (!MEILI_MASTER_KEY) { console.log('[MEILI] No master key configured, skipping'); return; }
+  if (!MEILI_MASTER_KEY) {
+    console.log('[MEILI] No master key configured, skipping');
+    return;
+  }
   try {
     meili = new MeiliSearch({ host: MEILI_HOST, apiKey: MEILI_MASTER_KEY });
     const health = await meili.health();
@@ -47,7 +50,11 @@ async function initMeilisearch(): Promise<void> {
 
       // Create/update index settings
       const index = meili.index('denbook');
-      try { await meili.createIndex('denbook', { primaryKey: 'search_id' }); } catch { /* exists */ }
+      try {
+        await meili.createIndex('denbook', { primaryKey: 'search_id' });
+      } catch {
+        /* exists */
+      }
       await index.updateSettings({
         searchableAttributes: ['title', 'content', 'author'],
         filterableAttributes: ['source_type', 'author'],
@@ -72,32 +79,107 @@ export async function backfillMeilisearch(): Promise<void> {
   const repoBase = path.join(import.meta.dirname || __dirname, '..');
 
   // Library
-  const libRows = sqlite.prepare('SELECT id, title, content, author, created_at FROM library').all() as any[];
-  for (const r of libRows) docs.push({ search_id: `library_${r.id}`, title: r.title, content: r.content, source_type: 'library', source_id: r.id, author: r.author, created_at: new Date(r.created_at).toISOString(), url: `/library?doc=${r.id}` });
+  const libRows = sqlite
+    .prepare('SELECT id, title, content, author, created_at FROM library')
+    .all() as any[];
+  for (const r of libRows)
+    docs.push({
+      search_id: `library_${r.id}`,
+      title: r.title,
+      content: r.content,
+      source_type: 'library',
+      source_id: r.id,
+      author: r.author,
+      created_at: new Date(r.created_at).toISOString(),
+      url: `/library?doc=${r.id}`,
+    });
 
   // Forum
-  const forumRows = sqlite.prepare('SELECT m.id, t.title, m.content, m.author, m.created_at, m.thread_id FROM forum_messages m JOIN forum_threads t ON m.thread_id = t.id').all() as any[];
-  for (const r of forumRows) docs.push({ search_id: `forum_${r.id}`, title: r.title, content: r.content, source_type: 'forum', source_id: r.id, author: r.author, created_at: r.created_at, url: `/forum?thread=${r.thread_id}` });
+  const forumRows = sqlite
+    .prepare(
+      'SELECT m.id, t.title, m.content, m.author, m.created_at, m.thread_id FROM forum_messages m JOIN forum_threads t ON m.thread_id = t.id',
+    )
+    .all() as any[];
+  for (const r of forumRows)
+    docs.push({
+      search_id: `forum_${r.id}`,
+      title: r.title,
+      content: r.content,
+      source_type: 'forum',
+      source_id: r.id,
+      author: r.author,
+      created_at: r.created_at,
+      url: `/forum?thread=${r.thread_id}`,
+    });
 
   // Tasks
-  const taskRows = sqlite.prepare('SELECT id, title, description, assigned_to, created_at FROM tasks').all() as any[];
-  for (const r of taskRows) docs.push({ search_id: `task_${r.id}`, title: r.title, content: r.description || '', source_type: 'task', source_id: r.id, author: r.assigned_to || '', created_at: r.created_at, url: `/board?task=${r.id}` });
+  const taskRows = sqlite
+    .prepare('SELECT id, title, description, assigned_to, created_at FROM tasks')
+    .all() as any[];
+  for (const r of taskRows)
+    docs.push({
+      search_id: `task_${r.id}`,
+      title: r.title,
+      content: r.description || '',
+      source_type: 'task',
+      source_id: r.id,
+      author: r.assigned_to || '',
+      created_at: r.created_at,
+      url: `/board?task=${r.id}`,
+    });
 
   // Specs (file content)
-  const specRows = sqlite.prepare('SELECT id, title, author, file_path, created_at FROM spec_reviews').all() as any[];
+  const specRows = sqlite
+    .prepare('SELECT id, title, author, file_path, created_at FROM spec_reviews')
+    .all() as any[];
   for (const r of specRows) {
     const fp = path.join(repoBase, r.file_path);
     const content = fs.existsSync(fp) ? fs.readFileSync(fp, 'utf-8') : r.title;
-    docs.push({ search_id: `spec_${r.id}`, title: r.title, content, source_type: 'spec', source_id: r.id, author: r.author, created_at: r.created_at, url: `/specs?spec=${r.id}` });
+    docs.push({
+      search_id: `spec_${r.id}`,
+      title: r.title,
+      content,
+      source_type: 'spec',
+      source_id: r.id,
+      author: r.author,
+      created_at: r.created_at,
+      url: `/specs?spec=${r.id}`,
+    });
   }
 
   // Risks
-  const riskRows = sqlite.prepare('SELECT id, title, description, created_by, created_at FROM risks').all() as any[];
-  for (const r of riskRows) docs.push({ search_id: `risk_${r.id}`, title: r.title, content: r.description || '', source_type: 'risk', source_id: r.id, author: r.created_by, created_at: r.created_at, url: '/risk' });
+  const riskRows = sqlite
+    .prepare('SELECT id, title, description, created_by, created_at FROM risks')
+    .all() as any[];
+  for (const r of riskRows)
+    docs.push({
+      search_id: `risk_${r.id}`,
+      title: r.title,
+      content: r.description || '',
+      source_type: 'risk',
+      source_id: r.id,
+      author: r.created_by,
+      created_at: r.created_at,
+      url: '/risk',
+    });
 
   // Shelves (T#351)
-  const shelfRows = sqlite.prepare('SELECT id, name, description, icon, color, created_by, created_at FROM library_shelves').all() as any[];
-  for (const r of shelfRows) docs.push({ search_id: `shelf_${r.id}`, title: r.name, content: r.description || '', source_type: 'shelf', source_id: r.id, author: r.created_by, created_at: r.created_at, url: `/library` });
+  const shelfRows = sqlite
+    .prepare(
+      'SELECT id, name, description, icon, color, created_by, created_at FROM library_shelves',
+    )
+    .all() as any[];
+  for (const r of shelfRows)
+    docs.push({
+      search_id: `shelf_${r.id}`,
+      title: r.name,
+      content: r.description || '',
+      source_type: 'shelf',
+      source_id: r.id,
+      author: r.created_by,
+      created_at: r.created_at,
+      url: `/library`,
+    });
 
   if (docs.length > 0) {
     const task = await index.addDocuments(docs);
@@ -108,14 +190,18 @@ export async function backfillMeilisearch(): Promise<void> {
 // Index specs by reading their markdown files
 function indexSpecFiles(): void {
   if (!sqlite) return;
-  const specs = sqlite.prepare('SELECT id, title, author, file_path, repo, created_at FROM spec_reviews').all() as any[];
+  const specs = sqlite
+    .prepare('SELECT id, title, author, file_path, repo, created_at FROM spec_reviews')
+    .all() as any[];
   const repoBase = path.join(import.meta.dirname || __dirname, '..');
   for (const spec of specs) {
     try {
       const filePath = path.join(repoBase, spec.file_path);
       const content = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : spec.title;
       searchIndexUpsert('spec', spec.id, spec.title, content, spec.author, spec.created_at);
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
 }
 
@@ -124,35 +210,71 @@ function indexSpecFiles(): void {
 // ============================================================================
 
 // Helper: index a document
-export function searchIndexUpsert(sourceType: string, sourceId: number, title: string, content: string, author: string, createdAt: string, url?: string): void {
+export function searchIndexUpsert(
+  sourceType: string,
+  sourceId: number,
+  title: string,
+  content: string,
+  author: string,
+  createdAt: string,
+  url?: string,
+): void {
   if (!sqlite) return;
   const resolvedUrl = searchUrlFor(sourceType, sourceId, url);
   // FTS5 (sync)
   try {
-    sqlite.prepare('DELETE FROM search_index WHERE source_type = ? AND source_id = ?').run(sourceType, String(sourceId));
-    sqlite.prepare('INSERT INTO search_index(title, content, source_type, source_id, author, created_at) VALUES (?, ?, ?, ?, ?, ?)').run(title, content, sourceType, String(sourceId), author, createdAt);
-  } catch { /* ignore indexing errors */ }
+    sqlite
+      .prepare('DELETE FROM search_index WHERE source_type = ? AND source_id = ?')
+      .run(sourceType, String(sourceId));
+    sqlite
+      .prepare(
+        'INSERT INTO search_index(title, content, source_type, source_id, author, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+      )
+      .run(title, content, sourceType, String(sourceId), author, createdAt);
+  } catch {
+    /* ignore indexing errors */
+  }
   // Meilisearch (async, fire-and-forget)
   if (meili && meiliAvailable) {
-    meili.index('denbook').addDocuments([{
-      search_id: `${sourceType}_${sourceId}`, title, content, source_type: sourceType,
-      source_id: sourceId, author, created_at: createdAt, url: resolvedUrl,
-    }]).catch(() => {});
+    meili
+      .index('denbook')
+      .addDocuments([
+        {
+          search_id: `${sourceType}_${sourceId}`,
+          title,
+          content,
+          source_type: sourceType,
+          source_id: sourceId,
+          author,
+          created_at: createdAt,
+          url: resolvedUrl,
+        },
+      ])
+      .catch(() => {});
   }
 }
 
 export function searchIndexDelete(sourceType: string, sourceId: number): void {
   if (!sqlite) return;
-  try { sqlite.prepare('DELETE FROM search_index WHERE source_type = ? AND source_id = ?').run(sourceType, String(sourceId)); } catch { /* ignore */ }
+  try {
+    sqlite
+      .prepare('DELETE FROM search_index WHERE source_type = ? AND source_id = ?')
+      .run(sourceType, String(sourceId));
+  } catch {
+    /* ignore */
+  }
   if (meili && meiliAvailable) {
-    meili.index('denbook').deleteDocument(`${sourceType}_${sourceId}`).catch(() => {});
+    meili
+      .index('denbook')
+      .deleteDocument(`${sourceType}_${sourceId}`)
+      .catch(() => {});
   }
 }
 
 // Sanitize FTS5 query — prevent column targeting
 function sanitizeFtsQuery(raw: string): string {
   const terms = raw.match(/"[^"]*"|[^\s]+/g) || [];
-  return terms.map(t => t.startsWith('"') ? t : `"${t.replace(/"/g, '')}"`).join(' ');
+  return terms.map((t) => (t.startsWith('"') ? t : `"${t.replace(/"/g, '')}"`)).join(' ');
 }
 
 // FTS5 search (used as fallback)
@@ -163,43 +285,63 @@ function fts5Search(q: string, type: string | undefined, limit: number, offset: 
 
   let where = 'search_index MATCH ?';
   const params: any[] = [sanitized];
-  if (type && VALID_SOURCE_TYPES.includes(type)) { where += ' AND source_type = ?'; params.push(type); }
+  if (type && VALID_SOURCE_TYPES.includes(type)) {
+    where += ' AND source_type = ?';
+    params.push(type);
+  }
 
-  const total = (sqlite.prepare(`SELECT COUNT(*) as c FROM search_index WHERE ${where}`).get(...params) as any)?.c || 0;
-  const rows = sqlite.prepare(
-    `SELECT source_type, source_id, title, snippet(search_index, 1, '<mark>', '</mark>', '...', 40) as snippet, author, rank, created_at
-     FROM search_index WHERE ${where} ORDER BY rank LIMIT ? OFFSET ?`
-  ).all(...params, limit, offset) as any[];
+  const total =
+    (sqlite.prepare(`SELECT COUNT(*) as c FROM search_index WHERE ${where}`).get(...params) as any)
+      ?.c || 0;
+  const rows = sqlite
+    .prepare(
+      `SELECT source_type, source_id, title, snippet(search_index, 1, '<mark>', '</mark>', '...', 40) as snippet, author, rank, created_at
+     FROM search_index WHERE ${where} ORDER BY rank LIMIT ? OFFSET ?`,
+    )
+    .all(...params, limit, offset) as any[];
 
   const urlMap: Record<string, (id: string) => string> = {
     library: (id) => `/library?doc=${id}`,
-    spec: (id) => `/specs?spec=${id}`, risk: () => `/risk`, task: (id) => `/board?task=${id}`,
+    spec: (id) => `/specs?spec=${id}`,
+    risk: () => `/risk`,
+    task: (id) => `/board?task=${id}`,
     shelf: () => `/library`,
   };
 
   // Forum source_id is message ID — look up thread_id for URL
   function forumUrl(messageId: string): string {
     if (!sqlite) return '#';
-    const row = sqlite.prepare('SELECT thread_id FROM forum_messages WHERE id = ?').get(parseInt(messageId, 10)) as any;
+    const row = sqlite
+      .prepare('SELECT thread_id FROM forum_messages WHERE id = ?')
+      .get(parseInt(messageId, 10)) as any;
     return row ? `/forum?thread=${row.thread_id}` : '#';
   }
 
   // Deduplicate by URL — keep first (best-ranked) result per URL
   const seen = new Set<string>();
   const deduped = rows.reduce((acc: any[], r: any) => {
-    const url = r.source_type === 'forum' ? forumUrl(r.source_id) : (urlMap[r.source_type] || (() => '#'))(r.source_id);
+    const url =
+      r.source_type === 'forum'
+        ? forumUrl(r.source_id)
+        : (urlMap[r.source_type] || (() => '#'))(r.source_id);
     if (url !== '#' && seen.has(url)) return acc;
     if (url !== '#') seen.add(url);
     acc.push({
-      source_type: r.source_type, source_id: r.source_id, title: r.title,
-      snippet: r.snippet, author: r.author, url,
+      source_type: r.source_type,
+      source_id: r.source_id,
+      title: r.title,
+      snippet: r.snippet,
+      author: r.author,
+      url,
     });
     return acc;
   }, []);
 
   return {
     results: deduped,
-    total: deduped.length, query: q, engine: 'fts5' as const,
+    total: deduped.length,
+    query: q,
+    engine: 'fts5' as const,
   };
 }
 
@@ -212,14 +354,19 @@ export function initSearch(sqliteDb: Database): void {
 
   // Create FTS5 virtual table (synchronous — must complete before any search hits)
   try {
-    sqlite.prepare(`CREATE VIRTUAL TABLE IF NOT EXISTS search_index USING fts5(
+    sqlite
+      .prepare(`CREATE VIRTUAL TABLE IF NOT EXISTS search_index USING fts5(
       title, content, source_type, source_id UNINDEXED, author, created_at UNINDEXED,
       tokenize = 'porter unicode61'
-    )`).run();
-  } catch { /* already exists */ }
+    )`)
+      .run();
+  } catch {
+    /* already exists */
+  }
 
   // Backfill if FTS5 index is empty (synchronous)
-  const searchCount = (sqlite.prepare('SELECT COUNT(*) as c FROM search_index').get() as any)?.c || 0;
+  const searchCount =
+    (sqlite.prepare('SELECT COUNT(*) as c FROM search_index').get() as any)?.c || 0;
   if (searchCount === 0) {
     console.log('[SEARCH] Backfilling FTS5 search index...');
     const backfillStmts = [
@@ -236,7 +383,11 @@ export function initSearch(sqliteDb: Database): void {
        SELECT name, COALESCE(description,''), 'shelf', id, created_by, created_at FROM library_shelves`,
     ];
     for (const stmt of backfillStmts) {
-      try { sqlite.prepare(stmt).run(); } catch (e) { console.log(`[SEARCH] Backfill warning: ${e}`); }
+      try {
+        sqlite.prepare(stmt).run();
+      } catch (e) {
+        console.log(`[SEARCH] Backfill warning: ${e}`);
+      }
     }
     indexSpecFiles();
     const total = (sqlite.prepare('SELECT COUNT(*) as c FROM search_index').get() as any)?.c || 0;
@@ -244,14 +395,21 @@ export function initSearch(sqliteDb: Database): void {
   }
 
   // Init Meilisearch (async, fire-and-forget — matches original initMeilisearch().then(...) shape)
-  initMeilisearch().then(() => {
-    if (meiliAvailable && meili) {
-      meili.index('denbook').getStats().then(stats => {
-        if (stats.numberOfDocuments === 0) backfillMeilisearch();
-        else console.log(`[MEILI] Index has ${stats.numberOfDocuments} docs, skipping backfill`);
-      }).catch(() => backfillMeilisearch());
-    }
-  }).catch(() => {});
+  initMeilisearch()
+    .then(() => {
+      if (meiliAvailable && meili) {
+        meili
+          .index('denbook')
+          .getStats()
+          .then((stats) => {
+            if (stats.numberOfDocuments === 0) backfillMeilisearch();
+            else
+              console.log(`[MEILI] Index has ${stats.numberOfDocuments} docs, skipping backfill`);
+          })
+          .catch(() => backfillMeilisearch());
+      }
+    })
+    .catch(() => {});
 }
 
 // ============================================================================
@@ -262,10 +420,23 @@ interface SearchHelpers {
   hasSessionAuth: (c: Context) => boolean;
   isLocalNetwork: (c: Context) => boolean;
   isTrustedRequest: (c: Context) => boolean;
-  handleSearch: (q: string, type: string, limit: number, offset: number, mode: 'hybrid' | 'fts' | 'vector', project?: string, cwd?: string, model?: string) => Promise<any>;
+  handleSearch: (
+    q: string,
+    type: string,
+    limit: number,
+    offset: number,
+    mode: 'hybrid' | 'fts' | 'vector',
+    project?: string,
+    cwd?: string,
+    model?: string,
+  ) => Promise<any>;
 }
 
-export function registerSearchRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: SearchHelpers): void {
+export function registerSearchRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: SearchHelpers,
+): void {
   const { hasSessionAuth, isLocalNetwork, isTrustedRequest, handleSearch } = helpers;
   // sqlite is already captured via initSearch; sqliteDb param matches DI pattern
 
@@ -309,26 +480,92 @@ export function registerSearchRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     const taskMatch = q.match(/^(?:t[:#]?|task)\s*[:#]?(\d+)$/i);
     if (taskMatch) {
       const id = parseInt(taskMatch[1], 10);
-      const task = sqliteDb.prepare('SELECT id, title, assigned_to FROM tasks WHERE id = ?').get(id) as any;
-      if (task) return c.json({ results: [{ source_type: 'task', source_id: task.id, title: task.title, snippet: '', author: task.assigned_to || '', url: `/board?task=${task.id}` }], total: 1, query: q, engine: 'id_lookup' });
+      const task = sqliteDb
+        .prepare('SELECT id, title, assigned_to FROM tasks WHERE id = ?')
+        .get(id) as any;
+      if (task)
+        return c.json({
+          results: [
+            {
+              source_type: 'task',
+              source_id: task.id,
+              title: task.title,
+              snippet: '',
+              author: task.assigned_to || '',
+              url: `/board?task=${task.id}`,
+            },
+          ],
+          total: 1,
+          query: q,
+          engine: 'id_lookup',
+        });
     }
     const threadMatch = q.match(/^(?:f[:#]?|thread)\s*[:#]?(\d+)$/i);
     if (threadMatch) {
       const id = parseInt(threadMatch[1], 10);
-      const thread = sqliteDb.prepare('SELECT id, title FROM forum_threads WHERE id = ?').get(id) as any;
-      if (thread) return c.json({ results: [{ source_type: 'forum', source_id: thread.id, title: thread.title, snippet: '', author: '', url: `/forum?thread=${thread.id}` }], total: 1, query: q, engine: 'id_lookup' });
+      const thread = sqliteDb
+        .prepare('SELECT id, title FROM forum_threads WHERE id = ?')
+        .get(id) as any;
+      if (thread)
+        return c.json({
+          results: [
+            {
+              source_type: 'forum',
+              source_id: thread.id,
+              title: thread.title,
+              snippet: '',
+              author: '',
+              url: `/forum?thread=${thread.id}`,
+            },
+          ],
+          total: 1,
+          query: q,
+          engine: 'id_lookup',
+        });
     }
     const specMatch = q.match(/^(?:s[:#]?|spec)\s*[:#]?(\d+)$/i);
     if (specMatch) {
       const id = parseInt(specMatch[1], 10);
-      const spec = sqliteDb.prepare('SELECT id, title FROM spec_reviews WHERE id = ?').get(id) as any;
-      if (spec) return c.json({ results: [{ source_type: 'spec', source_id: spec.id, title: spec.title, snippet: '', author: '', url: `/specs?spec=${spec.id}` }], total: 1, query: q, engine: 'id_lookup' });
+      const spec = sqliteDb
+        .prepare('SELECT id, title FROM spec_reviews WHERE id = ?')
+        .get(id) as any;
+      if (spec)
+        return c.json({
+          results: [
+            {
+              source_type: 'spec',
+              source_id: spec.id,
+              title: spec.title,
+              snippet: '',
+              author: '',
+              url: `/specs?spec=${spec.id}`,
+            },
+          ],
+          total: 1,
+          query: q,
+          engine: 'id_lookup',
+        });
     }
     const libMatch = q.match(/^(?:l[:#]?|library)\s*[:#]?(\d+)$/i);
     if (libMatch) {
       const id = parseInt(libMatch[1], 10);
       const entry = sqliteDb.prepare('SELECT id, title FROM library WHERE id = ?').get(id) as any;
-      if (entry) return c.json({ results: [{ source_type: 'library', source_id: entry.id, title: entry.title, snippet: '', author: '', url: `/library?doc=${entry.id}` }], total: 1, query: q, engine: 'id_lookup' });
+      if (entry)
+        return c.json({
+          results: [
+            {
+              source_type: 'library',
+              source_id: entry.id,
+              title: entry.title,
+              snippet: '',
+              author: '',
+              url: `/library?doc=${entry.id}`,
+            },
+          ],
+          total: 1,
+          query: q,
+          engine: 'id_lookup',
+        });
     }
 
     let type = c.req.query('type') || undefined;
@@ -337,10 +574,19 @@ export function registerSearchRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
 
     // Type aliases: "thread" → "forum", "post" → "forum", "entry" → "library", etc.
     const TYPE_ALIASES: Record<string, string> = {
-      thread: 'forum', post: 'forum', message: 'forum', f: 'forum',
-      entry: 'library', doc: 'library', document: 'library', l: 'library',
-      issue: 'task', ticket: 'task', t: 'task',
-      specification: 'spec', s: 'spec',
+      thread: 'forum',
+      post: 'forum',
+      message: 'forum',
+      f: 'forum',
+      entry: 'library',
+      doc: 'library',
+      document: 'library',
+      l: 'library',
+      issue: 'task',
+      ticket: 'task',
+      t: 'task',
+      specification: 'spec',
+      s: 'spec',
       r: 'risk',
     };
 
@@ -380,9 +626,12 @@ export function registerSearchRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     // Try Meilisearch first
     if (meili && meiliAvailable) {
       try {
-        const filter = type && VALID_SOURCE_TYPES.includes(type) ? `source_type = "${type}"` : undefined;
+        const filter =
+          type && VALID_SOURCE_TYPES.includes(type) ? `source_type = "${type}"` : undefined;
         const results = await meili.index('denbook').search(q, {
-          limit, offset, filter: filter || undefined,
+          limit,
+          offset,
+          filter: filter || undefined,
           attributesToHighlight: ['title', 'content'],
           attributesToCrop: ['content'],
           cropLength: 50,
@@ -394,9 +643,12 @@ export function registerSearchRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
           if (url !== '#' && seen.has(url)) return acc;
           if (url !== '#') seen.add(url);
           acc.push({
-            source_type: h.source_type, source_id: h.source_id, title: h.title,
+            source_type: h.source_type,
+            source_id: h.source_id,
+            title: h.title,
             snippet: h._formatted?.content || h.content?.slice(0, 200) || '',
-            author: h.author, url,
+            author: h.author,
+            url,
           });
           return acc;
         }, []);
@@ -436,11 +688,17 @@ export function registerSearchRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
        SELECT name, COALESCE(description,''), 'shelf', id, created_by, created_at FROM library_shelves`,
     ];
     for (const stmt of stmts) {
-      try { sqliteDb.prepare(stmt).run(); } catch { /* skip */ }
+      try {
+        sqliteDb.prepare(stmt).run();
+      } catch {
+        /* skip */
+      }
     }
     indexSpecFiles();
     const indexed: Record<string, number> = {};
-    const rows = sqliteDb.prepare('SELECT source_type, COUNT(*) as c FROM search_index GROUP BY source_type').all() as any[];
+    const rows = sqliteDb
+      .prepare('SELECT source_type, COUNT(*) as c FROM search_index GROUP BY source_type')
+      .all() as any[];
     for (const r of rows) indexed[r.source_type] = r.c;
     const fts5Total = Object.values(indexed).reduce((a, b) => a + b, 0);
 
@@ -452,10 +710,17 @@ export function registerSearchRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
         await backfillMeilisearch();
         const stats = await meili.index('denbook').getStats();
         meiliTotal = stats.numberOfDocuments;
-      } catch { /* skip */ }
+      } catch {
+        /* skip */
+      }
     }
 
-    return c.json({ reindexed: true, total: fts5Total, indexed, meili: meiliAvailable ? { total: meiliTotal } : null });
+    return c.json({
+      reindexed: true,
+      total: fts5Total,
+      indexed,
+      meili: meiliAvailable ? { total: meiliTotal } : null,
+    });
   });
 
   // GET /api/search/status — integrity check
@@ -463,28 +728,36 @@ export function registerSearchRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     const indexed: Record<string, number> = {};
     const source: Record<string, number> = {};
 
-    const indexedRows = sqliteDb.prepare('SELECT source_type, COUNT(*) as c FROM search_index GROUP BY source_type').all() as any[];
+    const indexedRows = sqliteDb
+      .prepare('SELECT source_type, COUNT(*) as c FROM search_index GROUP BY source_type')
+      .all() as any[];
     for (const r of indexedRows) indexed[r.source_type] = r.c;
 
     source.library = (sqliteDb.prepare('SELECT COUNT(*) as c FROM library').get() as any)?.c || 0;
-    source.forum = (sqliteDb.prepare('SELECT COUNT(*) as c FROM forum_messages').get() as any)?.c || 0;
+    source.forum =
+      (sqliteDb.prepare('SELECT COUNT(*) as c FROM forum_messages').get() as any)?.c || 0;
     source.spec = (sqliteDb.prepare('SELECT COUNT(*) as c FROM spec_reviews').get() as any)?.c || 0;
     source.risk = (sqliteDb.prepare('SELECT COUNT(*) as c FROM risks').get() as any)?.c || 0;
     source.task = (sqliteDb.prepare('SELECT COUNT(*) as c FROM tasks').get() as any)?.c || 0;
-    source.shelf = (sqliteDb.prepare('SELECT COUNT(*) as c FROM library_shelves').get() as any)?.c || 0;
+    source.shelf =
+      (sqliteDb.prepare('SELECT COUNT(*) as c FROM library_shelves').get() as any)?.c || 0;
 
-    const drift = Object.keys(source).some(k => (indexed[k] || 0) !== source[k]);
+    const drift = Object.keys(source).some((k) => (indexed[k] || 0) !== source[k]);
 
     let meiliStatus: any = { status: 'unavailable' };
     if (meili && meiliAvailable) {
       try {
         const stats = await meili.index('denbook').getStats();
         meiliStatus = { status: 'available', indexed: stats.numberOfDocuments };
-      } catch { meiliStatus = { status: 'error' }; }
+      } catch {
+        meiliStatus = { status: 'error' };
+      }
     }
 
     return c.json({
-      indexed, source, drift,
+      indexed,
+      source,
+      drift,
       total_indexed: Object.values(indexed).reduce((a, b) => a + b, 0),
       engine: meiliAvailable ? 'meilisearch' : 'fts5',
       meilisearch: meiliStatus,

--- a/src/server-legacy.ts
+++ b/src/server-legacy.ts
@@ -27,14 +27,7 @@ import {
 } from './process-manager/index.ts';
 
 // Config constants (no DB dependency)
-import {
-  PORT,
-  REPO_ROOT,
-  DB_PATH,
-  UI_PATH,
-  ARTHUR_UI_PATH,
-  DASHBOARD_PATH,
-} from './config.ts';
+import { PORT, REPO_ROOT, DB_PATH, UI_PATH, ARTHUR_UI_PATH, DASHBOARD_PATH } from './config.ts';
 import { sqlite as db, closeDb } from './db/index.ts';
 
 import {
@@ -43,13 +36,13 @@ import {
   handleList,
   handleStats,
   handleGraph,
-  handleLearn
+  handleLearn,
 } from './server/handlers.ts';
 
 import {
   handleDashboardSummary,
   handleDashboardActivity,
-  handleDashboardGrowth
+  handleDashboardGrowth,
 } from './server/dashboard.ts';
 
 import { handleContext } from './server/context.ts';
@@ -59,7 +52,7 @@ import {
   listThreads,
   getFullThread,
   getMessages,
-  updateThreadStatus
+  updateThreadStatus,
 } from './forum/handler.ts';
 
 import path from 'path';
@@ -113,15 +106,25 @@ const dataDir = path.join(import.meta.dirname || __dirname, '..');
 configure({ dataDir });
 
 // Write PID file for process tracking
-writePidFile({ pid: process.pid, port: Number(PORT), startedAt: new Date().toISOString(), name: 'oracle-http' });
+writePidFile({
+  pid: process.pid,
+  port: Number(PORT),
+  startedAt: new Date().toISOString(),
+  name: 'oracle-http',
+});
 
 // Register graceful shutdown handlers
 registerSignalHandlers(async () => {
   console.log('\n🔮 Shutting down gracefully...');
   await performGracefulShutdown({
     resources: [
-      { close: () => { closeDb(); return Promise.resolve(); } }
-    ]
+      {
+        close: () => {
+          closeDb();
+          return Promise.resolve();
+        },
+      },
+    ],
   });
   removePidFile();
   console.log('👋 Oracle v2 HTTP Server stopped.');
@@ -154,7 +157,9 @@ const server = http.createServer(async (req, res) => {
     // POST /api/thread - Send message to thread
     if (pathname === '/api/thread' && req.method === 'POST') {
       let body = '';
-      req.on('data', chunk => { body += chunk.toString(); });
+      req.on('data', (chunk) => {
+        body += chunk.toString();
+      });
       req.on('end', async () => {
         try {
           const data = JSON.parse(body);
@@ -167,20 +172,28 @@ const server = http.createServer(async (req, res) => {
             message: data.message,
             threadId: data.thread_id,
             title: data.title,
-            role: data.role || 'human'
+            role: data.role || 'human',
           });
-          res.end(JSON.stringify({
-            thread_id: result.threadId,
-            message_id: result.messageId,
-            status: result.status,
-            oracle_response: result.oracleResponse,
-            issue_url: result.issueUrl
-          }, null, 2));
+          res.end(
+            JSON.stringify(
+              {
+                thread_id: result.threadId,
+                message_id: result.messageId,
+                status: result.status,
+                oracle_response: result.oracleResponse,
+                issue_url: result.issueUrl,
+              },
+              null,
+              2,
+            ),
+          );
         } catch (error) {
           res.statusCode = 500;
-          res.end(JSON.stringify({
-            error: error instanceof Error ? error.message : 'Unknown error'
-          }));
+          res.end(
+            JSON.stringify({
+              error: error instanceof Error ? error.message : 'Unknown error',
+            }),
+          );
         }
       });
       return;
@@ -200,24 +213,30 @@ const server = http.createServer(async (req, res) => {
         res.end(JSON.stringify({ error: 'Thread not found' }));
         return;
       }
-      res.end(JSON.stringify({
-        thread: {
-          id: threadData.thread.id,
-          title: threadData.thread.title,
-          status: threadData.thread.status,
-          created_at: new Date(threadData.thread.createdAt).toISOString(),
-          issue_url: threadData.thread.issueUrl
-        },
-        messages: threadData.messages.map(m => ({
-          id: m.id,
-          role: m.role,
-          content: m.content,
-          author: m.author,
-          principles_found: m.principlesFound,
-          patterns_found: m.patternsFound,
-          created_at: new Date(m.createdAt).toISOString()
-        }))
-      }, null, 2));
+      res.end(
+        JSON.stringify(
+          {
+            thread: {
+              id: threadData.thread.id,
+              title: threadData.thread.title,
+              status: threadData.thread.status,
+              created_at: new Date(threadData.thread.createdAt).toISOString(),
+              issue_url: threadData.thread.issueUrl,
+            },
+            messages: threadData.messages.map((m) => ({
+              id: m.id,
+              role: m.role,
+              content: m.content,
+              author: m.author,
+              principles_found: m.principlesFound,
+              patterns_found: m.patternsFound,
+              created_at: new Date(m.createdAt).toISOString(),
+            })),
+          },
+          null,
+          2,
+        ),
+      );
       return;
     }
 
@@ -225,7 +244,9 @@ const server = http.createServer(async (req, res) => {
     if (pathname?.match(/^\/api\/thread\/\d+\/status$/) && req.method === 'PATCH') {
       const threadId = parseInt(pathname.split('/')[3], 10);
       let body = '';
-      req.on('data', chunk => { body += chunk.toString(); });
+      req.on('data', (chunk) => {
+        body += chunk.toString();
+      });
       req.on('end', () => {
         try {
           const data = JSON.parse(body);
@@ -247,7 +268,9 @@ const server = http.createServer(async (req, res) => {
     // POST /learn
     if (pathname === '/api/learn' && req.method === 'POST') {
       let body = '';
-      req.on('data', chunk => { body += chunk.toString(); });
+      req.on('data', (chunk) => {
+        body += chunk.toString();
+      });
       req.on('end', () => {
         try {
           const data = JSON.parse(body);
@@ -260,9 +283,11 @@ const server = http.createServer(async (req, res) => {
           res.end(JSON.stringify(result, null, 2));
         } catch (error) {
           res.statusCode = 500;
-          res.end(JSON.stringify({
-            error: error instanceof Error ? error.message : 'Unknown error'
-          }));
+          res.end(
+            JSON.stringify({
+              error: error instanceof Error ? error.message : 'Unknown error',
+            }),
+          );
         }
       });
       return;
@@ -310,11 +335,11 @@ const server = http.createServer(async (req, res) => {
             query.q as string,
             (query.type as string) || 'all',
             parseInt(query.limit as string) || 10,
-            parseInt(query.offset as string) || 0
+            parseInt(query.offset as string) || 0,
           );
           result = {
             ...searchResult,
-            query: query.q
+            query: query.q,
           };
         }
         break;
@@ -330,12 +355,14 @@ const server = http.createServer(async (req, res) => {
       case '/api/logs':
         // Return recent search logs for debugging
         try {
-          const logs = db.prepare(`
+          const logs = db
+            .prepare(`
             SELECT query, type, mode, results_count, search_time_ms, created_at, project
             FROM search_log
             ORDER BY created_at DESC
             LIMIT ?
-          `).all(parseInt(query.limit as string) || 20);
+          `)
+            .all(parseInt(query.limit as string) || 20);
           result = { logs, total: logs.length };
         } catch (e) {
           result = { logs: [], error: 'Log table not found' };
@@ -347,7 +374,7 @@ const server = http.createServer(async (req, res) => {
           (query.type as string) || 'all',
           parseInt(query.limit as string) || 10,
           parseInt(query.offset as string) || 0,
-          query.group !== 'false'  // default true, pass group=false to disable
+          query.group !== 'false', // default true, pass group=false to disable
         );
         break;
 
@@ -362,15 +389,11 @@ const server = http.createServer(async (req, res) => {
         break;
 
       case '/api/dashboard/activity':
-        result = handleDashboardActivity(
-          parseInt(query.days as string) || 7
-        );
+        result = handleDashboardActivity(parseInt(query.days as string) || 7);
         break;
 
       case '/api/dashboard/growth':
-        result = handleDashboardGrowth(
-          (query.period as string) || 'week'
-        );
+        result = handleDashboardGrowth((query.period as string) || 'week');
         break;
 
       case '/api/context':
@@ -419,18 +442,18 @@ const server = http.createServer(async (req, res) => {
         const threadList = listThreads({
           status: query.status as any,
           limit: parseInt(query.limit as string) || 20,
-          offset: parseInt(query.offset as string) || 0
+          offset: parseInt(query.offset as string) || 0,
         });
         result = {
-          threads: threadList.threads.map(t => ({
+          threads: threadList.threads.map((t) => ({
             id: t.id,
             title: t.title,
             status: t.status,
             message_count: getMessages(t.id).total,
             created_at: new Date(t.createdAt).toISOString(),
-            issue_url: t.issueUrl
+            issue_url: t.issueUrl,
           })),
-          total: threadList.total
+          total: threadList.total,
         };
         break;
 
@@ -466,17 +489,19 @@ const server = http.createServer(async (req, res) => {
             'GET /dashboard/growth?period=week - Growth over time',
             'GET /threads - List discussion threads',
             'GET /thread/:id - Get thread with messages',
-            'POST /thread - Send message to thread (Oracle auto-responds)'
-          ]
+            'POST /thread - Send message to thread (Oracle auto-responds)',
+          ],
         };
     }
 
     res.end(JSON.stringify(result, null, 2));
   } catch (error) {
     res.statusCode = 500;
-    res.end(JSON.stringify({
-      error: error instanceof Error ? error.message : 'Unknown error'
-    }));
+    res.end(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    );
   }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,13 @@
 import { type Context, type Next } from 'hono';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { swaggerUI } from '@hono/swagger-ui';
-import { healthRoute, authStatusRoute, authLoginRoute, authLogoutRoute, OPENAPI_INFO } from './server/openapi.ts';
+import {
+  healthRoute,
+  authStatusRoute,
+  authLoginRoute,
+  authLogoutRoute,
+  OPENAPI_INFO,
+} from './server/openapi.ts';
 import { cors } from 'hono/cors';
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import { createHmac, timingSafeEqual } from 'crypto';
@@ -25,12 +31,7 @@ import {
 import { getVaultPsiRoot } from './vault/handler.ts';
 
 // Config constants (no DB dependency)
-import {
-  PORT,
-  ORACLE_DATA_DIR,
-  REPO_ROOT,
-  DB_PATH,
-} from './config.ts';
+import { PORT, ORACLE_DATA_DIR, REPO_ROOT, DB_PATH } from './config.ts';
 
 import { eq, desc, gt, sql } from 'drizzle-orm';
 import {
@@ -62,7 +63,7 @@ import {
   handleSimilar,
   handleMap,
   handleMap3d,
-  handleVectorStats
+  handleVectorStats,
 } from './server/handlers.ts';
 
 import { handleRead } from './tools/read.ts';
@@ -70,7 +71,7 @@ import { handleRead } from './tools/read.ts';
 import {
   handleDashboardSummary,
   handleDashboardActivity,
-  handleDashboardGrowth
+  handleDashboardGrowth,
 } from './server/dashboard.ts';
 
 import { handleContext } from './server/context.ts';
@@ -85,7 +86,6 @@ import {
   updateThreadStatus,
   addMessage,
 } from './forum/handler.ts';
-
 
 import { enqueueNotification } from './notify.ts';
 import { rbacMiddleware, getGuestAllowlist } from './server/rbac.ts';
@@ -105,7 +105,12 @@ import { registerGuestRoutes } from './guest/routes.ts';
 import { registerLibraryRoutes } from './library/routes.ts';
 import { registerRiskRoutes } from './risk/routes.ts';
 import { registerTelegramRoutes } from './telegram/routes.ts';
-import { registerSearchRoutes, initSearch, searchIndexUpsert, searchIndexDelete } from './search/routes.ts';
+import {
+  registerSearchRoutes,
+  initSearch,
+  searchIndexUpsert,
+  searchIndexDelete,
+} from './search/routes.ts';
 import { registerSchedulerRoutes, initScheduler } from './scheduler/routes.ts';
 import { initDaemons, registerDaemonRoutes } from './daemons/routes.ts';
 import { registerBoardRoutes } from './board/routes.ts';
@@ -145,10 +150,7 @@ import {
   initGuestSafetyMigrations,
 } from './server/guest-safety.ts';
 
-import {
-  logSecurityEvent,
-  generateRequestId,
-} from './server/security-logger.ts';
+import { logSecurityEvent, generateRequestId } from './server/security-logger.ts';
 
 import {
   createToken,
@@ -168,15 +170,12 @@ import {
   getTraceChain,
   linkTraces,
   unlinkTraces,
-  getTraceLinkedChain
+  getTraceLinkedChain,
 } from './trace/handler.ts';
 
 // Reset stale indexing status on startup using Drizzle
 try {
-  db.update(indexingStatus)
-    .set({ isIndexing: 0 })
-    .where(eq(indexingStatus.id, 1))
-    .run();
+  db.update(indexingStatus).set({ isIndexing: 0 }).where(eq(indexingStatus.id, 1)).run();
   console.log('🔮 Reset indexing status on startup');
 } catch (e) {
   // Table might not exist yet - that's fine
@@ -188,9 +187,10 @@ async function withRetry<T>(fn: () => T | Promise<T>, maxRetries = 3, delayMs = 
     try {
       return await fn();
     } catch (err: any) {
-      const isBusy = err?.message?.includes('SQLITE_BUSY') || err?.message?.includes('database is locked');
+      const isBusy =
+        err?.message?.includes('SQLITE_BUSY') || err?.message?.includes('database is locked');
       if (isBusy && attempt < maxRetries) {
-        await new Promise(r => setTimeout(r, delayMs * (attempt + 1)));
+        await new Promise((r) => setTimeout(r, delayMs * (attempt + 1)));
         continue;
       }
       throw err;
@@ -203,15 +203,25 @@ async function withRetry<T>(fn: () => T | Promise<T>, maxRetries = 3, delayMs = 
 configure({ dataDir: ORACLE_DATA_DIR, pidFileName: 'oracle-http.pid' });
 
 // Write PID file for process tracking
-writePidFile({ pid: process.pid, port: Number(PORT), startedAt: new Date().toISOString(), name: 'oracle-http' });
+writePidFile({
+  pid: process.pid,
+  port: Number(PORT),
+  startedAt: new Date().toISOString(),
+  name: 'oracle-http',
+});
 
 // Register graceful shutdown handlers
 registerSignalHandlers(async () => {
   console.log('\n🔮 Shutting down gracefully...');
   await performGracefulShutdown({
     resources: [
-      { close: () => { closeDb(); return Promise.resolve(); } }
-    ]
+      {
+        close: () => {
+          closeDb();
+          return Promise.resolve();
+        },
+      },
+    ],
   });
   removePidFile();
   console.log('👋 Oracle Nightly HTTP Server stopped.');
@@ -245,22 +255,31 @@ const ARCHIVE_DIR = path.join(ORACLE_DATA_DIR, 'uploads', 'archive');
 // HELP_ENDPOINTS imported from ./knowledge/routes.ts (T#806 extraction; T#811 hotfix)
 function findSimilarPaths(requested: string): string[] {
   const reqParts = requested.toLowerCase().split('/').filter(Boolean);
-  const paths = HELP_ENDPOINTS.map(e => e.path);
+  const paths = HELP_ENDPOINTS.map((e) => e.path);
   const uniquePaths = [...new Set(paths)];
-  const scored = uniquePaths.map(p => {
-    const parts = p.toLowerCase().split('/').filter(Boolean);
-    let score = 0;
-    for (const rp of reqParts) {
-      if (rp === 'api') continue;
-      for (const pp of parts) {
-        if (pp.startsWith(':')) continue;
-        if (pp === rp) { score += 3; break; }
-        if (pp.includes(rp) || rp.includes(pp)) { score += 1; break; }
+  const scored = uniquePaths
+    .map((p) => {
+      const parts = p.toLowerCase().split('/').filter(Boolean);
+      let score = 0;
+      for (const rp of reqParts) {
+        if (rp === 'api') continue;
+        for (const pp of parts) {
+          if (pp.startsWith(':')) continue;
+          if (pp === rp) {
+            score += 3;
+            break;
+          }
+          if (pp.includes(rp) || rp.includes(pp)) {
+            score += 1;
+            break;
+          }
+        }
       }
-    }
-    return { path: p, score };
-  }).filter(s => s.score > 0).sort((a, b) => b.score - a.score);
-  return scored.slice(0, 3).map(s => s.path);
+      return { path: p, score };
+    })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score);
+  return scored.slice(0, 3).map((s) => s.path);
 }
 
 app.notFound((c) => {
@@ -269,22 +288,29 @@ app.notFound((c) => {
     return c.text('Not Found', 404);
   }
   const suggestions = findSimilarPaths(reqPath);
-  return c.json({
-    error: 'Not Found',
-    path: reqPath,
-    method: c.req.method,
-    hint: suggestions.length > 0
-      ? `Did you mean: ${suggestions.join(', ')}?`
-      : 'Use GET /api/help to see all available endpoints, or GET /api/help?q=keyword to search.',
-    docs: '/api/help',
-  }, 404);
+  return c.json(
+    {
+      error: 'Not Found',
+      path: reqPath,
+      method: c.req.method,
+      hint:
+        suggestions.length > 0
+          ? `Did you mean: ${suggestions.join(', ')}?`
+          : 'Use GET /api/help to see all available endpoints, or GET /api/help?q=keyword to search.',
+      docs: '/api/help',
+    },
+    404,
+  );
 });
 
 // CORS middleware — restricted to known origins (T#502)
-app.use('*', cors({
-  origin: ['http://localhost:47778', 'http://127.0.0.1:47778', 'https://denbook.online'],
-  credentials: true,
-}));
+app.use(
+  '*',
+  cors({
+    origin: ['http://localhost:47778', 'http://127.0.0.1:47778', 'https://denbook.online'],
+    credentials: true,
+  }),
+);
 
 // Security headers middleware (T#502 — Talon audit finding, T#503 — CSP)
 app.use('*', async (c, next) => {
@@ -293,18 +319,21 @@ app.use('*', async (c, next) => {
   c.header('X-Frame-Options', 'DENY');
   c.header('Referrer-Policy', 'strict-origin-when-cross-origin');
   c.header('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-  c.header('Content-Security-Policy', [
-    "default-src 'none'",
-    "script-src 'self' cdn.jsdelivr.net",
-    "style-src 'self' 'unsafe-inline' fonts.googleapis.com",
-    "font-src fonts.gstatic.com",
-    "img-src 'self' data: blob:",
-    "connect-src 'self' ws: wss:",
-    "object-src 'none'",
-    "frame-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-  ].join('; '));
+  c.header(
+    'Content-Security-Policy',
+    [
+      "default-src 'none'",
+      "script-src 'self' cdn.jsdelivr.net",
+      "style-src 'self' 'unsafe-inline' fonts.googleapis.com",
+      'font-src fonts.gstatic.com',
+      "img-src 'self' data: blob:",
+      "connect-src 'self' ws: wss:",
+      "object-src 'none'",
+      "frame-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+    ].join('; '),
+  );
 });
 
 // ============================================================================
@@ -325,27 +354,29 @@ export function isLocalNetwork(c: Context): boolean {
   const realIp = c.req.header('x-real-ip');
   const ip = forwarded?.split(',')[0]?.trim() || realIp || '127.0.0.1';
 
-  return ip === '127.0.0.1'
-      || ip === '::1'
-      || ip === 'localhost'
-      || ip.startsWith('192.168.')
-      || ip.startsWith('10.')
-      || ip.startsWith('172.16.')
-      || ip.startsWith('172.17.')
-      || ip.startsWith('172.18.')
-      || ip.startsWith('172.19.')
-      || ip.startsWith('172.20.')
-      || ip.startsWith('172.21.')
-      || ip.startsWith('172.22.')
-      || ip.startsWith('172.23.')
-      || ip.startsWith('172.24.')
-      || ip.startsWith('172.25.')
-      || ip.startsWith('172.26.')
-      || ip.startsWith('172.27.')
-      || ip.startsWith('172.28.')
-      || ip.startsWith('172.29.')
-      || ip.startsWith('172.30.')
-      || ip.startsWith('172.31.');
+  return (
+    ip === '127.0.0.1' ||
+    ip === '::1' ||
+    ip === 'localhost' ||
+    ip.startsWith('192.168.') ||
+    ip.startsWith('10.') ||
+    ip.startsWith('172.16.') ||
+    ip.startsWith('172.17.') ||
+    ip.startsWith('172.18.') ||
+    ip.startsWith('172.19.') ||
+    ip.startsWith('172.20.') ||
+    ip.startsWith('172.21.') ||
+    ip.startsWith('172.22.') ||
+    ip.startsWith('172.23.') ||
+    ip.startsWith('172.24.') ||
+    ip.startsWith('172.25.') ||
+    ip.startsWith('172.26.') ||
+    ip.startsWith('172.27.') ||
+    ip.startsWith('172.28.') ||
+    ip.startsWith('172.29.') ||
+    ip.startsWith('172.30.') ||
+    ip.startsWith('172.31.')
+  );
 }
 
 // Generate session token using HMAC-SHA256
@@ -355,9 +386,7 @@ export function generateSessionToken(role: Role = 'owner', data: string = ''): s
   const duration = role === 'guest' ? GUEST_SESSION_DURATION_MS : SESSION_DURATION_MS;
   const expires = Date.now() + duration;
   const payload = `${role}:${data}:${expires}`;
-  const signature = createHmac('sha256', SESSION_SECRET)
-    .update(payload)
-    .digest('hex');
+  const signature = createHmac('sha256', SESSION_SECRET).update(payload).digest('hex');
   return `${payload}:${signature}`;
 }
 
@@ -385,9 +414,7 @@ export function parseSessionToken(token: string): SessionInfo {
     const expires = parseInt(expiresStr, 10);
     if (isNaN(expires) || expires < Date.now()) return { valid: false };
 
-    const expectedSignature = createHmac('sha256', SESSION_SECRET)
-      .update(expiresStr)
-      .digest('hex');
+    const expectedSignature = createHmac('sha256', SESSION_SECRET).update(expiresStr).digest('hex');
 
     const sigBuf = Buffer.from(signature);
     const expectedBuf = Buffer.from(expectedSignature);
@@ -405,9 +432,7 @@ export function parseSessionToken(token: string): SessionInfo {
     if (role !== 'owner' && role !== 'guest') return { valid: false };
 
     const payload = `${role}:${data}:${expiresStr}`;
-    const expectedSignature = createHmac('sha256', SESSION_SECRET)
-      .update(payload)
-      .digest('hex');
+    const expectedSignature = createHmac('sha256', SESSION_SECRET).update(payload).digest('hex');
 
     const sigBuf = Buffer.from(signature);
     const expectedBuf = Buffer.from(expectedSignature);
@@ -483,7 +508,7 @@ app.use('/api/*', async (c, next) => {
     // shared-secret lives. Path-level allowlist (not pattern) keeps the surface narrow.
     '/api/webhooks/hevy',
   ];
-  if (publicPaths.some(p => path === p)) {
+  if (publicPaths.some((p) => path === p)) {
     return next();
   }
 
@@ -496,7 +521,13 @@ app.use('/api/*', async (c, next) => {
     if (result.valid) {
       // Decree #70 Req 8 — expired-grace tokens can ONLY reach /api/auth/rotate
       if (result.expiredGrace && path !== '/api/auth/rotate') {
-        return c.json({ error: 'Token expired — self-rotate available at POST /api/auth/rotate', code: 'expired_grace_rotate_only' }, 401);
+        return c.json(
+          {
+            error: 'Token expired — self-rotate available at POST /api/auth/rotate',
+            code: 'expired_grace_rotate_only',
+          },
+          401,
+        );
       }
       // Token validated — set actor identity and skip further auth
       c.set('actor' as any, result.beast);
@@ -531,7 +562,10 @@ app.use('/api/*', async (c, next) => {
       return next();
     } else {
       // Invalid/expired token — log and reject
-      const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+      const ip =
+        c.req.header('x-real-ip') ||
+        c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+        'local';
       logSecurityEvent({
         eventType: 'auth_failure',
         severity: 'warning',
@@ -568,7 +602,10 @@ app.use('/api/*', async (c, next) => {
         // Log guest API access
         logGuestAction(sqlite, guest.id, path, c.req.method);
       } else {
-        return c.json({ error: 'Unauthorized', message: 'Guest account not found', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Unauthorized', message: 'Guest account not found', requiresAuth: true },
+          401,
+        );
       }
     } else {
       c.set('role' as any, 'owner' as Role);
@@ -591,7 +628,13 @@ app.use('/api/*', rbacMiddleware());
 // Audit Logging Middleware (Task #72 — logs all mutating API requests)
 // ============================================================================
 
-const AUDIT_SKIP = ['/api/health', '/api/help', '/api/auth/status', '/api/auth/login', '/api/session/stats'];
+const AUDIT_SKIP = [
+  '/api/health',
+  '/api/help',
+  '/api/auth/status',
+  '/api/auth/login',
+  '/api/session/stats',
+];
 
 app.use('/api/*', async (c, next) => {
   const method = c.req.method;
@@ -603,23 +646,33 @@ app.use('/api/*', async (c, next) => {
 
   // Skip: GETs (except sensitive), static, health, WS
   const isMutation = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method);
-  const isSensitiveGet = method === 'GET' && (path.includes('/dm/') || path.includes('/settings') || path.includes('/audit'));
+  const isSensitiveGet =
+    method === 'GET' &&
+    (path.includes('/dm/') || path.includes('/settings') || path.includes('/audit'));
   if (!isMutation && !isSensitiveGet) return next();
-  if (AUDIT_SKIP.some(p => path === p)) return next();
+  if (AUDIT_SKIP.some((p) => path === p)) return next();
 
   // Clone body BEFORE next() consumes it — extraction after next() fails on consumed streams
   let bodyData: Record<string, unknown> | null = null;
   if (isMutation) {
     try {
-      bodyData = await c.req.raw.clone().json().catch(() => null) as Record<string, unknown> | null;
-    } catch { /* body parse failed */ }
+      bodyData = (await c.req.raw
+        .clone()
+        .json()
+        .catch(() => null)) as Record<string, unknown> | null;
+    } catch {
+      /* body parse failed */
+    }
   }
 
   await next();
 
   // Log after handler completes
   try {
-    const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+    const ip =
+      c.req.header('x-real-ip') ||
+      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+      'local';
     // Actor extraction chain (T#718 — closes Bertus/Flint #10002 audit-attribution spoof gap):
     // 1. Bearer token identity (set by auth middleware — trusted)
     // 2. Session cookie → "gorn" (browser requests — trusted)
@@ -651,7 +704,9 @@ app.use('/api/*', async (c, next) => {
     }
     if (!actor) {
       // Path-identity routes — /api/dm/<beast>/... has the beast in the path itself
-      const pathMatch = path.match(/\/api\/(?:dm|schedules)\/(?!messages|dashboard|due|pending)([a-z][\w-]*)/i);
+      const pathMatch = path.match(
+        /\/api\/(?:dm|schedules)\/(?!messages|dashboard|due|pending)([a-z][\w-]*)/i,
+      );
       if (pathMatch) actor = pathMatch[1];
     }
 
@@ -664,7 +719,11 @@ app.use('/api/*', async (c, next) => {
         actor: actor || 'unknown',
         actorType: (actorType as any) || 'unknown',
         target: path,
-        details: { auth_method: 'legacy_as_param', as_param_value: asParam, deprecation: 'Use Bearer token auth' },
+        details: {
+          auth_method: 'legacy_as_param',
+          as_param_value: asParam,
+          deprecation: 'Use Bearer token auth',
+        },
         ipSource: ip,
         requestId,
       });
@@ -687,10 +746,23 @@ app.use('/api/*', async (c, next) => {
     const resourceType = parts[0] || null;
     const resourceId = parts[1] || null;
 
-    sqlite.prepare(
-      `INSERT INTO audit_log (actor, actor_type, action, resource_type, resource_id, ip_source, request_method, request_path, status_code, request_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(actor, actorType, `${method} ${path}`, resourceType, resourceId, ip, method, path, statusCode, requestId);
+    sqlite
+      .prepare(
+        `INSERT INTO audit_log (actor, actor_type, action, resource_type, resource_id, ip_source, request_method, request_path, status_code, request_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        actor,
+        actorType,
+        `${method} ${path}`,
+        resourceType,
+        resourceId,
+        ip,
+        method,
+        path,
+        statusCode,
+        requestId,
+      );
 
     // Auto-log 403 permission denials as security events
     if (statusCode === 403) {
@@ -705,7 +777,9 @@ app.use('/api/*', async (c, next) => {
         requestId,
       });
     }
-  } catch { /* never block requests for logging failures */ }
+  } catch {
+    /* never block requests for logging failures */
+  }
 });
 
 // ============================================================================
@@ -744,10 +818,14 @@ sqlite.exec(`CREATE TABLE IF NOT EXISTS telegram_messages (
   PRIMARY KEY (chat_id, id)
 )`);
 // Retention-shape-reserved index for future cleanup cron (Bertus #887 flag 2).
-sqlite.exec(`CREATE INDEX IF NOT EXISTS idx_telegram_messages_date_unix ON telegram_messages(date_unix)`);
+sqlite.exec(
+  `CREATE INDEX IF NOT EXISTS idx_telegram_messages_date_unix ON telegram_messages(date_unix)`,
+);
 
 export function getRateLimit(ip: string): { count: number; firstAttempt: number } | null {
-  const row = sqlite.prepare('SELECT count, first_attempt_at FROM login_rate_limits WHERE ip = ?').get(ip) as any;
+  const row = sqlite
+    .prepare('SELECT count, first_attempt_at FROM login_rate_limits WHERE ip = ?')
+    .get(ip) as any;
   if (!row) return null;
   return { count: row.count, firstAttempt: row.first_attempt_at };
 }
@@ -755,7 +833,6 @@ export function getRateLimit(ip: string): { count: number; firstAttempt: number 
 export function clearRateLimit(ip: string): void {
   sqlite.prepare('DELETE FROM login_rate_limits WHERE ip = ?').run(ip);
 }
-
 
 // ============================================================================
 // Settings Routes
@@ -768,7 +845,6 @@ registerSettingsRoutes(app, { getSetting, setSetting, logSecurityEvent });
 // API Routes
 // ============================================================================
 
-
 // Health check (OpenAPI — Spec #55 Phase 1 proof-of-pattern)
 app.openapi(healthRoute, (c) => {
   return c.json({ status: 'ok', server: 'oracle-nightly', port: PORT, oracleV2: 'connected' });
@@ -777,27 +853,32 @@ app.openapi(healthRoute, (c) => {
 // Knowledge / docs routes extracted to src/knowledge/routes.ts (T#806 P3-B)
 registerKnowledgeRoutes(app, sqlite, { repoRoot: REPO_ROOT });
 
-
 // ============================================================================
 // Dashboard Routes
 // ============================================================================
 
-
 // Guest routes extracted to src/guest/routes.ts (T#807 P3-C)
-registerGuestRoutes(app, sqlite, { wsBroadcast, withRetry, getTmuxStatus, normalizeAvatarUrl, uploadsDir: UPLOADS_DIR });
-
+registerGuestRoutes(app, sqlite, {
+  wsBroadcast,
+  withRetry,
+  getTmuxStatus,
+  normalizeAvatarUrl,
+  uploadsDir: UPLOADS_DIR,
+});
 
 // Session stats endpoint - tracks activity from DB (includes MCP usage)
 app.get('/api/session/stats', (c) => {
   const since = c.req.query('since');
   const sinceTime = since ? parseInt(since) : Date.now() - 24 * 60 * 60 * 1000; // Default 24h
 
-  const searches = db.select({ count: sql<number>`count(*)` })
+  const searches = db
+    .select({ count: sql<number>`count(*)` })
     .from(searchLog)
     .where(gt(searchLog.createdAt, sinceTime))
     .get();
 
-  const learnings = db.select({ count: sql<number>`count(*)` })
+  const learnings = db
+    .select({ count: sql<number>`count(*)` })
     .from(learnLog)
     .where(gt(learnLog.createdAt, sinceTime))
     .get();
@@ -805,7 +886,7 @@ app.get('/api/session/stats', (c) => {
   return c.json({
     searches: searches?.count || 0,
     learnings: learnings?.count || 0,
-    since: sinceTime
+    since: sinceTime,
   });
 });
 
@@ -823,23 +904,28 @@ function loadAllSpinnerVerbs(): Set<string> {
   const verbs = new Set<string>();
   const workspaceDir = '/home/gorn/workspace';
   try {
-    const dirs = fs.readdirSync(workspaceDir, { withFileTypes: true })
-      .filter(d => d.isDirectory())
-      .map(d => d.name);
+    const dirs = fs
+      .readdirSync(workspaceDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
     for (const dir of dirs) {
       try {
         const configPath = path.join(workspaceDir, dir, '.claude', 'settings.local.json');
         const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
         const sv = config.spinnerVerbs;
         if (sv) {
-          const verbList = Array.isArray(sv) ? sv : (sv.verbs || []);
+          const verbList = Array.isArray(sv) ? sv : sv.verbs || [];
           for (const v of verbList) {
             if (typeof v === 'string') verbs.add(v);
           }
         }
-      } catch { /* skip dirs without config */ }
+      } catch {
+        /* skip dirs without config */
+      }
     }
-  } catch { /* workspace not readable */ }
+  } catch {
+    /* workspace not readable */
+  }
   return verbs;
 }
 
@@ -863,29 +949,39 @@ function normalizeAvatarUrl(url: string | null): string | null {
   // /api/files/ID/download -> look up filename from files table, rewrite to /api/f/
   const filesMatch = url.match(/^\/api\/files\/(\d+)\/download$/);
   if (filesMatch) {
-    const file = sqlite.prepare('SELECT filename FROM files WHERE id = ?').get(parseInt(filesMatch[1])) as any;
+    const file = sqlite
+      .prepare('SELECT filename FROM files WHERE id = ?')
+      .get(parseInt(filesMatch[1])) as any;
     if (file) return '/api/f/' + file.filename;
   }
   return url;
 }
 
 // Shared tmux status detection — used by both /api/pack and /api/guest/pack
-function getTmuxStatus(): { tmuxStatus: Map<string, 'processing' | 'idle' | 'waiting' | 'shell' | 'offline'>; contextPctMap: Map<string, number | null> } {
-  const tmuxStatus: Map<string, 'processing' | 'idle' | 'waiting' | 'shell' | 'offline'> = new Map();
+function getTmuxStatus(): {
+  tmuxStatus: Map<string, 'processing' | 'idle' | 'waiting' | 'shell' | 'offline'>;
+  contextPctMap: Map<string, number | null>;
+} {
+  const tmuxStatus: Map<string, 'processing' | 'idle' | 'waiting' | 'shell' | 'offline'> =
+    new Map();
   const contextPctMap: Map<string, number | null> = new Map();
   try {
-    const output = execSync(
-      'tmux list-sessions -F "#{session_name}" 2>/dev/null',
-      { timeout: 3000 }
-    ).toString().trim();
+    const output = execSync('tmux list-sessions -F "#{session_name}" 2>/dev/null', {
+      timeout: 3000,
+    })
+      .toString()
+      .trim();
     const sessions = output.split('\n').filter(Boolean);
 
     for (const session of sessions) {
       try {
         const cmd = execSync(
           `tmux list-panes -t ${JSON.stringify(session)} -F "#{pane_current_command}" 2>/dev/null`,
-          { timeout: 2000 }
-        ).toString().trim().split('\n')[0];
+          { timeout: 2000 },
+        )
+          .toString()
+          .trim()
+          .split('\n')[0];
 
         if (cmd !== 'claude') {
           tmuxStatus.set(session.toLowerCase(), 'shell');
@@ -919,7 +1015,10 @@ function getTmuxStatus(): { tmuxStatus: Map<string, 'processing' | 'idle' | 'wai
           // Find the last ❯ prompt line
           let promptIdx = -1;
           for (let i = lines.length - 1; i >= 0; i--) {
-            if (/^❯/.test(lines[i].trim())) { promptIdx = i; break; }
+            if (/^❯/.test(lines[i].trim())) {
+              promptIdx = i;
+              break;
+            }
           }
 
           // Check the 2 lines above the ❯ prompt (skip separator)
@@ -948,20 +1047,25 @@ function getTmuxStatus(): { tmuxStatus: Map<string, 'processing' | 'idle' | 'wai
           let contextPct: number | null = null;
           for (let i = lines.length - 1; i >= 0; i--) {
             const pctMatch = lines[i].match(/(\d+)%\s*\|/);
-            if (pctMatch) { contextPct = parseInt(pctMatch[1], 10); break; }
+            if (pctMatch) {
+              contextPct = parseInt(pctMatch[1], 10);
+              break;
+            }
           }
           contextPctMap.set(session.toLowerCase(), contextPct);
 
           // Detect waiting state — Claude is stuck at a permission/choice prompt
           // Only scan lines near the prompt (last 8 lines before ❯) to avoid false positives
           // from notification text or conversation content in the pane buffer
-          const promptArea = promptIdx > 0
-            ? lines.slice(Math.max(promptIdx - 8, 0), promptIdx).join('\n')
-            : '';
+          const promptArea =
+            promptIdx > 0 ? lines.slice(Math.max(promptIdx - 8, 0), promptIdx).join('\n') : '';
           // Match actual Claude permission UI: bordered choice boxes, (y/n) prompts
-          const isWaiting = promptArea.length > 0
-            && /Allow.*│|│.*Allow|Deny.*│|│.*Deny|Do you want to|trust this|Allow once|Always allow|\(y\/n\)|\(Y\/n\)/.test(promptArea)
-            && !isProcessing;
+          const isWaiting =
+            promptArea.length > 0 &&
+            /Allow.*│|│.*Allow|Deny.*│|│.*Deny|Do you want to|trust this|Allow once|Always allow|\(y\/n\)|\(Y\/n\)/.test(
+              promptArea,
+            ) &&
+            !isProcessing;
 
           if (isProcessing) {
             tmuxStatus.set(session.toLowerCase(), 'processing');
@@ -977,7 +1081,9 @@ function getTmuxStatus(): { tmuxStatus: Map<string, 'processing' | 'idle' | 'wai
         tmuxStatus.set(session.toLowerCase(), 'shell');
       }
     }
-  } catch { /* tmux not running */ }
+  } catch {
+    /* tmux not running */
+  }
 
   return { tmuxStatus, contextPctMap };
 }
@@ -1010,9 +1116,17 @@ registerRemoteRoutes(app, { isLocalNetwork, hasSessionAuth });
 // List all beast profiles
 
 // Migration: add sex column to beast_profiles (T#411)
-try { sqlite.prepare('ALTER TABLE beast_profiles ADD COLUMN sex TEXT DEFAULT NULL').run(); } catch { /* exists */ }
+try {
+  sqlite.prepare('ALTER TABLE beast_profiles ADD COLUMN sex TEXT DEFAULT NULL').run();
+} catch {
+  /* exists */
+}
 // T#658 — Norm #65 (Nap vs Rest) — scheduler-aware rest state
-try { sqlite.prepare("ALTER TABLE beast_profiles ADD COLUMN rest_status TEXT DEFAULT 'active'").run(); } catch { /* exists */ }
+try {
+  sqlite.prepare("ALTER TABLE beast_profiles ADD COLUMN rest_status TEXT DEFAULT 'active'").run();
+} catch {
+  /* exists */
+}
 
 // Get beast profile by name
 
@@ -1031,26 +1145,59 @@ try { sqlite.prepare("ALTER TABLE beast_profiles ADD COLUMN rest_status TEXT DEF
 // Get unread counts for a beast (T#618: excludes muted threads)
 
 // File archive columns (T#533)
-try { sqlite.prepare(`ALTER TABLE files ADD COLUMN archived_at INTEGER`).run(); } catch { /* exists */ }
-try { sqlite.prepare(`ALTER TABLE files ADD COLUMN archive_path TEXT`).run(); } catch { /* exists */ }
+try {
+  sqlite.prepare(`ALTER TABLE files ADD COLUMN archived_at INTEGER`).run();
+} catch {
+  /* exists */
+}
+try {
+  sqlite.prepare(`ALTER TABLE files ADD COLUMN archive_path TEXT`).run();
+} catch {
+  /* exists */
+}
 
 // UPLOADS_DIR moved up — needed by registerGuestRoutes + registerFilesRoutes (T#807 hotfix:
 // TDZ error if defined after first use).
 
 // Files + upload routes extracted to src/files/routes.ts (T#804 P3-E)
-registerFilesRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, isLocalNetwork, verifySessionToken, uploadsDir: UPLOADS_DIR, sessionCookieName: SESSION_COOKIE_NAME });
+registerFilesRoutes(app, sqlite, {
+  hasSessionAuth,
+  isTrustedRequest,
+  isLocalNetwork,
+  verifySessionToken,
+  uploadsDir: UPLOADS_DIR,
+  sessionCookieName: SESSION_COOKIE_NAME,
+});
 
 // (stats endpoint moved above :id routes)
 
 // Get attachments for a message
 
 // T#618: Inline migration — add level column to forum_notification_prefs
-try { sqlite.exec("ALTER TABLE forum_notification_prefs ADD COLUMN level TEXT NOT NULL DEFAULT 'full'"); } catch { /* exists */ }
-try { sqlite.exec("UPDATE forum_notification_prefs SET level = 'muted' WHERE muted = 1 AND level = 'full'"); } catch { /* ignore */ }
+try {
+  sqlite.exec("ALTER TABLE forum_notification_prefs ADD COLUMN level TEXT NOT NULL DEFAULT 'full'");
+} catch {
+  /* exists */
+}
+try {
+  sqlite.exec(
+    "UPDATE forum_notification_prefs SET level = 'muted' WHERE muted = 1 AND level = 'full'",
+  );
+} catch {
+  /* ignore */
+}
 
 // T#622: Inline migration — add deleted_at column to forum_messages for soft delete
-try { sqlite.exec("ALTER TABLE forum_messages ADD COLUMN deleted_at TEXT DEFAULT NULL"); } catch { /* exists */ }
-try { sqlite.exec("ALTER TABLE forum_messages ADD COLUMN deleted_by TEXT DEFAULT NULL"); } catch { /* exists */ }
+try {
+  sqlite.exec('ALTER TABLE forum_messages ADD COLUMN deleted_at TEXT DEFAULT NULL');
+} catch {
+  /* exists */
+}
+try {
+  sqlite.exec('ALTER TABLE forum_messages ADD COLUMN deleted_by TEXT DEFAULT NULL');
+} catch {
+  /* exists */
+}
 
 // Mute/unmute thread notifications for a beast (alias for subscribe with level muted/full)
 
@@ -1086,30 +1233,66 @@ try { sqlite.exec("ALTER TABLE forum_messages ADD COLUMN deleted_by TEXT DEFAULT
 // Add reaction to message
 // Emoji whitelist — DB-backed, any Beast can add (T#385)
 try {
-  sqlite.prepare(`CREATE TABLE IF NOT EXISTS emoji_whitelist (
+  sqlite
+    .prepare(`CREATE TABLE IF NOT EXISTS emoji_whitelist (
     emoji TEXT PRIMARY KEY,
     added_by TEXT,
     created_at INTEGER NOT NULL
-  )`).run();
-} catch { /* already exists */ }
+  )`)
+    .run();
+} catch {
+  /* already exists */
+}
 
 // Seed defaults if table is empty
-const emojiCount = (sqlite.prepare('SELECT COUNT(*) as c FROM emoji_whitelist').get() as any)?.c || 0;
+const emojiCount =
+  (sqlite.prepare('SELECT COUNT(*) as c FROM emoji_whitelist').get() as any)?.c || 0;
 if (emojiCount === 0) {
   const defaults = [
-    '👍', '👎', '❤️', '🔥', '👀', '✅', '❌',
-    '😂', '😢', '🤔', '💪', '🎉', '🙏', '👏', '💯',
-    '🚀', '⭐', '⚠️', '💡', '🏆', '🫡', '🤝',
-    '📦', '🐾', '🐴', '🐊', '🐻', '🦘', '🦁', '🦝', '🦦', '🐙', '🐦‍⬛',
+    '👍',
+    '👎',
+    '❤️',
+    '🔥',
+    '👀',
+    '✅',
+    '❌',
+    '😂',
+    '😢',
+    '🤔',
+    '💪',
+    '🎉',
+    '🙏',
+    '👏',
+    '💯',
+    '🚀',
+    '⭐',
+    '⚠️',
+    '💡',
+    '🏆',
+    '🫡',
+    '🤝',
+    '📦',
+    '🐾',
+    '🐴',
+    '🐊',
+    '🐻',
+    '🦘',
+    '🦁',
+    '🦝',
+    '🦦',
+    '🐙',
+    '🐦‍⬛',
   ];
-  const insert = sqlite.prepare('INSERT OR IGNORE INTO emoji_whitelist (emoji, added_by, created_at) VALUES (?, ?, ?)');
+  const insert = sqlite.prepare(
+    'INSERT OR IGNORE INTO emoji_whitelist (emoji, added_by, created_at) VALUES (?, ?, ?)',
+  );
   const now = Date.now();
   for (const e of defaults) insert.run(e, 'system', now);
 }
 
 function getSupportedEmoji(): Set<string> {
   const rows = sqlite.prepare('SELECT emoji FROM emoji_whitelist').all() as any[];
-  return new Set(rows.map(r => r.emoji));
+  return new Set(rows.map((r) => r.emoji));
 }
 
 // Cache — refreshed on add/remove
@@ -1122,7 +1305,6 @@ let SUPPORTED_EMOJI = getSupportedEmoji();
 // DELETE /api/forum/emojis/:emoji — remove emoji (Gorn only)
 
 // GET /api/reactions/supported — legacy endpoint
-
 
 // Remove reaction
 
@@ -1137,20 +1319,30 @@ let SUPPORTED_EMOJI = getSupportedEmoji();
 // Ensure queue columns exist
 try {
   sqlite.prepare('ALTER TABLE forum_threads ADD COLUMN queue_status TEXT DEFAULT NULL').run();
-} catch { /* column already exists */ }
+} catch {
+  /* column already exists */
+}
 try {
   sqlite.prepare('ALTER TABLE forum_threads ADD COLUMN queue_tagged_by TEXT DEFAULT NULL').run();
-} catch { /* column already exists */ }
+} catch {
+  /* column already exists */
+}
 try {
   sqlite.prepare('ALTER TABLE forum_threads ADD COLUMN queue_tagged_at INTEGER DEFAULT NULL').run();
-} catch { /* column already exists */ }
+} catch {
+  /* column already exists */
+}
 try {
   sqlite.prepare('ALTER TABLE forum_threads ADD COLUMN queue_summary TEXT DEFAULT NULL').run();
-} catch { /* column already exists */ }
+} catch {
+  /* column already exists */
+}
 
 try {
   sqlite.prepare('ALTER TABLE forum_threads ADD COLUMN deleted_at TEXT DEFAULT NULL').run();
-} catch { /* column already exists */ }
+} catch {
+  /* column already exists */
+}
 
 // Mindlink removed — replaced by Prowl (T#279/T#280)
 // DB table 'mindlinks' preserved for data migration to Prowl
@@ -1187,7 +1379,15 @@ import {
 } from './dm/handler.ts';
 
 // DM performance index — composite for sorted conversation queries
-try { sqlite.prepare('CREATE INDEX IF NOT EXISTS idx_dm_messages_conv_created ON dm_messages(conversation_id, created_at)').run(); } catch { /* exists */ }
+try {
+  sqlite
+    .prepare(
+      'CREATE INDEX IF NOT EXISTS idx_dm_messages_conv_created ON dm_messages(conversation_id, created_at)',
+    )
+    .run();
+} catch {
+  /* exists */
+}
 
 // DM Dashboard — accessible to authenticated users (auth middleware handles access)
 
@@ -1212,7 +1412,8 @@ try { sqlite.prepare('CREATE INDEX IF NOT EXISTS idx_dm_messages_conv_created ON
 
 // Create library table
 try {
-  sqlite.prepare(`CREATE TABLE IF NOT EXISTS library (
+  sqlite
+    .prepare(`CREATE TABLE IF NOT EXISTS library (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT NOT NULL,
     content TEXT NOT NULL,
@@ -1221,11 +1422,16 @@ try {
     tags TEXT DEFAULT '[]',
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
-  )`).run();
-} catch { /* already exists */ }
+  )`)
+    .run();
+} catch {
+  /* already exists */
+}
 
 // Library Shelves table (T#330)
-try { sqlite.prepare(`
+try {
+  sqlite
+    .prepare(`
   CREATE TABLE IF NOT EXISTS library_shelves (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL UNIQUE,
@@ -1236,20 +1442,46 @@ try { sqlite.prepare(`
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
   )
-`).run(); } catch { /* exists */ }
+`)
+    .run();
+} catch {
+  /* exists */
+}
 
 // Add shelf_id to library table
-try { sqlite.prepare(`ALTER TABLE library ADD COLUMN shelf_id INTEGER REFERENCES library_shelves(id) ON DELETE SET NULL`).run(); } catch { /* exists */ }
+try {
+  sqlite
+    .prepare(
+      `ALTER TABLE library ADD COLUMN shelf_id INTEGER REFERENCES library_shelves(id) ON DELETE SET NULL`,
+    )
+    .run();
+} catch {
+  /* exists */
+}
 // Index for efficient shelf filtering
-try { sqlite.prepare(`CREATE INDEX IF NOT EXISTS idx_library_shelf_id ON library(shelf_id)`).run(); } catch { /* exists */ }
+try {
+  sqlite.prepare(`CREATE INDEX IF NOT EXISTS idx_library_shelf_id ON library(shelf_id)`).run();
+} catch {
+  /* exists */
+}
 // T#623: Add visibility to shelves (public/internal, default internal)
-try { sqlite.prepare(`ALTER TABLE library_shelves ADD COLUMN visibility TEXT NOT NULL DEFAULT 'internal'`).run(); } catch { /* exists */ }
+try {
+  sqlite
+    .prepare(`ALTER TABLE library_shelves ADD COLUMN visibility TEXT NOT NULL DEFAULT 'internal'`)
+    .run();
+} catch {
+  /* exists */
+}
 
 // Library routes — extracted to src/library/routes.ts
 
 // Board routes (projects + tasks + task_comments + /api/board summary) — extracted to src/board/routes.ts (T#774)
-registerBoardRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast });
-
+registerBoardRoutes(app, sqlite, {
+  hasSessionAuth,
+  requireBeastIdentity,
+  isTrustedRequest,
+  wsBroadcast,
+});
 
 // ============================================================================
 // Beast Scheduler — Persistent schedules that survive sleep cycles
@@ -1257,7 +1489,8 @@ registerBoardRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, isTrust
 
 // Create beast_schedules table
 try {
-  sqlite.prepare(`CREATE TABLE IF NOT EXISTS beast_schedules (
+  sqlite
+    .prepare(`CREATE TABLE IF NOT EXISTS beast_schedules (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     beast TEXT NOT NULL,
     task TEXT NOT NULL,
@@ -1270,26 +1503,66 @@ try {
     source TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now'))
-  )`).run();
-  sqlite.prepare(`CREATE INDEX IF NOT EXISTS idx_beast_schedules_beast ON beast_schedules(beast)`).run();
-  sqlite.prepare(`CREATE INDEX IF NOT EXISTS idx_beast_schedules_due ON beast_schedules(next_due_at)`).run();
+  )`)
+    .run();
+  sqlite
+    .prepare(`CREATE INDEX IF NOT EXISTS idx_beast_schedules_beast ON beast_schedules(beast)`)
+    .run();
+  sqlite
+    .prepare(`CREATE INDEX IF NOT EXISTS idx_beast_schedules_due ON beast_schedules(next_due_at)`)
+    .run();
   // v2 columns
-  try { sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN last_triggered_at TEXT`).run(); } catch { /* exists */ }
-  try { sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN trigger_status TEXT DEFAULT 'pending'`).run(); } catch { /* exists */ }
+  try {
+    sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN last_triggered_at TEXT`).run();
+  } catch {
+    /* exists */
+  }
+  try {
+    sqlite
+      .prepare(`ALTER TABLE beast_schedules ADD COLUMN trigger_status TEXT DEFAULT 'pending'`)
+      .run();
+  } catch {
+    /* exists */
+  }
   // v3: fixed-time scheduling
-  try { sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN schedule_time TEXT`).run(); } catch { /* exists */ }
-  try { sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN timezone TEXT DEFAULT 'Asia/Bangkok'`).run(); } catch { /* exists */ }
+  try {
+    sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN schedule_time TEXT`).run();
+  } catch {
+    /* exists */
+  }
+  try {
+    sqlite
+      .prepare(`ALTER TABLE beast_schedules ADD COLUMN timezone TEXT DEFAULT 'Asia/Bangkok'`)
+      .run();
+  } catch {
+    /* exists */
+  }
   // v4: one-off schedules
-  try { sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN once INTEGER DEFAULT 0`).run(); } catch { /* exists */ }
-  try { sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN run_at TEXT`).run(); } catch { /* exists */ }
+  try {
+    sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN once INTEGER DEFAULT 0`).run();
+  } catch {
+    /* exists */
+  }
+  try {
+    sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN run_at TEXT`).run();
+  } catch {
+    /* exists */
+  }
   // v5: weekday-anchored recurring (T#706 — Boro coach lane)
-  try { sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN days_of_week TEXT`).run(); } catch { /* exists */ }
-} catch { /* already exists */ }
+  try {
+    sqlite.prepare(`ALTER TABLE beast_schedules ADD COLUMN days_of_week TEXT`).run();
+  } catch {
+    /* exists */
+  }
+} catch {
+  /* already exists */
+}
 
 // ============================================================================
 // Audit Log table (Task #72 — Bertus design, thread #81)
 try {
-  sqlite.prepare(`CREATE TABLE IF NOT EXISTS audit_log (
+  sqlite
+    .prepare(`CREATE TABLE IF NOT EXISTS audit_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp TEXT DEFAULT (datetime('now')),
     actor TEXT,
@@ -1303,39 +1576,58 @@ try {
     request_path TEXT,
     status_code INTEGER,
     request_id TEXT
-  )`).run();
+  )`)
+    .run();
   sqlite.prepare(`CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp)`).run();
   sqlite.prepare(`CREATE INDEX IF NOT EXISTS idx_audit_actor ON audit_log(actor)`).run();
-  sqlite.prepare(`CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_log(resource_type, resource_id)`).run();
+  sqlite
+    .prepare(
+      `CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_log(resource_type, resource_id)`,
+    )
+    .run();
   sqlite.prepare(`CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_log(action)`).run();
-  try { sqlite.prepare(`ALTER TABLE audit_log ADD COLUMN request_id TEXT`).run(); } catch { /* exists */ }
+  try {
+    sqlite.prepare(`ALTER TABLE audit_log ADD COLUMN request_id TEXT`).run();
+  } catch {
+    /* exists */
+  }
   sqlite.prepare(`CREATE INDEX IF NOT EXISTS idx_audit_request_id ON audit_log(request_id)`).run();
-} catch { /* already exists */ }
+} catch {
+  /* already exists */
+}
 
 // Teams tables (Task #81 — Gnarl spec, thread #105)
 try {
-  sqlite.prepare(`CREATE TABLE IF NOT EXISTS teams (
+  sqlite
+    .prepare(`CREATE TABLE IF NOT EXISTS teams (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL UNIQUE,
     description TEXT,
     created_by TEXT NOT NULL,
     created_at TEXT DEFAULT (datetime('now'))
-  )`).run();
-  sqlite.prepare(`CREATE TABLE IF NOT EXISTS team_members (
+  )`)
+    .run();
+  sqlite
+    .prepare(`CREATE TABLE IF NOT EXISTS team_members (
     team_id INTEGER NOT NULL,
     beast TEXT NOT NULL,
     role TEXT DEFAULT 'member',
     joined_at TEXT DEFAULT (datetime('now')),
     PRIMARY KEY (team_id, beast),
     FOREIGN KEY (team_id) REFERENCES teams(id)
-  )`).run();
-  sqlite.prepare(`CREATE TABLE IF NOT EXISTS team_projects (
+  )`)
+    .run();
+  sqlite
+    .prepare(`CREATE TABLE IF NOT EXISTS team_projects (
     team_id INTEGER NOT NULL,
     project_id INTEGER NOT NULL,
     PRIMARY KEY (team_id, project_id),
     FOREIGN KEY (team_id) REFERENCES teams(id)
-  )`).run();
-} catch { /* already exists */ }
+  )`)
+    .run();
+} catch {
+  /* already exists */
+}
 
 // ============================================================================
 // Audit Log Query (Task #72 — Gorn-only read access)
@@ -1351,21 +1643,15 @@ registerAuditRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, requireBeas
 // Teams routes extracted to src/teams/routes.ts (T#803 P3-H)
 registerTeamsRoutes(app, sqlite, { hasSessionAuth });
 
-
 // Scheduler routes + helpers + auto-trigger daemon — extracted to src/scheduler/routes.ts (T#772)
 initScheduler(sqlite, db, REPO_ROOT, { wsBroadcast, enqueueNotification });
 registerSchedulerRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity });
-
-
 
 // Daemons (notification drain + DB maintenance + file archive) — extracted to src/daemons/routes.ts (T#773)
 initDaemons(sqlite);
 registerDaemonRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest });
 
-
-
 // Withings auto-sync daemon — moved to src/integrations/routes.ts initIntegrations() (T#775)
-
 
 // Supersede routes extracted to src/supersede/routes.ts (T#801 P3-I)
 registerSupersedeRoutes(app);
@@ -1373,9 +1659,6 @@ registerSupersedeRoutes(app);
 // ============================================================================
 // Trace Routes - Discovery journey visualization
 // ============================================================================
-
-
-
 
 // Link traces: POST /api/traces/:prevId/link { nextId: "..." }
 
@@ -1390,15 +1673,21 @@ registerSupersedeRoutes(app);
 // Inbox routes (handoff + inbox + learn) extracted to src/inbox/routes.ts (T#805 P3-J)
 registerInboxRoutes(app, sqlite, { isTrustedRequest, wsBroadcast, repoRoot: REPO_ROOT });
 
-
 // Specs routes (Spec Review SDD workflow) — extracted to src/specs/routes.ts (T#776)
-registerSpecsRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast });
+registerSpecsRoutes(app, sqlite, {
+  hasSessionAuth,
+  requireBeastIdentity,
+  isTrustedRequest,
+  wsBroadcast,
+});
 
 // ============================================================================
 // Risk Register (T#316)
 // ============================================================================
 
-try { sqlite.prepare(`
+try {
+  sqlite
+    .prepare(`
   CREATE TABLE IF NOT EXISTS risks (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT NOT NULL,
@@ -1431,11 +1720,17 @@ try { sqlite.prepare(`
     closed_at DATETIME,
     deleted_at DATETIME
   )
-`).run(); } catch { /* exists */ }
+`)
+    .run();
+} catch {
+  /* exists */
+}
 
 // Risk + risk comment routes — extracted to src/risk/routes.ts
 
-try { sqlite.prepare(`
+try {
+  sqlite
+    .prepare(`
   CREATE TABLE IF NOT EXISTS risk_comments (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     risk_id INTEGER NOT NULL,
@@ -1443,7 +1738,11 @@ try { sqlite.prepare(`
     content TEXT NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
   )
-`).run(); } catch { /* exists */ }
+`)
+    .run();
+} catch {
+  /* exists */
+}
 
 // ============================================================================
 // Withings OAuth Integration (T#414, Spec #23)
@@ -1468,14 +1767,30 @@ sqlite.exec(`
   )
 `);
 // Migration: add separate IV/tag columns for access and refresh tokens
-try { sqlite.prepare('ALTER TABLE oauth_tokens ADD COLUMN access_iv TEXT').run(); } catch { /* exists */ }
-try { sqlite.prepare('ALTER TABLE oauth_tokens ADD COLUMN access_tag TEXT').run(); } catch { /* exists */ }
-try { sqlite.prepare('ALTER TABLE oauth_tokens ADD COLUMN refresh_iv TEXT').run(); } catch { /* exists */ }
-try { sqlite.prepare('ALTER TABLE oauth_tokens ADD COLUMN refresh_tag TEXT').run(); } catch { /* exists */ }
+try {
+  sqlite.prepare('ALTER TABLE oauth_tokens ADD COLUMN access_iv TEXT').run();
+} catch {
+  /* exists */
+}
+try {
+  sqlite.prepare('ALTER TABLE oauth_tokens ADD COLUMN access_tag TEXT').run();
+} catch {
+  /* exists */
+}
+try {
+  sqlite.prepare('ALTER TABLE oauth_tokens ADD COLUMN refresh_iv TEXT').run();
+} catch {
+  /* exists */
+}
+try {
+  sqlite.prepare('ALTER TABLE oauth_tokens ADD COLUMN refresh_tag TEXT').run();
+} catch {
+  /* exists */
+}
 // Migration: drop NOT NULL on old token_iv/token_tag columns (T#476 — schema mismatch)
 // SQLite can't ALTER columns, so recreate the table if old columns exist
 try {
-  const cols = sqlite.prepare("PRAGMA table_info(oauth_tokens)").all() as any[];
+  const cols = sqlite.prepare('PRAGMA table_info(oauth_tokens)').all() as any[];
   const hasOldCol = cols.some((c: any) => c.name === 'token_iv' && c.notnull === 1);
   if (hasOldCol) {
     sqlite.exec(`
@@ -1494,23 +1809,23 @@ try {
     `);
     console.log('[OAuth] Migrated oauth_tokens: dropped NOT NULL on token_iv/token_tag');
   }
-} catch (err) { console.error('[OAuth] Migration error:', err); }
-
+} catch (err) {
+  console.error('[OAuth] Migration error:', err);
+}
 
 // OAuth tokens + Withings + Google + Gmail — extracted to src/integrations/routes.ts (T#775)
 initIntegrations(sqlite);
 registerIntegrationsRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, isForgeAuthorized });
-
 
 // Forge — Personal Routine Tracker — extracted to src/forge/routes.ts (T#777)
 // isForgeAuthorized + FORGE_BEAST_MODES kept here for cross-domain consumers (integrations)
 // Forge beast → mode map. 'write' implies 'read'. Owner session always full write.
 // Library #96 lever 1: scope-for-post-compromise-damage — grant the minimum mode each lane needs.
 const FORGE_BEAST_MODES: Record<string, 'read' | 'write'> = {
-  gorn: 'write',   // owner
-  sable: 'write',  // gatekeeper — logs meals for bear
-  karo: 'write',   // partner — bedrock 04-09 grant
-  boro: 'read',    // coach — periodization + progression reads only; writes route through Sable
+  gorn: 'write', // owner
+  sable: 'write', // gatekeeper — logs meals for bear
+  karo: 'write', // partner — bedrock 04-09 grant
+  boro: 'read', // coach — periodization + progression reads only; writes route through Sable
 };
 
 // Auth helper: Gorn (session) + allowlisted beasts per FORGE_BEAST_MODES.
@@ -1520,7 +1835,10 @@ const FORGE_BEAST_MODES: Record<string, 'read' | 'write'> = {
 // the legacy ?as= query param shape. Bearer-token-actor path is checked first;
 // ?as= path retained for backwards-compat with existing callers (Sable TG flows,
 // legacy scripts) until follow-up T# removes it post-migration audit.
-function isForgeAuthorized(c: any, options: { mode: 'read' | 'write' } = { mode: 'write' }): boolean {
+function isForgeAuthorized(
+  c: any,
+  options: { mode: 'read' | 'write' } = { mode: 'write' },
+): boolean {
   if (hasSessionAuth(c)) return true; // Gorn browser session — owner, full write
 
   // T#718 path: read requester from authenticated bearer-token actor (no ?as= needed)
@@ -1529,7 +1847,7 @@ function isForgeAuthorized(c: any, options: { mode: 'read' | 'write' } = { mode:
     const beastMode = FORGE_BEAST_MODES[actor];
     if (!beastMode) return false;
     if (options.mode === 'read') return true; // either mode satisfies read
-    return beastMode === 'write';              // write requires write
+    return beastMode === 'write'; // write requires write
   }
 
   // Backwards-compat: ?as= query param + isTrustedRequest local-network bypass.
@@ -1550,11 +1868,40 @@ function isForgeAuthorized(c: any, options: { mode: 'read' | 'write' } = { mode:
 
 // GET /api/routine/logs — list logs
 registerForgeRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, wsBroadcast });
-registerForumRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast, withRetry, getSupportedEmoji });
-registerDmRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast, sendDm, withRetry });
+registerForumRoutes(app, sqlite, {
+  hasSessionAuth,
+  requireBeastIdentity,
+  isTrustedRequest,
+  wsBroadcast,
+  withRetry,
+  getSupportedEmoji,
+});
+registerDmRoutes(app, sqlite, {
+  hasSessionAuth,
+  requireBeastIdentity,
+  isTrustedRequest,
+  wsBroadcast,
+  sendDm,
+  withRetry,
+});
 registerTraceRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest });
-registerDashboardRoutes(app, sqlite, { hasSessionAuth, handleDashboardSummary, handleDashboardActivity, handleDashboardGrowth, handleStats, handleReflect, handleList, handleGraph, handleMap, handleMap3d, handleVectorStats, getSetting, DB_PATH, oracleCache: null, setOracleCache: () => {} });
-
+registerDashboardRoutes(app, sqlite, {
+  hasSessionAuth,
+  handleDashboardSummary,
+  handleDashboardActivity,
+  handleDashboardGrowth,
+  handleStats,
+  handleReflect,
+  handleList,
+  handleGraph,
+  handleMap,
+  handleMap3d,
+  handleVectorStats,
+  getSetting,
+  DB_PATH,
+  oracleCache: null,
+  setOracleCache: () => {},
+});
 
 // ============================================================================
 // Rules — Decree and Norm governance (T#360)
@@ -1579,42 +1926,121 @@ sqlite.exec(`
 `);
 
 // Unique constraint on active rules to prevent duplicates
-try { sqlite.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_rules_unique_active ON rules (title, type) WHERE status = 'active'"); } catch {}
+try {
+  sqlite.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_rules_unique_active ON rules (title, type) WHERE status = 'active'",
+  );
+} catch {}
 
 // Migration: add decree approval columns
-try { sqlite.exec('ALTER TABLE rules ADD COLUMN approval_status TEXT DEFAULT NULL'); } catch {}
-try { sqlite.exec('ALTER TABLE rules ADD COLUMN approved_by TEXT DEFAULT NULL'); } catch {}
-try { sqlite.exec('ALTER TABLE rules ADD COLUMN approved_at DATETIME DEFAULT NULL'); } catch {}
-try { sqlite.exec('ALTER TABLE rules ADD COLUMN rejection_reason TEXT DEFAULT NULL'); } catch {}
+try {
+  sqlite.exec('ALTER TABLE rules ADD COLUMN approval_status TEXT DEFAULT NULL');
+} catch {}
+try {
+  sqlite.exec('ALTER TABLE rules ADD COLUMN approved_by TEXT DEFAULT NULL');
+} catch {}
+try {
+  sqlite.exec('ALTER TABLE rules ADD COLUMN approved_at DATETIME DEFAULT NULL');
+} catch {}
+try {
+  sqlite.exec('ALTER TABLE rules ADD COLUMN rejection_reason TEXT DEFAULT NULL');
+} catch {}
 
 // Seed data — only on first run (empty table)
 const ruleCount = (sqlite.prepare('SELECT COUNT(*) as c FROM rules').get() as any).c;
 if (ruleCount === 0) {
   const seedRules = [
-    { type: 'decree', title: 'SDD: All new features require spec files', content: 'All new features with endpoints or data models require a spec file in docs/specs/. Big features need Gorn approval via Sable.', author: 'leonard', enforcement: 'mandatory', source_thread_id: 256 },
-    { type: 'decree', title: 'Big features need Gorn approval via Sable', content: 'New projects, cross-team features, and significant architecture changes require spec submission to /specs and Gorn approval routed through Sable.', author: 'leonard', enforcement: 'mandatory', source_thread_id: 256 },
-    { type: 'decree', title: 'All Gorn action items route through Sable', content: 'Sable is the gatekeeper for all Gorn action items — spec approvals, reviews, decisions.', author: 'leonard', enforcement: 'mandatory', source_thread_id: 264 },
-    { type: 'decree', title: 'Nothing is deleted — archive, never delete', content: 'No git push --force. No rm -rf without backup. Supersede, don\'t delete. Timestamps are truth.', author: 'gorn', enforcement: 'mandatory' },
-    { type: 'decree', title: 'No git push --force', content: 'Force pushing violates the Nothing is Deleted principle. Always preserve history.', author: 'gorn', enforcement: 'mandatory' },
-    { type: 'decree', title: 'No commits of secrets (.env, credentials)', content: 'Never commit secrets, .env files, or credentials to any repository.', author: 'gorn', enforcement: 'mandatory' },
-    { type: 'norm', title: 'Use reactions for acknowledgments', content: 'Use emoji reactions (✅, 👀, etc.) for simple acknowledgments. Save posts for substantive content.', author: 'mara', enforcement: 'recommended' },
-    { type: 'norm', title: 'Sign all work with Beast name', content: 'End forum posts and DMs with your Beast name (— Karo, — Zaghnal, etc.) for clear attribution.', author: 'mara', enforcement: 'recommended' },
+    {
+      type: 'decree',
+      title: 'SDD: All new features require spec files',
+      content:
+        'All new features with endpoints or data models require a spec file in docs/specs/. Big features need Gorn approval via Sable.',
+      author: 'leonard',
+      enforcement: 'mandatory',
+      source_thread_id: 256,
+    },
+    {
+      type: 'decree',
+      title: 'Big features need Gorn approval via Sable',
+      content:
+        'New projects, cross-team features, and significant architecture changes require spec submission to /specs and Gorn approval routed through Sable.',
+      author: 'leonard',
+      enforcement: 'mandatory',
+      source_thread_id: 256,
+    },
+    {
+      type: 'decree',
+      title: 'All Gorn action items route through Sable',
+      content:
+        'Sable is the gatekeeper for all Gorn action items — spec approvals, reviews, decisions.',
+      author: 'leonard',
+      enforcement: 'mandatory',
+      source_thread_id: 264,
+    },
+    {
+      type: 'decree',
+      title: 'Nothing is deleted — archive, never delete',
+      content:
+        "No git push --force. No rm -rf without backup. Supersede, don't delete. Timestamps are truth.",
+      author: 'gorn',
+      enforcement: 'mandatory',
+    },
+    {
+      type: 'decree',
+      title: 'No git push --force',
+      content: 'Force pushing violates the Nothing is Deleted principle. Always preserve history.',
+      author: 'gorn',
+      enforcement: 'mandatory',
+    },
+    {
+      type: 'decree',
+      title: 'No commits of secrets (.env, credentials)',
+      content: 'Never commit secrets, .env files, or credentials to any repository.',
+      author: 'gorn',
+      enforcement: 'mandatory',
+    },
+    {
+      type: 'norm',
+      title: 'Use reactions for acknowledgments',
+      content:
+        'Use emoji reactions (✅, 👀, etc.) for simple acknowledgments. Save posts for substantive content.',
+      author: 'mara',
+      enforcement: 'recommended',
+    },
+    {
+      type: 'norm',
+      title: 'Sign all work with Beast name',
+      content:
+        'End forum posts and DMs with your Beast name (— Karo, — Zaghnal, etc.) for clear attribution.',
+      author: 'mara',
+      enforcement: 'recommended',
+    },
   ];
-  const insert = sqlite.prepare('INSERT INTO rules (type, title, content, author, enforcement, source_thread_id) VALUES (?, ?, ?, ?, ?, ?)');
+  const insert = sqlite.prepare(
+    'INSERT INTO rules (type, title, content, author, enforcement, source_thread_id) VALUES (?, ?, ?, ?, ?, ?)',
+  );
   for (const r of seedRules) {
     insert.run(r.type, r.title, r.content, r.author, r.enforcement, r.source_thread_id || null);
   }
 }
 
 // Governance routes extracted to src/governance/routes.ts (T#766)
-registerGovernanceRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, addMessage, sendDm, withRetry, wsBroadcast });
+registerGovernanceRoutes(app, sqlite, {
+  hasSessionAuth,
+  requireBeastIdentity,
+  addMessage,
+  sendDm,
+  withRetry,
+  wsBroadcast,
+});
 
 // ============================================================================
 // Prowl — Personal Task Manager for Gorn (T#279)
 // ============================================================================
 
-
-try { sqlite.prepare(`
+try {
+  sqlite
+    .prepare(`
   CREATE TABLE IF NOT EXISTS prowl_tasks (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT NOT NULL,
@@ -1630,15 +2056,29 @@ try { sqlite.prepare(`
     updated_at TEXT NOT NULL,
     completed_at TEXT
   )
-`).run(); } catch { /* exists */ }
+`)
+    .run();
+} catch {
+  /* exists */
+}
 
 // Add notified_at column for Prowl Telegram notifications (T#467)
-try { sqlite.prepare(`ALTER TABLE prowl_tasks ADD COLUMN notified_at TEXT`).run(); } catch { /* already exists */ }
+try {
+  sqlite.prepare(`ALTER TABLE prowl_tasks ADD COLUMN notified_at TEXT`).run();
+} catch {
+  /* already exists */
+}
 // Add remind_before column for advance reminders (T#471) — values: null, 15m, 30m, 1h, 1d
-try { sqlite.prepare(`ALTER TABLE prowl_tasks ADD COLUMN remind_before TEXT`).run(); } catch { /* already exists */ }
+try {
+  sqlite.prepare(`ALTER TABLE prowl_tasks ADD COLUMN remind_before TEXT`).run();
+} catch {
+  /* already exists */
+}
 
 // --- Prowl Checklist Items (T#628) ---
-try { sqlite.prepare(`
+try {
+  sqlite
+    .prepare(`
   CREATE TABLE IF NOT EXISTS checklist_items (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     task_id INTEGER NOT NULL REFERENCES prowl_tasks(id) ON DELETE CASCADE,
@@ -1648,19 +2088,40 @@ try { sqlite.prepare(`
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   )
-`).run(); } catch { /* exists */ }
+`)
+    .run();
+} catch {
+  /* exists */
+}
 
 // Prowl routes extracted to src/prowl/routes.ts (T#767)
-registerProwlRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, requireBeastIdentity, wsBroadcast, enqueueNotification });
+registerProwlRoutes(app, sqlite, {
+  hasSessionAuth,
+  isTrustedRequest,
+  requireBeastIdentity,
+  wsBroadcast,
+  enqueueNotification,
+});
 
 // Library routes extracted to src/library/routes.ts (T#768)
-registerLibraryRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, searchIndexUpsert, searchIndexDelete, wsBroadcast });
+registerLibraryRoutes(app, sqlite, {
+  hasSessionAuth,
+  requireBeastIdentity,
+  searchIndexUpsert,
+  searchIndexDelete,
+  wsBroadcast,
+});
 
 // Risk routes extracted to src/risk/routes.ts (T#769)
 registerRiskRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, wsBroadcast });
 // Search routes + Meilisearch + FTS5 — extracted to src/search/routes.ts (T#771)
 initSearch(sqlite);
-registerSearchRoutes(app, sqlite, { hasSessionAuth, isLocalNetwork, isTrustedRequest, handleSearch });
+registerSearchRoutes(app, sqlite, {
+  hasSessionAuth,
+  isLocalNetwork,
+  isTrustedRequest,
+  handleSearch,
+});
 
 // Telegram routes + polling — extracted to src/telegram/routes.ts (T#770)
 registerTelegramRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, uploadsDir: UPLOADS_DIR });
@@ -1670,7 +2131,16 @@ registerTelegramRoutes(app, sqlite, { hasSessionAuth, isTrustedRequest, uploadsD
 // Keyed by identity (e.g. 'gorn', 'gorn_guest'). Rebuilt on server restart.
 const webPresence = new Map<string, { identity: string; role: string; lastSeen: number }>();
 export const WEB_PRESENCE_TIMEOUT_MS = 90_000; // 90s — 3 missed heartbeats
-registerPackRoutes(app, sqlite, { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast, getTmuxStatus, normalizeAvatarUrl, webPresence, WEB_PRESENCE_TIMEOUT_MS });
+registerPackRoutes(app, sqlite, {
+  hasSessionAuth,
+  requireBeastIdentity,
+  isTrustedRequest,
+  wsBroadcast,
+  getTmuxStatus,
+  normalizeAvatarUrl,
+  webPresence,
+  WEB_PRESENCE_TIMEOUT_MS,
+});
 registerServerRoutes(app, sqlite, { hasSessionAuth, wsBroadcast, webPresence });
 
 // ============================================================================
@@ -1747,7 +2217,10 @@ const WS_ALLOWED_ORIGINS = new Set([
 ]);
 
 // Validate WebSocket upgrade request
-function validateWsUpgrade(req: Request, server: any): { allowed: boolean; reason?: string; identity?: string } {
+function validateWsUpgrade(
+  req: Request,
+  server: any,
+): { allowed: boolean; reason?: string; identity?: string } {
   // 1. Origin validation — reject cross-origin browser connections.
   // Design decision: missing Origin is allowed (non-browser clients like curl, wscat, Beast
   // processes don't send Origin headers). The auth check below gates non-browser access.
@@ -1759,17 +2232,23 @@ function validateWsUpgrade(req: Request, server: any): { allowed: boolean; reaso
   }
 
   // 2. Auth check — same as REST: local network OR valid session
-  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-    || req.headers.get('x-real-ip')
-    || server.requestIP(req)?.address
-    || '127.0.0.1';
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip') ||
+    server.requestIP(req)?.address ||
+    '127.0.0.1';
 
-  const isLocal = ip === '127.0.0.1' || ip === '::1' || ip === 'localhost'
-    || ip.startsWith('192.168.') || ip.startsWith('10.')
-    || (ip.startsWith('172.') && (() => {
-      const second = parseInt(ip.split('.')[1], 10);
-      return second >= 16 && second <= 31;
-    })());
+  const isLocal =
+    ip === '127.0.0.1' ||
+    ip === '::1' ||
+    ip === 'localhost' ||
+    ip.startsWith('192.168.') ||
+    ip.startsWith('10.') ||
+    (ip.startsWith('172.') &&
+      (() => {
+        const second = parseInt(ip.split('.')[1], 10);
+        return second >= 16 && second <= 31;
+      })());
 
   // Check session cookie from Cookie header
   const cookies = req.headers.get('cookie') || '';
@@ -1799,7 +2278,7 @@ function validateWsUpgrade(req: Request, server: any): { allowed: boolean; reaso
   // Session auth is not required for WS since cookies may not be sent with WS upgrades
   // in all browsers (SameSite restrictions). The origin whitelist prevents cross-site abuse.
 
-  const identity = hasSession ? 'gorn' : (isLocal ? 'local' : (origin ? 'browser' : 'unknown'));
+  const identity = hasSession ? 'gorn' : isLocal ? 'local' : origin ? 'browser' : 'unknown';
   return { allowed: true, identity };
 }
 
@@ -1807,7 +2286,11 @@ function validateWsUpgrade(req: Request, server: any): { allowed: boolean; reaso
 export function wsBroadcast(event: string, data: any) {
   const payload = JSON.stringify({ event, data, ts: Date.now() });
   for (const ws of wsClients) {
-    try { ws.send(payload); } catch { wsClients.delete(ws); }
+    try {
+      ws.send(payload);
+    } catch {
+      wsClients.delete(ws);
+    }
   }
 }
 
@@ -1856,15 +2339,21 @@ export default {
       const validation = validateWsUpgrade(req, server);
       if (!validation.allowed) {
         // Audit log rejected WebSocket upgrade attempts
-        const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-          || req.headers.get('x-real-ip')
-          || server.requestIP(req)?.address || 'unknown';
+        const ip =
+          req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+          req.headers.get('x-real-ip') ||
+          server.requestIP(req)?.address ||
+          'unknown';
         try {
-          sqlite.prepare(
-            `INSERT INTO audit_log (actor, actor_type, action, resource_type, resource_id, ip_source, request_method, request_path, status_code)
-             VALUES (?, 'unknown', 'ws_upgrade_rejected', 'websocket', NULL, ?, 'GET', '/ws', 403)`
-          ).run(req.headers.get('origin') || 'no-origin', ip);
-        } catch (e) { console.error('[WS audit]', e); }
+          sqlite
+            .prepare(
+              `INSERT INTO audit_log (actor, actor_type, action, resource_type, resource_id, ip_source, request_method, request_path, status_code)
+             VALUES (?, 'unknown', 'ws_upgrade_rejected', 'websocket', NULL, ?, 'GET', '/ws', 403)`,
+            )
+            .run(req.headers.get('origin') || 'no-origin', ip);
+        } catch (e) {
+          console.error('[WS audit]', e);
+        }
         return new Response(validation.reason || 'Forbidden', { status: 403 });
       }
       // Derive role and identity from session cookie using the full parser
@@ -1873,13 +2362,21 @@ export default {
       const wsCookies = req.headers.get('cookie') || '';
       const wsSessionMatch = wsCookies.match(/(?:^|;\s*)oracle_session=([^;]+)/);
       const wsParsed = parseSessionToken(wsSessionMatch?.[1] || '');
-      const wsRole = wsParsed.valid ? (wsParsed.role || 'owner') : (validation.identity === 'local' ? 'beast' : 'unknown');
+      const wsRole = wsParsed.valid
+        ? wsParsed.role || 'owner'
+        : validation.identity === 'local'
+          ? 'beast'
+          : 'unknown';
       const wsData = wsParsed.valid && wsParsed.role === 'guest' ? wsParsed.data : undefined;
       // Identity for presence: use parsed session result, fall back to validateWsUpgrade's value
       const wsIdentity = wsParsed.valid
-        ? (wsParsed.role === 'guest' ? (wsParsed.data || 'guest') : 'gorn')
+        ? wsParsed.role === 'guest'
+          ? wsParsed.data || 'guest'
+          : 'gorn'
         : validation.identity;
-      const success = server.upgrade(req, { data: { identity: wsIdentity, role: wsRole, username: wsData } });
+      const success = server.upgrade(req, {
+        data: { identity: wsIdentity, role: wsRole, username: wsData },
+      });
       if (success) return undefined;
       return new Response('WebSocket upgrade failed', { status: 400 });
     }
@@ -1889,7 +2386,13 @@ export default {
     open(ws: any) {
       wsClients.add(ws);
       const identity = ws.data?.identity || 'unknown';
-      ws.send(JSON.stringify({ event: 'connected', data: { clients: wsClients.size, identity }, ts: Date.now() }));
+      ws.send(
+        JSON.stringify({
+          event: 'connected',
+          data: { clients: wsClients.size, identity },
+          ts: Date.now(),
+        }),
+      );
     },
     message(ws: any, message: string) {
       // Clients can send ping, we respond pong
@@ -1910,7 +2413,9 @@ export default {
             }
           }
         }
-      } catch { /* not JSON — ignore */ }
+      } catch {
+        /* not JSON — ignore */
+      }
     },
     close(ws: any) {
       wsClients.delete(ws);

--- a/src/server/__tests__/beast-tokens.test.ts
+++ b/src/server/__tests__/beast-tokens.test.ts
@@ -181,9 +181,9 @@ describe('validateToken', () => {
     const created = createToken('karo', 'gorn');
     if ('token' in created) {
       // Expire token 7h ago — past the 6h grace window
-      sqlite.prepare(
-        `UPDATE beast_tokens SET expires_at = datetime('now', '-7 hours') WHERE id = ?`
-      ).run(created.id);
+      sqlite
+        .prepare(`UPDATE beast_tokens SET expires_at = datetime('now', '-7 hours') WHERE id = ?`)
+        .run(created.id);
       const result = validateToken(created.token);
       expect(result.valid).toBe(false);
       if (!result.valid) {
@@ -196,9 +196,9 @@ describe('validateToken', () => {
     const created = createToken('karo', 'gorn');
     if ('token' in created) {
       // Expire token 1h ago — within the 6h grace window
-      sqlite.prepare(
-        `UPDATE beast_tokens SET expires_at = datetime('now', '-1 hour') WHERE id = ?`
-      ).run(created.id);
+      sqlite
+        .prepare(`UPDATE beast_tokens SET expires_at = datetime('now', '-1 hour') WHERE id = ?`)
+        .run(created.id);
       const result = validateToken(created.token);
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -211,9 +211,11 @@ describe('validateToken', () => {
     const created = createToken('karo', 'gorn');
     if ('token' in created) {
       // 5h59m — safely within the 6h grace window
-      sqlite.prepare(
-        `UPDATE beast_tokens SET expires_at = datetime('now', '-359 minutes') WHERE id = ?`
-      ).run(created.id);
+      sqlite
+        .prepare(
+          `UPDATE beast_tokens SET expires_at = datetime('now', '-359 minutes') WHERE id = ?`,
+        )
+        .run(created.id);
       const result = validateToken(created.token);
       expect(result.valid).toBe(true);
       if (result.valid) {
@@ -226,9 +228,11 @@ describe('validateToken', () => {
     const created = createToken('karo', 'gorn');
     if ('token' in created) {
       // 6h1m — just past the 6h grace window
-      sqlite.prepare(
-        `UPDATE beast_tokens SET expires_at = datetime('now', '-361 minutes') WHERE id = ?`
-      ).run(created.id);
+      sqlite
+        .prepare(
+          `UPDATE beast_tokens SET expires_at = datetime('now', '-361 minutes') WHERE id = ?`,
+        )
+        .run(created.id);
       const result = validateToken(created.token);
       expect(result.valid).toBe(false);
       if (!result.valid) {
@@ -244,9 +248,11 @@ describe('validateToken', () => {
       const rotated = selfRotateToken(created.id, 'karo');
       expect('token' in rotated).toBe(true);
       // Force expiry to 1h ago (within grace) AND rotated_at to 30s ago (outside 10s rotation grace)
-      sqlite.prepare(
-        `UPDATE beast_tokens SET expires_at = datetime('now', '-1 hour'), rotated_at = datetime('now', '-30 seconds') WHERE id = ?`
-      ).run(created.id);
+      sqlite
+        .prepare(
+          `UPDATE beast_tokens SET expires_at = datetime('now', '-1 hour'), rotated_at = datetime('now', '-30 seconds') WHERE id = ?`,
+        )
+        .run(created.id);
       const result = validateToken(created.token);
       // Chain-compromise detection fires before expired-grace check
       expect(result.valid).toBe(false);
@@ -260,9 +266,11 @@ describe('validateToken', () => {
     const created = createToken('karo', 'gorn');
     if ('token' in created) {
       // expires_at 1h ago (within 6h grace), max_lifetime_at 2h ago (should be hard ceiling)
-      sqlite.prepare(
-        `UPDATE beast_tokens SET expires_at = datetime('now', '-1 hour'), max_lifetime_at = datetime('now', '-2 hours') WHERE id = ?`
-      ).run(created.id);
+      sqlite
+        .prepare(
+          `UPDATE beast_tokens SET expires_at = datetime('now', '-1 hour'), max_lifetime_at = datetime('now', '-2 hours') WHERE id = ?`,
+        )
+        .run(created.id);
       const result = validateToken(created.token);
       // GAP: expired-grace early-return at line 352 skips the max_lifetime check at line 356.
       // Token is valid despite being past its absolute lifetime ceiling.
@@ -422,8 +430,8 @@ describe('listTokens', () => {
     }
     createToken('karo', 'gorn');
     const tokens = listTokens();
-    const active = tokens.filter(t => t.active);
-    const inactive = tokens.filter(t => !t.active);
+    const active = tokens.filter((t) => t.active);
+    const inactive = tokens.filter((t) => !t.active);
     expect(active.length).toBe(1);
     expect(inactive.length).toBe(1);
   });
@@ -451,9 +459,11 @@ describe('pruneBeastTokens', () => {
   it('prunes tokens expired beyond grace period', () => {
     createToken('karo', 'gorn');
     // Manually backdate a token to expired 8 days ago (grace period is 7 days)
-    sqlite.prepare(
-      `UPDATE beast_tokens SET expires_at = datetime('now', '-8 days') WHERE beast = 'karo'`
-    ).run();
+    sqlite
+      .prepare(
+        `UPDATE beast_tokens SET expires_at = datetime('now', '-8 days') WHERE beast = 'karo'`,
+      )
+      .run();
     const pruned = pruneBeastTokens();
     expect(pruned).toBe(1);
     expect(listTokens().length).toBe(0);
@@ -464,9 +474,9 @@ describe('pruneBeastTokens', () => {
     if ('token' in created) {
       revokeToken(created.id, 'gorn');
       // Backdate revocation to 8 days ago
-      sqlite.prepare(
-        `UPDATE beast_tokens SET revoked_at = datetime('now', '-8 days') WHERE id = ?`
-      ).run(created.id);
+      sqlite
+        .prepare(`UPDATE beast_tokens SET revoked_at = datetime('now', '-8 days') WHERE id = ?`)
+        .run(created.id);
     }
     const pruned = pruneBeastTokens();
     expect(pruned).toBe(1);
@@ -477,9 +487,9 @@ describe('pruneBeastTokens', () => {
     if ('token' in created) {
       revokeToken(created.id, 'gorn');
       // Revoked 3 days ago — within 7-day grace
-      sqlite.prepare(
-        `UPDATE beast_tokens SET revoked_at = datetime('now', '-3 days') WHERE id = ?`
-      ).run(created.id);
+      sqlite
+        .prepare(`UPDATE beast_tokens SET revoked_at = datetime('now', '-3 days') WHERE id = ?`)
+        .run(created.id);
     }
     const pruned = pruneBeastTokens();
     expect(pruned).toBe(0);
@@ -524,13 +534,19 @@ describe('auto-refresh (Spec #51)', () => {
     if (!('token' in created)) throw new Error('createToken failed');
     // Move expiry to 1h from now (well inside the 6h refresh window) and clear
     // last_used_at so the throttle does not block.
-    sqlite.prepare(
-      `UPDATE beast_tokens SET expires_at = datetime('now', '+1 hour'), last_used_at = NULL WHERE id = ?`
-    ).run(created.id);
-    const before = sqlite.prepare(`SELECT expires_at FROM beast_tokens WHERE id = ?`).get(created.id) as { expires_at: string };
+    sqlite
+      .prepare(
+        `UPDATE beast_tokens SET expires_at = datetime('now', '+1 hour'), last_used_at = NULL WHERE id = ?`,
+      )
+      .run(created.id);
+    const before = sqlite
+      .prepare(`SELECT expires_at FROM beast_tokens WHERE id = ?`)
+      .get(created.id) as { expires_at: string };
     const result = validateToken(created.token);
     expect(result.valid).toBe(true);
-    const after = sqlite.prepare(`SELECT expires_at FROM beast_tokens WHERE id = ?`).get(created.id) as { expires_at: string };
+    const after = sqlite
+      .prepare(`SELECT expires_at FROM beast_tokens WHERE id = ?`)
+      .get(created.id) as { expires_at: string };
     expect(after.expires_at > before.expires_at).toBe(true);
   });
 
@@ -539,12 +555,16 @@ describe('auto-refresh (Spec #51)', () => {
     if (!('token' in created)) throw new Error('createToken failed');
     // Default TTL is 24h; that is well outside the 6h refresh window.
     // Force last_used_at older than throttle so the throttle is not the gate.
-    sqlite.prepare(
-      `UPDATE beast_tokens SET last_used_at = datetime('now', '-10 minutes') WHERE id = ?`
-    ).run(created.id);
-    const before = sqlite.prepare(`SELECT expires_at FROM beast_tokens WHERE id = ?`).get(created.id) as { expires_at: string };
+    sqlite
+      .prepare(`UPDATE beast_tokens SET last_used_at = datetime('now', '-10 minutes') WHERE id = ?`)
+      .run(created.id);
+    const before = sqlite
+      .prepare(`SELECT expires_at FROM beast_tokens WHERE id = ?`)
+      .get(created.id) as { expires_at: string };
     validateToken(created.token);
-    const after = sqlite.prepare(`SELECT expires_at FROM beast_tokens WHERE id = ?`).get(created.id) as { expires_at: string };
+    const after = sqlite
+      .prepare(`SELECT expires_at FROM beast_tokens WHERE id = ?`)
+      .get(created.id) as { expires_at: string };
     expect(after.expires_at).toBe(before.expires_at);
   });
 
@@ -553,17 +573,19 @@ describe('auto-refresh (Spec #51)', () => {
     if (!('token' in created)) throw new Error('createToken failed');
     // Set max_lifetime_at to 2 hours from now and expires_at to 1 hour.
     // Refresh should clamp the new expires_at at +2h, not +24h.
-    sqlite.prepare(
-      `UPDATE beast_tokens
+    sqlite
+      .prepare(
+        `UPDATE beast_tokens
          SET expires_at = datetime('now', '+1 hour'),
              max_lifetime_at = datetime('now', '+2 hours'),
              last_used_at = NULL
-         WHERE id = ?`
-    ).run(created.id);
+         WHERE id = ?`,
+      )
+      .run(created.id);
     validateToken(created.token);
-    const after = sqlite.prepare(
-      `SELECT expires_at, max_lifetime_at FROM beast_tokens WHERE id = ?`
-    ).get(created.id) as { expires_at: string; max_lifetime_at: string };
+    const after = sqlite
+      .prepare(`SELECT expires_at, max_lifetime_at FROM beast_tokens WHERE id = ?`)
+      .get(created.id) as { expires_at: string; max_lifetime_at: string };
     expect(after.expires_at <= after.max_lifetime_at).toBe(true);
   });
 
@@ -575,12 +597,14 @@ describe('auto-refresh (Spec #51)', () => {
     // max_lifetime branch we need expires_at in the future but max_lifetime in
     // the past. That's a state the system shouldn't reach naturally, but we
     // simulate it to verify the branch.
-    sqlite.prepare(
-      `UPDATE beast_tokens
+    sqlite
+      .prepare(
+        `UPDATE beast_tokens
          SET expires_at = datetime('now', '+1 hour'),
              max_lifetime_at = datetime('now', '-1 hour')
-         WHERE id = ?`
-    ).run(created.id);
+         WHERE id = ?`,
+      )
+      .run(created.id);
     const result = validateToken(created.token);
     expect(result.valid).toBe(false);
     if (!result.valid) expect(result.reason).toBe('max_lifetime_reached');
@@ -600,9 +624,13 @@ describe('selfRotateToken (Spec #52)', () => {
     if (!('token' in rotated)) return;
     expect(rotated.token).not.toBe(created.token);
     // Old row should have rotated_at + next_token_id set, NOT revoked.
-    const oldRow = sqlite.prepare(
-      `SELECT rotated_at, next_token_id, revoked_at FROM beast_tokens WHERE id = ?`
-    ).get(created.id) as { rotated_at: string | null; next_token_id: number | null; revoked_at: string | null };
+    const oldRow = sqlite
+      .prepare(`SELECT rotated_at, next_token_id, revoked_at FROM beast_tokens WHERE id = ?`)
+      .get(created.id) as {
+      rotated_at: string | null;
+      next_token_id: number | null;
+      revoked_at: string | null;
+    };
     expect(oldRow.rotated_at).toBeTruthy();
     expect(oldRow.next_token_id).toBe(rotated.id);
     expect(oldRow.revoked_at).toBeNull();
@@ -612,9 +640,9 @@ describe('selfRotateToken (Spec #52)', () => {
     const created = createToken('karo', 'gorn');
     if (!('token' in created)) throw new Error('createToken failed');
     // Expire 7h ago — past the 6h post-expiry grace window
-    sqlite.prepare(
-      `UPDATE beast_tokens SET expires_at = datetime('now', '-7 hours') WHERE id = ?`
-    ).run(created.id);
+    sqlite
+      .prepare(`UPDATE beast_tokens SET expires_at = datetime('now', '-7 hours') WHERE id = ?`)
+      .run(created.id);
     const result = selfRotateToken(created.id, 'karo');
     expect('error' in result).toBe(true);
     if ('error' in result) expect(result.code).toBe('rotate_window_expired');
@@ -624,9 +652,9 @@ describe('selfRotateToken (Spec #52)', () => {
     const created = createToken('karo', 'gorn');
     if (!('token' in created)) throw new Error('createToken failed');
     // Expire 2h ago — within the 6h grace window
-    sqlite.prepare(
-      `UPDATE beast_tokens SET expires_at = datetime('now', '-2 hours') WHERE id = ?`
-    ).run(created.id);
+    sqlite
+      .prepare(`UPDATE beast_tokens SET expires_at = datetime('now', '-2 hours') WHERE id = ?`)
+      .run(created.id);
     const result = selfRotateToken(created.id, 'karo');
     expect('token' in result).toBe(true);
   });
@@ -635,9 +663,9 @@ describe('selfRotateToken (Spec #52)', () => {
     const created = createToken('karo', 'gorn');
     if (!('token' in created)) throw new Error('createToken failed');
     // 5h59m — safely within the 6h grace window
-    sqlite.prepare(
-      `UPDATE beast_tokens SET expires_at = datetime('now', '-359 minutes') WHERE id = ?`
-    ).run(created.id);
+    sqlite
+      .prepare(`UPDATE beast_tokens SET expires_at = datetime('now', '-359 minutes') WHERE id = ?`)
+      .run(created.id);
     const result = selfRotateToken(created.id, 'karo');
     expect('token' in result).toBe(true);
   });
@@ -646,9 +674,9 @@ describe('selfRotateToken (Spec #52)', () => {
     const created = createToken('karo', 'gorn');
     if (!('token' in created)) throw new Error('createToken failed');
     // 6h1m — past the 6h grace window
-    sqlite.prepare(
-      `UPDATE beast_tokens SET expires_at = datetime('now', '-361 minutes') WHERE id = ?`
-    ).run(created.id);
+    sqlite
+      .prepare(`UPDATE beast_tokens SET expires_at = datetime('now', '-361 minutes') WHERE id = ?`)
+      .run(created.id);
     const result = selfRotateToken(created.id, 'karo');
     expect('error' in result).toBe(true);
     if ('error' in result) expect(result.code).toBe('rotate_window_expired');
@@ -658,9 +686,9 @@ describe('selfRotateToken (Spec #52)', () => {
     const created = createToken('karo', 'gorn');
     if (!('token' in created)) throw new Error('createToken failed');
     // Expire 1h ago (within grace), then rotate once
-    sqlite.prepare(
-      `UPDATE beast_tokens SET expires_at = datetime('now', '-1 hour') WHERE id = ?`
-    ).run(created.id);
+    sqlite
+      .prepare(`UPDATE beast_tokens SET expires_at = datetime('now', '-1 hour') WHERE id = ?`)
+      .run(created.id);
     const first = selfRotateToken(created.id, 'karo');
     expect('token' in first).toBe(true);
     // Second rotate on same token — should be locked
@@ -685,17 +713,17 @@ describe('selfRotateToken (Spec #52)', () => {
     const rotated = selfRotateToken(created.id, 'karo');
     if (!('token' in rotated)) throw new Error('selfRotateToken failed');
     // Force rotated_at on old token to 30s ago (outside 10s grace).
-    sqlite.prepare(
-      `UPDATE beast_tokens SET rotated_at = datetime('now', '-30 seconds') WHERE id = ?`
-    ).run(created.id);
+    sqlite
+      .prepare(`UPDATE beast_tokens SET rotated_at = datetime('now', '-30 seconds') WHERE id = ?`)
+      .run(created.id);
     // Replay the OLD (rotated-away) token.
     const result = validateToken(created.token);
     expect(result.valid).toBe(false);
     if (!result.valid) expect(result.reason).toBe('chain_compromised');
     // The new token should also be revoked as part of the chain walk.
-    const newRow = sqlite.prepare(
-      `SELECT revoked_at FROM beast_tokens WHERE id = ?`
-    ).get(rotated.id) as { revoked_at: string | null };
+    const newRow = sqlite
+      .prepare(`SELECT revoked_at FROM beast_tokens WHERE id = ?`)
+      .get(rotated.id) as { revoked_at: string | null };
     expect(newRow.revoked_at).toBeTruthy();
   });
 
@@ -709,9 +737,9 @@ describe('selfRotateToken (Spec #52)', () => {
     expect(result.valid).toBe(true);
     if (result.valid) expect(result.rotationGrace).toBe(true);
     // No chain revoke in grace path.
-    const newRow = sqlite.prepare(
-      `SELECT revoked_at FROM beast_tokens WHERE id = ?`
-    ).get(rotated.id) as { revoked_at: string | null };
+    const newRow = sqlite
+      .prepare(`SELECT revoked_at FROM beast_tokens WHERE id = ?`)
+      .get(rotated.id) as { revoked_at: string | null };
     expect(newRow.revoked_at).toBeNull();
   });
 });
@@ -766,9 +794,11 @@ describe('rotation_recommended flag (Spec #52 Phase 4)', () => {
     const created = createToken('karo', 'gorn');
     if (!('token' in created)) throw new Error('createToken failed');
     // Age token to 13h (past 12h trigger, before 24h door-close).
-    sqlite.prepare(
-      `UPDATE beast_tokens SET created_at = datetime('now', '-13 hours'), expires_at = datetime('now', '+11 hours') WHERE id = ?`
-    ).run(created.id);
+    sqlite
+      .prepare(
+        `UPDATE beast_tokens SET created_at = datetime('now', '-13 hours'), expires_at = datetime('now', '+11 hours') WHERE id = ?`,
+      )
+      .run(created.id);
     const result = validateToken(created.token);
     expect(result.valid).toBe(true);
     if (result.valid) expect(result.rotationRecommended).toBe(true);
@@ -783,9 +813,9 @@ describe('revokeBeastChain (Spec #52)', () => {
     if (!('token' in t2)) throw new Error('selfRotateToken failed');
     const result = revokeBeastChain('karo', 'gorn');
     expect(result.revoked.length).toBe(2);
-    const rows = sqlite.prepare(
-      `SELECT id, revoked_at FROM beast_tokens WHERE beast = ?`
-    ).all('karo') as Array<{ id: number; revoked_at: string | null }>;
-    expect(rows.every(r => r.revoked_at !== null)).toBe(true);
+    const rows = sqlite
+      .prepare(`SELECT id, revoked_at FROM beast_tokens WHERE beast = ?`)
+      .all('karo') as Array<{ id: number; revoked_at: string | null }>;
+    expect(rows.every((r) => r.revoked_at !== null)).toBe(true);
   });
 });

--- a/src/server/__tests__/project-detect.test.ts
+++ b/src/server/__tests__/project-detect.test.ts
@@ -33,9 +33,7 @@ describe('detectProject — GitHub paths', () => {
   });
 
   it('should detect project from GitHub root (no trailing subdir)', () => {
-    expect(detectProject('/Users/nat/Code/github.com/owner/repo')).toBe(
-      'github.com/owner/repo',
-    );
+    expect(detectProject('/Users/nat/Code/github.com/owner/repo')).toBe('github.com/owner/repo');
   });
 });
 
@@ -45,9 +43,7 @@ describe('detectProject — GitHub paths', () => {
 
 describe('detectProject — GitLab paths', () => {
   it('should detect project from ghq GitLab path', () => {
-    expect(detectProject('/Users/nat/Code/gitlab.com/owner/repo')).toBe(
-      'gitlab.com/owner/repo',
-    );
+    expect(detectProject('/Users/nat/Code/gitlab.com/owner/repo')).toBe('gitlab.com/owner/repo');
   });
 });
 
@@ -57,15 +53,13 @@ describe('detectProject — GitLab paths', () => {
 
 describe('detectProject — nested subdirectories', () => {
   it('should extract project from deep nested path', () => {
-    expect(
-      detectProject('/Users/nat/Code/github.com/org/project/src/deep/path'),
-    ).toBe('github.com/org/project');
+    expect(detectProject('/Users/nat/Code/github.com/org/project/src/deep/path')).toBe(
+      'github.com/org/project',
+    );
   });
 
   it('should not include extra path segments beyond owner/repo', () => {
-    const result = detectProject(
-      '/Users/nat/Code/github.com/org/project/packages/core/lib',
-    );
+    const result = detectProject('/Users/nat/Code/github.com/org/project/packages/core/lib');
     expect(result).toBe('github.com/org/project');
   });
 });

--- a/src/server/beast-tokens.ts
+++ b/src/server/beast-tokens.ts
@@ -29,24 +29,27 @@ const TOKEN_PRUNE_GRACE_DAYS = 7; // Keep expired tokens for audit trail
 const LAST_USED_UPDATE_INTERVAL_MS = 60_000; // Once per minute per token
 
 // Spec #51 — auto-refresh constants
-const REFRESH_WINDOW_HOURS = 6;          // Refresh when within this many hours of expiry
-const MAX_LIFETIME_DAYS = 7;             // Hard cap on refresh chain (Bertus security)
-const IDLE_TIMEOUT_DAYS = 7;             // No use in this many days → expires regardless
-const REFRESH_THROTTLE_MINUTES = 5;      // Min gap between refresh-fires per token (write-amp)
+const REFRESH_WINDOW_HOURS = 6; // Refresh when within this many hours of expiry
+const MAX_LIFETIME_DAYS = 7; // Hard cap on refresh chain (Bertus security)
+const IDLE_TIMEOUT_DAYS = 7; // No use in this many days → expires regardless
+const REFRESH_THROTTLE_MINUTES = 5; // Min gap between refresh-fires per token (write-amp)
 
 // Spec #52 — self-rotate constants
-const SELF_ROTATE_WINDOW_HOURS = 24;     // Token must be within this window of created_at/rotated_at to self-rotate
+const SELF_ROTATE_WINDOW_HOURS = 24; // Token must be within this window of created_at/rotated_at to self-rotate
 const SELF_ROTATE_GRACE_AFTER_EXPIRY_HOURS = 6; // Allow self-rotation up to 6h after token expiry (Decree #70 Req 8)
-const ROTATION_GRACE_SECONDS = 10;       // Stale-in-flight window after rotated_at
+const ROTATION_GRACE_SECONDS = 10; // Stale-in-flight window after rotated_at
 // Phase 4 (Gnarl architect-frame #10850 17h-cliff data): rotation_recommended fires
 // at this many hours of token life so Beast self-rotates inside the empirical
 // 17h band-aid cliff envelope. 12h leaves ~5h margin even on the worst observed cliff.
 const ROTATION_RECOMMENDED_HOURS = 12;
 
 // HMAC secret — reuse session secret from env, or generate per-run
-const TOKEN_HMAC_SECRET = process.env.ORACLE_SESSION_SECRET || process.env.ORACLE_TOKEN_SECRET || crypto.randomUUID();
+const TOKEN_HMAC_SECRET =
+  process.env.ORACLE_SESSION_SECRET || process.env.ORACLE_TOKEN_SECRET || crypto.randomUUID();
 if (!process.env.ORACLE_SESSION_SECRET && !process.env.ORACLE_TOKEN_SECRET) {
-  console.warn('[BeastTokens] WARNING: No ORACLE_SESSION_SECRET or ORACLE_TOKEN_SECRET set — tokens will not survive server restart');
+  console.warn(
+    '[BeastTokens] WARNING: No ORACLE_SESSION_SECRET or ORACLE_TOKEN_SECRET set — tokens will not survive server restart',
+  );
 }
 
 // Track last_used_at update timestamps to avoid excessive writes
@@ -78,11 +81,13 @@ try {
   // Spec #51 + #52 — additive migration (idempotent column-adds)
   // Each ALTER wrapped individually because SQLite errors if column exists.
   const cols = sqlite.prepare(`PRAGMA table_info(beast_tokens)`).all() as Array<{ name: string }>;
-  const has = (name: string) => cols.some(c => c.name === name);
+  const has = (name: string) => cols.some((c) => c.name === name);
   if (!has('max_lifetime_at')) {
     sqlite.exec(`ALTER TABLE beast_tokens ADD COLUMN max_lifetime_at TEXT`);
     // Backfill: max_lifetime_at = created_at + MAX_LIFETIME_DAYS for existing rows.
-    sqlite.exec(`UPDATE beast_tokens SET max_lifetime_at = datetime(created_at, '+${MAX_LIFETIME_DAYS} days') WHERE max_lifetime_at IS NULL`);
+    sqlite.exec(
+      `UPDATE beast_tokens SET max_lifetime_at = datetime(created_at, '+${MAX_LIFETIME_DAYS} days') WHERE max_lifetime_at IS NULL`,
+    );
   }
   if (!has('rotated_at')) {
     sqlite.exec(`ALTER TABLE beast_tokens ADD COLUMN rotated_at TEXT`);
@@ -90,7 +95,9 @@ try {
   if (!has('next_token_id')) {
     sqlite.exec(`ALTER TABLE beast_tokens ADD COLUMN next_token_id INTEGER`);
   }
-} catch (err) { console.warn('[BeastTokens] schema init/migration:', err); }
+} catch (err) {
+  console.warn('[BeastTokens] schema init/migration:', err);
+}
 
 // ============================================================================
 // Prepared statements
@@ -102,35 +109,35 @@ const findTokenByBeastStmt = sqlite.prepare(
   `SELECT id, token_hash, expires_at, created_at, rotated_at, max_lifetime_at, last_used_at, next_token_id
    FROM beast_tokens
    WHERE beast = ? AND revoked_at IS NULL
-   ORDER BY created_at DESC`
+   ORDER BY created_at DESC`,
 );
 
 const insertTokenStmt = sqlite.prepare(
   `INSERT INTO beast_tokens (beast, token_hash, expires_at, created_by, max_lifetime_at)
-   VALUES (?, ?, ?, ?, ?)`
+   VALUES (?, ?, ?, ?, ?)`,
 );
 
 const revokeTokenStmt = sqlite.prepare(
-  `UPDATE beast_tokens SET revoked_at = datetime('now') WHERE id = ?`
+  `UPDATE beast_tokens SET revoked_at = datetime('now') WHERE id = ?`,
 );
 
 const updateLastUsedStmt = sqlite.prepare(
-  `UPDATE beast_tokens SET last_used_at = datetime('now') WHERE id = ?`
+  `UPDATE beast_tokens SET last_used_at = datetime('now') WHERE id = ?`,
 );
 
 const countActiveTokensStmt = sqlite.prepare(
   `SELECT COUNT(*) as count FROM beast_tokens
-   WHERE beast = ? AND revoked_at IS NULL AND rotated_at IS NULL AND expires_at > datetime('now')`
+   WHERE beast = ? AND revoked_at IS NULL AND rotated_at IS NULL AND expires_at > datetime('now')`,
 );
 
 const listTokensStmt = sqlite.prepare(
   `SELECT id, beast, created_at, expires_at, revoked_at, last_used_at, created_by, rotated_at, next_token_id, max_lifetime_at
-   FROM beast_tokens ORDER BY created_at DESC`
+   FROM beast_tokens ORDER BY created_at DESC`,
 );
 
 const getTokenByIdStmt = sqlite.prepare(
   `SELECT id, beast, created_at, expires_at, revoked_at, last_used_at, created_by, rotated_at, next_token_id, max_lifetime_at
-   FROM beast_tokens WHERE id = ?`
+   FROM beast_tokens WHERE id = ?`,
 );
 
 // Spec #51 — auto-refresh: single conditional UPDATE with 4 guards.
@@ -145,22 +152,22 @@ const refreshTokenStmt = sqlite.prepare(
      AND datetime('now', '+${REFRESH_WINDOW_HOURS} hours') > expires_at
      AND datetime('now') < max_lifetime_at
      AND (last_used_at IS NULL OR last_used_at < datetime('now', '-${REFRESH_THROTTLE_MINUTES} minutes'))
-     AND (last_used_at IS NULL OR last_used_at > datetime('now', '-${IDLE_TIMEOUT_DAYS} days'))`
+     AND (last_used_at IS NULL OR last_used_at > datetime('now', '-${IDLE_TIMEOUT_DAYS} days'))`,
 );
 
 // Spec #52 — mark a token as rotated, link to its successor.
 const markRotatedStmt = sqlite.prepare(
-  `UPDATE beast_tokens SET rotated_at = datetime('now'), next_token_id = ? WHERE id = ?`
+  `UPDATE beast_tokens SET rotated_at = datetime('now'), next_token_id = ? WHERE id = ?`,
 );
 
 // Spec #52 — chain-walk forward: starting from a rotated_away token id, collect successor IDs.
 const getNextInChainStmt = sqlite.prepare(
-  `SELECT id, next_token_id, revoked_at FROM beast_tokens WHERE id = ?`
+  `SELECT id, next_token_id, revoked_at FROM beast_tokens WHERE id = ?`,
 );
 
 // Spec #52 — find all non-revoked tokens for a beast (for chain-compromise sweep).
 const findActiveAndRotatedByBeastStmt = sqlite.prepare(
-  `SELECT id FROM beast_tokens WHERE beast = ? AND revoked_at IS NULL`
+  `SELECT id FROM beast_tokens WHERE beast = ? AND revoked_at IS NULL`,
 );
 
 // ============================================================================
@@ -179,17 +186,25 @@ function hmacHash(token: string): string {
  * Generate a new token for a beast. Returns plaintext token (shown once).
  * Enforces max active tokens per beast.
  */
-export function createToken(beast: string, createdBy: string, ttlHours?: number): {
-  token: string;
-  id: number;
-  expiresAt: string;
-} | { error: string } {
+export function createToken(
+  beast: string,
+  createdBy: string,
+  ttlHours?: number,
+):
+  | {
+      token: string;
+      id: number;
+      expiresAt: string;
+    }
+  | { error: string } {
   const ttl = ttlHours || TOKEN_TTL_HOURS_DEFAULT;
 
   // Check max active tokens
   const countResult = countActiveTokensStmt.get(beast) as { count: number } | undefined;
   if (countResult && countResult.count >= MAX_ACTIVE_TOKENS_PER_BEAST) {
-    return { error: `Maximum ${MAX_ACTIVE_TOKENS_PER_BEAST} active tokens per beast. Revoke an existing token first.` };
+    return {
+      error: `Maximum ${MAX_ACTIVE_TOKENS_PER_BEAST} active tokens per beast. Revoke an existing token first.`,
+    };
   }
 
   // Generate token: den_{beast}_{32 hex chars from 16 random bytes}
@@ -198,9 +213,15 @@ export function createToken(beast: string, createdBy: string, ttlHours?: number)
   const hash = hmacHash(token);
 
   const nowMs = Date.now();
-  const expiresAt = new Date(nowMs + ttl * 60 * 60 * 1000).toISOString().replace('T', ' ').slice(0, 19);
+  const expiresAt = new Date(nowMs + ttl * 60 * 60 * 1000)
+    .toISOString()
+    .replace('T', ' ')
+    .slice(0, 19);
   // Spec #51 — set hard MAX_LIFETIME cap from issue time, defends rolling-refresh chain length.
-  const maxLifetimeAt = new Date(nowMs + MAX_LIFETIME_DAYS * 24 * 60 * 60 * 1000).toISOString().replace('T', ' ').slice(0, 19);
+  const maxLifetimeAt = new Date(nowMs + MAX_LIFETIME_DAYS * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .replace('T', ' ')
+    .slice(0, 19);
 
   const result = insertTokenStmt.run(beast, hash, expiresAt, createdBy, maxLifetimeAt);
   const id = Number(result.lastInsertRowid);
@@ -221,26 +242,34 @@ export function createToken(beast: string, createdBy: string, ttlHours?: number)
 // Token validation
 // ============================================================================
 
-type TokenValidationResult = {
-  valid: true;
-  beast: string;
-  tokenId: number;
-  // Spec #52 — set when validation accepted under the rotation-grace window;
-  // server can emit a `rotation_grace` warning header for caller telemetry.
-  rotationGrace?: boolean;
-  // Spec #52 Phase 4 — set when token is older than ROTATION_RECOMMENDED_HOURS
-  // and still inside SELF_ROTATE_WINDOW_HOURS. Server emits an
-  // `X-Rotation-Recommended: true` response header so the Beast caller
-  // can call /api/auth/rotate transparently before the door closes.
-  rotationRecommended?: boolean;
-  // Decree #70 Req 8 — token is expired but within SELF_ROTATE_GRACE_AFTER_EXPIRY_HOURS;
-  // only /api/auth/rotate should be reachable with this flag.
-  expiredGrace?: boolean;
-} | {
-  valid: false;
-  reason: 'invalid_format' | 'no_matching_token' | 'expired' | 'revoked' | 'chain_compromised' | 'max_lifetime_reached';
-  beast?: string;
-}
+type TokenValidationResult =
+  | {
+      valid: true;
+      beast: string;
+      tokenId: number;
+      // Spec #52 — set when validation accepted under the rotation-grace window;
+      // server can emit a `rotation_grace` warning header for caller telemetry.
+      rotationGrace?: boolean;
+      // Spec #52 Phase 4 — set when token is older than ROTATION_RECOMMENDED_HOURS
+      // and still inside SELF_ROTATE_WINDOW_HOURS. Server emits an
+      // `X-Rotation-Recommended: true` response header so the Beast caller
+      // can call /api/auth/rotate transparently before the door closes.
+      rotationRecommended?: boolean;
+      // Decree #70 Req 8 — token is expired but within SELF_ROTATE_GRACE_AFTER_EXPIRY_HOURS;
+      // only /api/auth/rotate should be reachable with this flag.
+      expiredGrace?: boolean;
+    }
+  | {
+      valid: false;
+      reason:
+        | 'invalid_format'
+        | 'no_matching_token'
+        | 'expired'
+        | 'revoked'
+        | 'chain_compromised'
+        | 'max_lifetime_reached';
+      beast?: string;
+    };
 
 /**
  * Validate a Bearer token. Returns the beast identity if valid.
@@ -292,7 +321,7 @@ export function validateToken(token: string): TokenValidationResult {
   // Timing-safe comparison against each candidate (Bertus + Gnarl requirement).
   // Iterate ALL rows — never short-circuit on first mismatch — so timing depends
   // only on candidate count, not on which row matches.
-  let matched: typeof rows[number] | null = null;
+  let matched: (typeof rows)[number] | null = null;
   for (const row of rows) {
     const storedBuf = Buffer.from(row.token_hash, 'utf-8');
     const incomingBuf = Buffer.from(incomingHash, 'utf-8');
@@ -375,10 +404,17 @@ export function validateToken(token: string): TokenValidationResult {
   try {
     const refreshResult = refreshTokenStmt.run(matched.id);
     if (refreshResult.changes > 0) {
-      const newExpiresAt = new Date(Math.min(
-        nowMs + TOKEN_TTL_HOURS_DEFAULT * 60 * 60 * 1000,
-        matched.max_lifetime_at ? new Date(matched.max_lifetime_at.replace(' ', 'T') + 'Z').getTime() : Number.MAX_SAFE_INTEGER,
-      )).toISOString().replace('T', ' ').slice(0, 19);
+      const newExpiresAt = new Date(
+        Math.min(
+          nowMs + TOKEN_TTL_HOURS_DEFAULT * 60 * 60 * 1000,
+          matched.max_lifetime_at
+            ? new Date(matched.max_lifetime_at.replace(' ', 'T') + 'Z').getTime()
+            : Number.MAX_SAFE_INTEGER,
+        ),
+      )
+        .toISOString()
+        .replace('T', ' ')
+        .slice(0, 19);
       logSecurityEvent({
         eventType: 'token_refreshed',
         severity: 'info',
@@ -392,7 +428,9 @@ export function validateToken(token: string): TokenValidationResult {
         },
       });
     }
-  } catch { /* non-blocking — refresh is best-effort */ }
+  } catch {
+    /* non-blocking — refresh is best-effort */
+  }
 
   // Update last_used_at (sampled, at most once per minute) — only if refresh
   // didn't already touch it. The refresh UPDATE writes last_used_at as part
@@ -402,7 +440,9 @@ export function validateToken(token: string): TokenValidationResult {
     try {
       updateLastUsedStmt.run(matched.id);
       lastUsedUpdateCache.set(matched.id, nowMs);
-    } catch { /* non-blocking */ }
+    } catch {
+      /* non-blocking */
+    }
   }
 
   // Log token_validated (sampled: first-per-minute-per-beast per Gnarl)
@@ -425,7 +465,8 @@ export function validateToken(token: string): TokenValidationResult {
   // header and call /api/auth/rotate transparently before the window closes.
   const createdMsForFlag = new Date(matched.created_at.replace(' ', 'T') + 'Z').getTime();
   const ageHours = (nowMs - createdMsForFlag) / (60 * 60 * 1000);
-  const rotationRecommended = ageHours >= ROTATION_RECOMMENDED_HOURS && ageHours < SELF_ROTATE_WINDOW_HOURS;
+  const rotationRecommended =
+    ageHours >= ROTATION_RECOMMENDED_HOURS && ageHours < SELF_ROTATE_WINDOW_HOURS;
 
   return { valid: true, beast, tokenId: matched.id, rotationRecommended };
 }
@@ -460,9 +501,16 @@ export function getTokenInfo(tokenId: number): {
 } | null {
   const row = getTokenByIdStmt.get(tokenId) as
     | {
-        id: number; beast: string; created_at: string; expires_at: string;
-        revoked_at: string | null; last_used_at: string | null; created_by: string;
-        rotated_at: string | null; next_token_id: number | null; max_lifetime_at: string | null;
+        id: number;
+        beast: string;
+        created_at: string;
+        expires_at: string;
+        revoked_at: string | null;
+        last_used_at: string | null;
+        created_by: string;
+        rotated_at: string | null;
+        next_token_id: number | null;
+        max_lifetime_at: string | null;
       }
     | undefined;
   if (!row || row.revoked_at) return null;
@@ -480,7 +528,9 @@ export function getTokenInfo(tokenId: number): {
     rotated_at: row.rotated_at,
     next_token_id: row.next_token_id,
     refresh_window_starts_at: fmt(expiresMs - REFRESH_WINDOW_HOURS * 60 * 60 * 1000),
-    self_rotate_door_closes_at: fmt(expiresMs + SELF_ROTATE_GRACE_AFTER_EXPIRY_HOURS * 60 * 60 * 1000),
+    self_rotate_door_closes_at: fmt(
+      expiresMs + SELF_ROTATE_GRACE_AFTER_EXPIRY_HOURS * 60 * 60 * 1000,
+    ),
     rotation_recommended_at: fmt(createdMs + ROTATION_RECOMMENDED_HOURS * 60 * 60 * 1000),
   };
 }
@@ -505,7 +555,8 @@ function revokeChainForward(startTokenId: number): number[] {
     if (seen.has(cursorId)) break;
     seen.add(cursorId);
     const row = getNextInChainStmt.get(cursorId) as
-      { id: number; next_token_id: number | null; revoked_at: string | null } | undefined;
+      | { id: number; next_token_id: number | null; revoked_at: string | null }
+      | undefined;
     if (!row) break;
     if (!row.revoked_at) {
       revokeTokenStmt.run(row.id);
@@ -526,11 +577,16 @@ function revokeChainForward(startTokenId: number): number[] {
  * Beast-self). Spec #52 introduces `selfRotateToken()` as the chain-aware
  * Beast-self primitive — see below.
  */
-export function rotateToken(currentTokenId: number, beast: string): {
-  token: string;
-  id: number;
-  expiresAt: string;
-} | { error: string } {
+export function rotateToken(
+  currentTokenId: number,
+  beast: string,
+):
+  | {
+      token: string;
+      id: number;
+      expiresAt: string;
+    }
+  | { error: string } {
   // Use transaction for atomicity (Bertus + Talon requirement)
   const txn = sqlite.transaction(() => {
     // Revoke old token
@@ -542,9 +598,13 @@ export function rotateToken(currentTokenId: number, beast: string): {
     const hash = hmacHash(token);
     const nowMs = Date.now();
     const expiresAt = new Date(nowMs + TOKEN_TTL_HOURS_DEFAULT * 60 * 60 * 1000)
-      .toISOString().replace('T', ' ').slice(0, 19);
+      .toISOString()
+      .replace('T', ' ')
+      .slice(0, 19);
     const maxLifetimeAt = new Date(nowMs + MAX_LIFETIME_DAYS * 24 * 60 * 60 * 1000)
-      .toISOString().replace('T', ' ').slice(0, 19);
+      .toISOString()
+      .replace('T', ' ')
+      .slice(0, 19);
 
     const result = insertTokenStmt.run(beast, hash, expiresAt, beast, maxLifetimeAt);
     const id = Number(result.lastInsertRowid);
@@ -589,13 +649,28 @@ export function rotateToken(currentTokenId: number, beast: string): {
  * Chain-compromise detection is in `validateToken()`; this primitive only
  * issues new + chain-links old.
  */
-export function selfRotateToken(currentTokenId: number, beast: string): {
-  token: string;
-  id: number;
-  expiresAt: string;
-} | { error: string; code: 'rotate_window_expired' | 'token_not_found' | 'rotation_locked' | 'tx_failed' } {
+export function selfRotateToken(
+  currentTokenId: number,
+  beast: string,
+):
+  | {
+      token: string;
+      id: number;
+      expiresAt: string;
+    }
+  | {
+      error: string;
+      code: 'rotate_window_expired' | 'token_not_found' | 'rotation_locked' | 'tx_failed';
+    } {
   const row = getTokenByIdStmt.get(currentTokenId) as
-    | { id: number; beast: string; created_at: string; expires_at: string; rotated_at: string | null; revoked_at: string | null }
+    | {
+        id: number;
+        beast: string;
+        created_at: string;
+        expires_at: string;
+        rotated_at: string | null;
+        revoked_at: string | null;
+      }
     | undefined;
   if (!row) return { error: 'Token not found', code: 'token_not_found' };
   if (row.revoked_at) return { error: 'Token revoked', code: 'token_not_found' };
@@ -613,9 +688,16 @@ export function selfRotateToken(currentTokenId: number, beast: string): {
       actor: beast,
       actorType: 'beast',
       target: beast,
-      details: { token_id: currentTokenId, failure_reason: 'rotate_window_expired', age_hours: Math.round(ageHours) },
+      details: {
+        token_id: currentTokenId,
+        failure_reason: 'rotate_window_expired',
+        age_hours: Math.round(ageHours),
+      },
     });
-    return { error: 'Self-rotate window expired (6h post-expiry grace passed); owner reprovision required', code: 'rotate_window_expired' };
+    return {
+      error: 'Self-rotate window expired (6h post-expiry grace passed); owner reprovision required',
+      code: 'rotate_window_expired',
+    };
   }
 
   const txn = sqlite.transaction(() => {
@@ -625,9 +707,13 @@ export function selfRotateToken(currentTokenId: number, beast: string): {
     const hash = hmacHash(token);
     const nowMs = Date.now();
     const expiresAt = new Date(nowMs + TOKEN_TTL_HOURS_DEFAULT * 60 * 60 * 1000)
-      .toISOString().replace('T', ' ').slice(0, 19);
+      .toISOString()
+      .replace('T', ' ')
+      .slice(0, 19);
     const maxLifetimeAt = new Date(nowMs + MAX_LIFETIME_DAYS * 24 * 60 * 60 * 1000)
-      .toISOString().replace('T', ' ').slice(0, 19);
+      .toISOString()
+      .replace('T', ' ')
+      .slice(0, 19);
 
     const insertResult = insertTokenStmt.run(beast, hash, expiresAt, beast, maxLifetimeAt);
     const newId = Number(insertResult.lastInsertRowid);
@@ -684,8 +770,13 @@ export function revokeBeastChain(beast: string, revokedBy: string): { revoked: n
 // Token revocation
 // ============================================================================
 
-export function revokeToken(tokenId: number, revokedBy: string): { success: boolean; error?: string } {
-  const row = getTokenByIdStmt.get(tokenId) as { id: number; beast: string; revoked_at: string | null } | undefined;
+export function revokeToken(
+  tokenId: number,
+  revokedBy: string,
+): { success: boolean; error?: string } {
+  const row = getTokenByIdStmt.get(tokenId) as
+    | { id: number; beast: string; revoked_at: string | null }
+    | undefined;
   if (!row) return { success: false, error: 'Token not found' };
   if (row.revoked_at) return { success: false, error: 'Token already revoked' };
 
@@ -728,7 +819,7 @@ export function listTokens(): Array<{
   }>;
 
   const now = new Date().toISOString().replace('T', ' ').slice(0, 19);
-  return rows.map(r => ({
+  return rows.map((r) => ({
     ...r,
     active: !r.revoked_at && r.expires_at > now,
   }));
@@ -743,11 +834,13 @@ const TOKEN_PRUNE_DAYS = TOKEN_PRUNE_GRACE_DAYS;
 export function pruneBeastTokens(): number {
   try {
     const cutoff = `-${TOKEN_PRUNE_DAYS} days`;
-    const result = sqlite.prepare(
-      `DELETE FROM beast_tokens WHERE
+    const result = sqlite
+      .prepare(
+        `DELETE FROM beast_tokens WHERE
         (expires_at < datetime('now', ?))
-        OR (revoked_at IS NOT NULL AND revoked_at < datetime('now', ?))`
-    ).run(cutoff, cutoff);
+        OR (revoked_at IS NOT NULL AND revoked_at < datetime('now', ?))`,
+      )
+      .run(cutoff, cutoff);
     return result.changes || 0;
   } catch (err) {
     console.error(`[BeastTokens] Prune failed: ${err}`);

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -7,18 +7,18 @@ import { execSync } from 'child_process';
 
 export interface ProjectContext {
   // From ghq path parsing
-  github: string;      // "https://github.com/laris-co/oracle-v2"
-  owner: string;       // "laris-co"
-  repo: string;        // "oracle-v2"
-  ghqPath: string;     // "github.com/laris-co/oracle-v2"
+  github: string; // "https://github.com/laris-co/oracle-v2"
+  owner: string; // "laris-co"
+  repo: string; // "oracle-v2"
+  ghqPath: string; // "github.com/laris-co/oracle-v2"
 
   // Directories
-  root: string;        // Git root directory
-  cwd: string;         // Current working directory
+  root: string; // Git root directory
+  cwd: string; // Current working directory
 
   // Git state
-  branch: string;      // Current branch
-  worktree: string;    // Git worktree path
+  branch: string; // Current branch
+  worktree: string; // Git worktree path
 }
 
 /**
@@ -26,7 +26,9 @@ export interface ProjectContext {
  * e.g., ~/Code/github.com/owner/repo/src
  *    -> github.com/owner/repo
  */
-export function parseGhqPath(path: string): { owner: string; repo: string; ghqPath: string } | null {
+export function parseGhqPath(
+  path: string,
+): { owner: string; repo: string; ghqPath: string } | null {
   // Match github.com/owner/repo pattern anywhere in the path
   const match = path.match(/github\.com\/([^\/]+)\/([^\/]+)/);
   if (match) {

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -13,26 +13,25 @@ import type { DashboardSummary, DashboardActivity, DashboardGrowth } from './typ
  */
 export function handleDashboardSummary(): DashboardSummary {
   // Document counts
-  const totalDocsResult = db.select({ count: sql<number>`count(*)` })
-    .from(oracleDocuments)
-    .get();
+  const totalDocsResult = db.select({ count: sql<number>`count(*)` }).from(oracleDocuments).get();
   const totalDocs = totalDocsResult?.count || 0;
 
-  const byTypeResults = db.select({
-    type: oracleDocuments.type,
-    count: sql<number>`count(*)`
-  })
+  const byTypeResults = db
+    .select({
+      type: oracleDocuments.type,
+      count: sql<number>`count(*)`,
+    })
     .from(oracleDocuments)
     .groupBy(oracleDocuments.type)
     .all();
 
   // Concept counts - need to parse JSON concepts from all documents
-  const conceptsResult = db.select({ concepts: oracleDocuments.concepts })
+  const conceptsResult = db
+    .select({ concepts: oracleDocuments.concepts })
     .from(oracleDocuments)
-    .where(and(
-      sql`${oracleDocuments.concepts} IS NOT NULL`,
-      sql`${oracleDocuments.concepts} != '[]'`
-    ))
+    .where(
+      and(sql`${oracleDocuments.concepts} IS NOT NULL`, sql`${oracleDocuments.concepts} != '[]'`),
+    )
     .all();
 
   const conceptCounts = new Map<string, number>();
@@ -59,7 +58,8 @@ export function handleDashboardSummary(): DashboardSummary {
   let learnings7d = 0;
 
   try {
-    const searchResult = db.select({ count: sql<number>`count(*)` })
+    const searchResult = db
+      .select({ count: sql<number>`count(*)` })
       .from(searchLog)
       .where(gt(searchLog.createdAt, sevenDaysAgo))
       .get();
@@ -67,7 +67,8 @@ export function handleDashboardSummary(): DashboardSummary {
   } catch {}
 
   try {
-    const learnResult = db.select({ count: sql<number>`count(*)` })
+    const learnResult = db
+      .select({ count: sql<number>`count(*)` })
       .from(learnLog)
       .where(gt(learnLog.createdAt, sevenDaysAgo))
       .get();
@@ -75,29 +76,30 @@ export function handleDashboardSummary(): DashboardSummary {
   } catch {}
 
   // Health status
-  const lastIndexedResult = db.select({ lastIndexed: sql<number | null>`max(${oracleDocuments.indexedAt})` })
+  const lastIndexedResult = db
+    .select({ lastIndexed: sql<number | null>`max(${oracleDocuments.indexedAt})` })
     .from(oracleDocuments)
     .get();
 
   return {
     documents: {
       total: totalDocs,
-      by_type: byTypeResults.reduce((acc, row) => ({ ...acc, [row.type]: row.count }), {})
+      by_type: byTypeResults.reduce((acc, row) => ({ ...acc, [row.type]: row.count }), {}),
     },
     concepts: {
       total: conceptCounts.size,
-      top: topConcepts
+      top: topConcepts,
     },
     activity: {
       searches_7d: searches7d,
-      learnings_7d: learnings7d
+      learnings_7d: learnings7d,
     },
     health: {
       fts_status: totalDocs > 0 ? 'healthy' : 'empty',
       last_indexed: lastIndexedResult?.lastIndexed
         ? new Date(lastIndexedResult.lastIndexed).toISOString()
-        : null
-    }
+        : null,
+    },
   };
 }
 
@@ -110,50 +112,52 @@ export function handleDashboardActivity(days: number = 7): DashboardActivity {
   // Recent searches
   let searches: DashboardActivity['searches'] = [];
   try {
-    const rows = db.select({
-      query: searchLog.query,
-      type: searchLog.type,
-      resultsCount: searchLog.resultsCount,
-      searchTimeMs: searchLog.searchTimeMs,
-      createdAt: searchLog.createdAt
-    })
+    const rows = db
+      .select({
+        query: searchLog.query,
+        type: searchLog.type,
+        resultsCount: searchLog.resultsCount,
+        searchTimeMs: searchLog.searchTimeMs,
+        createdAt: searchLog.createdAt,
+      })
       .from(searchLog)
       .where(gt(searchLog.createdAt, since))
       .orderBy(desc(searchLog.createdAt))
       .limit(20)
       .all();
 
-    searches = rows.map(row => ({
+    searches = rows.map((row) => ({
       query: row.query.substring(0, 100),
       type: row.type,
       results_count: row.resultsCount,
       search_time_ms: row.searchTimeMs,
-      created_at: new Date(row.createdAt).toISOString()
+      created_at: new Date(row.createdAt).toISOString(),
     }));
   } catch {}
 
   // Recent learnings
   let learnings: DashboardActivity['learnings'] = [];
   try {
-    const rows = db.select({
-      documentId: learnLog.documentId,
-      patternPreview: learnLog.patternPreview,
-      source: learnLog.source,
-      concepts: learnLog.concepts,
-      createdAt: learnLog.createdAt
-    })
+    const rows = db
+      .select({
+        documentId: learnLog.documentId,
+        patternPreview: learnLog.patternPreview,
+        source: learnLog.source,
+        concepts: learnLog.concepts,
+        createdAt: learnLog.createdAt,
+      })
       .from(learnLog)
       .where(gt(learnLog.createdAt, since))
       .orderBy(desc(learnLog.createdAt))
       .limit(20)
       .all();
 
-    learnings = rows.map(row => ({
+    learnings = rows.map((row) => ({
       document_id: row.documentId,
       pattern_preview: row.patternPreview,
       source: row.source,
       concepts: JSON.parse(row.concepts || '[]'),
-      created_at: new Date(row.createdAt).toISOString()
+      created_at: new Date(row.createdAt).toISOString(),
     }));
   } catch {}
 
@@ -167,7 +171,7 @@ export function handleDashboardGrowth(period: string = 'week'): DashboardGrowth 
   const daysMap: Record<string, number> = {
     week: 7,
     month: 30,
-    quarter: 90
+    quarter: 90,
   };
   const days = daysMap[period] || 7;
 
@@ -180,23 +184,19 @@ export function handleDashboardGrowth(period: string = 'week'): DashboardGrowth 
     const date = new Date(dayStart).toISOString().split('T')[0];
 
     // Documents created that day
-    const docsResult = db.select({ count: sql<number>`count(*)` })
+    const docsResult = db
+      .select({ count: sql<number>`count(*)` })
       .from(oracleDocuments)
-      .where(and(
-        gte(oracleDocuments.createdAt, dayStart),
-        lt(oracleDocuments.createdAt, dayEnd)
-      ))
+      .where(and(gte(oracleDocuments.createdAt, dayStart), lt(oracleDocuments.createdAt, dayEnd)))
       .get();
 
     // Searches that day
     let searchCount = 0;
     try {
-      const searchResult = db.select({ count: sql<number>`count(*)` })
+      const searchResult = db
+        .select({ count: sql<number>`count(*)` })
         .from(searchLog)
-        .where(and(
-          gte(searchLog.createdAt, dayStart),
-          lt(searchLog.createdAt, dayEnd)
-        ))
+        .where(and(gte(searchLog.createdAt, dayStart), lt(searchLog.createdAt, dayEnd)))
         .get();
       searchCount = searchResult?.count || 0;
     } catch {}
@@ -204,7 +204,7 @@ export function handleDashboardGrowth(period: string = 'week'): DashboardGrowth 
     data.push({
       date,
       documents: docsResult?.count || 0,
-      searches: searchCount
+      searches: searchCount,
     });
   }
 

--- a/src/server/guest-accounts.ts
+++ b/src/server/guest-accounts.ts
@@ -41,9 +41,27 @@ const LOCKOUT_DURATION_MS = 15 * 60 * 1000; // 15 minutes
 
 // Reserved names that guests cannot use (Beast names + system names)
 const RESERVED_NAMES = new Set([
-  'gorn', 'leonard', 'zaghnal', 'karo', 'gnarl', 'bertus', 'dex', 'quill',
-  'talon', 'flint', 'vigil', 'rax', 'sable', 'snap', 'pip', 'system',
-  'admin', 'owner', 'beast', 'guest', 'unknown',
+  'gorn',
+  'leonard',
+  'zaghnal',
+  'karo',
+  'gnarl',
+  'bertus',
+  'dex',
+  'quill',
+  'talon',
+  'flint',
+  'vigil',
+  'rax',
+  'sable',
+  'snap',
+  'pip',
+  'system',
+  'admin',
+  'owner',
+  'beast',
+  'guest',
+  'unknown',
 ]);
 
 /**
@@ -79,7 +97,7 @@ export function initGuestTables(sqlite: Database): void {
 
   // Add last_active_at column if not present
   try {
-    sqlite.exec("ALTER TABLE guest_accounts ADD COLUMN last_active_at TEXT");
+    sqlite.exec('ALTER TABLE guest_accounts ADD COLUMN last_active_at TEXT');
   } catch {
     // Column already exists
   }
@@ -92,14 +110,38 @@ export function initGuestTables(sqlite: Database): void {
   }
 
   // Add profile fields for guest settings (T#574, Spec #35)
-  try { sqlite.exec("ALTER TABLE guest_accounts ADD COLUMN bio TEXT"); } catch { /* exists */ }
-  try { sqlite.exec("ALTER TABLE guest_accounts ADD COLUMN interests TEXT"); } catch { /* exists */ }
-  try { sqlite.exec("ALTER TABLE guest_accounts ADD COLUMN avatar_url TEXT"); } catch { /* exists */ }
+  try {
+    sqlite.exec('ALTER TABLE guest_accounts ADD COLUMN bio TEXT');
+  } catch {
+    /* exists */
+  }
+  try {
+    sqlite.exec('ALTER TABLE guest_accounts ADD COLUMN interests TEXT');
+  } catch {
+    /* exists */
+  }
+  try {
+    sqlite.exec('ALTER TABLE guest_accounts ADD COLUMN avatar_url TEXT');
+  } catch {
+    /* exists */
+  }
 
   // Add ban fields (T#616, Spec #36)
-  try { sqlite.exec("ALTER TABLE guest_accounts ADD COLUMN banned_at TEXT"); } catch { /* exists */ }
-  try { sqlite.exec("ALTER TABLE guest_accounts ADD COLUMN banned_by TEXT"); } catch { /* exists */ }
-  try { sqlite.exec("ALTER TABLE guest_accounts ADD COLUMN ban_reason TEXT"); } catch { /* exists */ }
+  try {
+    sqlite.exec('ALTER TABLE guest_accounts ADD COLUMN banned_at TEXT');
+  } catch {
+    /* exists */
+  }
+  try {
+    sqlite.exec('ALTER TABLE guest_accounts ADD COLUMN banned_by TEXT');
+  } catch {
+    /* exists */
+  }
+  try {
+    sqlite.exec('ALTER TABLE guest_accounts ADD COLUMN ban_reason TEXT');
+  } catch {
+    /* exists */
+  }
 }
 
 /**
@@ -118,7 +160,9 @@ export async function createGuest(
     throw new Error('Username must be at least 3 characters');
   }
   if (!/^[a-z0-9_-]+$/.test(lower)) {
-    throw new Error('Username must contain only lowercase letters, numbers, hyphens, and underscores');
+    throw new Error(
+      'Username must contain only lowercase letters, numbers, hyphens, and underscores',
+    );
   }
   if (RESERVED_NAMES.has(lower)) {
     throw new Error(`Username "${lower}" is reserved`);
@@ -129,19 +173,25 @@ export async function createGuest(
 
   const hash = await Bun.password.hash(password, { algorithm: 'bcrypt', cost: 12 });
 
-  const result = sqlite.prepare(`
+  const result = sqlite
+    .prepare(`
     INSERT INTO guest_accounts (username, password_hash, display_name, expires_at)
     VALUES (?, ?, ?, ?)
-  `).run(lower, hash, displayName || lower, expiresAt || null);
+  `)
+    .run(lower, hash, displayName || lower, expiresAt || null);
 
-  return sqlite.prepare('SELECT * FROM guest_accounts WHERE id = ?').get(result.lastInsertRowid) as GuestAccount;
+  return sqlite
+    .prepare('SELECT * FROM guest_accounts WHERE id = ?')
+    .get(result.lastInsertRowid) as GuestAccount;
 }
 
 /**
  * List all guest accounts (no password hashes returned).
  */
 export function listGuests(sqlite: Database): Omit<GuestAccount, 'password_hash'>[] {
-  const guests = sqlite.prepare('SELECT * FROM guest_accounts ORDER BY created_at DESC').all() as GuestAccount[];
+  const guests = sqlite
+    .prepare('SELECT * FROM guest_accounts ORDER BY created_at DESC')
+    .all() as GuestAccount[];
   return guests.map(({ password_hash, ...rest }) => rest);
 }
 
@@ -156,14 +206,18 @@ export function getGuest(sqlite: Database, id: number): GuestAccount | null {
  * Get a guest by username.
  */
 export function getGuestByUsername(sqlite: Database, username: string): GuestAccount | null {
-  return sqlite.prepare('SELECT * FROM guest_accounts WHERE username = ?').get(username.toLowerCase().trim()) as GuestAccount | null;
+  return sqlite
+    .prepare('SELECT * FROM guest_accounts WHERE username = ?')
+    .get(username.toLowerCase().trim()) as GuestAccount | null;
 }
 
 /**
  * Look up a guest by display name (case-insensitive). Falls back for DM recipient resolution.
  */
 export function getGuestByDisplayName(sqlite: Database, displayName: string): GuestAccount | null {
-  return sqlite.prepare('SELECT * FROM guest_accounts WHERE LOWER(display_name) = ?').get(displayName.toLowerCase().trim()) as GuestAccount | null;
+  return sqlite
+    .prepare('SELECT * FROM guest_accounts WHERE LOWER(display_name) = ?')
+    .get(displayName.toLowerCase().trim()) as GuestAccount | null;
 }
 
 /**
@@ -215,9 +269,11 @@ export function banGuest(
   reason: string,
 ): GuestAccount | null {
   const now = new Date().toISOString();
-  sqlite.prepare(
-    `UPDATE guest_accounts SET banned_at = ?, banned_by = ?, ban_reason = ?, disabled_at = COALESCE(disabled_at, ?) WHERE id = ?`
-  ).run(now, bannedBy, reason, now, id);
+  sqlite
+    .prepare(
+      `UPDATE guest_accounts SET banned_at = ?, banned_by = ?, ban_reason = ?, disabled_at = COALESCE(disabled_at, ?) WHERE id = ?`,
+    )
+    .run(now, bannedBy, reason, now, id);
   return getGuest(sqlite, id);
 }
 
@@ -225,9 +281,11 @@ export function banGuest(
  * Unban a guest account (T#616).
  */
 export function unbanGuest(sqlite: Database, id: number): GuestAccount | null {
-  sqlite.prepare(
-    `UPDATE guest_accounts SET banned_at = NULL, banned_by = NULL, ban_reason = NULL WHERE id = ?`
-  ).run(id);
+  sqlite
+    .prepare(
+      `UPDATE guest_accounts SET banned_at = NULL, banned_by = NULL, ban_reason = NULL WHERE id = ?`,
+    )
+    .run(id);
   return getGuest(sqlite, id);
 }
 
@@ -264,10 +322,12 @@ export function recordFailedAttempt(sqlite: Database, guest: GuestAccount): void
   const newCount = guest.failed_attempts + 1;
   if (newCount >= LOCKOUT_THRESHOLD) {
     const lockUntil = new Date(Date.now() + LOCKOUT_DURATION_MS).toISOString();
-    sqlite.prepare('UPDATE guest_accounts SET failed_attempts = ?, locked_until = ? WHERE id = ?')
+    sqlite
+      .prepare('UPDATE guest_accounts SET failed_attempts = ?, locked_until = ? WHERE id = ?')
       .run(newCount, lockUntil, guest.id);
   } else {
-    sqlite.prepare('UPDATE guest_accounts SET failed_attempts = ? WHERE id = ?')
+    sqlite
+      .prepare('UPDATE guest_accounts SET failed_attempts = ? WHERE id = ?')
       .run(newCount, guest.id);
   }
 }
@@ -276,7 +336,10 @@ export function recordFailedAttempt(sqlite: Database, guest: GuestAccount): void
  * Record a successful login.
  */
 export function recordSuccessfulLogin(sqlite: Database, guestId: number): void {
-  sqlite.prepare('UPDATE guest_accounts SET failed_attempts = 0, locked_until = NULL, last_login_at = datetime(\'now\') WHERE id = ?')
+  sqlite
+    .prepare(
+      "UPDATE guest_accounts SET failed_attempts = 0, locked_until = NULL, last_login_at = datetime('now') WHERE id = ?",
+    )
     .run(guestId);
 }
 
@@ -318,12 +381,19 @@ export function updateGuestProfile(
 /**
  * Reset a guest's password (by ID, owner action).
  */
-export async function resetGuestPassword(sqlite: Database, id: number, newPassword: string): Promise<boolean> {
+export async function resetGuestPassword(
+  sqlite: Database,
+  id: number,
+  newPassword: string,
+): Promise<boolean> {
   if (!newPassword || newPassword.length < 8) {
     throw new Error('Password must be at least 8 characters');
   }
   const hash = await Bun.password.hash(newPassword, { algorithm: 'bcrypt', cost: 12 });
-  const result = sqlite.prepare('UPDATE guest_accounts SET password_hash = ?, failed_attempts = 0, locked_until = NULL WHERE id = ?')
+  const result = sqlite
+    .prepare(
+      'UPDATE guest_accounts SET password_hash = ?, failed_attempts = 0, locked_until = NULL WHERE id = ?',
+    )
     .run(hash, id);
   return result.changes > 0;
 }
@@ -345,7 +415,10 @@ export async function changeGuestPassword(
     return { success: false, error: 'New password must be at least 8 characters' };
   }
   const hash = await Bun.password.hash(newPassword, { algorithm: 'bcrypt', cost: 12 });
-  sqlite.prepare('UPDATE guest_accounts SET password_hash = ?, failed_attempts = 0, locked_until = NULL WHERE id = ?')
+  sqlite
+    .prepare(
+      'UPDATE guest_accounts SET password_hash = ?, failed_attempts = 0, locked_until = NULL WHERE id = ?',
+    )
     .run(hash, guest.id);
   return { success: true };
 }
@@ -353,9 +426,16 @@ export async function changeGuestPassword(
 /**
  * Log a guest API action to the audit log.
  */
-export function logGuestAction(sqlite: Database, guestId: number, endpoint: string, method: string): void {
-  sqlite.prepare('INSERT INTO guest_audit_log (guest_id, endpoint, method) VALUES (?, ?, ?)')
+export function logGuestAction(
+  sqlite: Database,
+  guestId: number,
+  endpoint: string,
+  method: string,
+): void {
+  sqlite
+    .prepare('INSERT INTO guest_audit_log (guest_id, endpoint, method) VALUES (?, ?, ?)')
     .run(guestId, endpoint, method);
-  sqlite.prepare('UPDATE guest_accounts SET last_active_at = datetime(\'now\') WHERE id = ?')
+  sqlite
+    .prepare("UPDATE guest_accounts SET last_active_at = datetime('now') WHERE id = ?")
     .run(guestId);
 }

--- a/src/server/guest-safety.ts
+++ b/src/server/guest-safety.ts
@@ -57,9 +57,9 @@ interface RateWindow {
 }
 
 // In-memory rate limiters (reset on server restart — acceptable for MVP)
-const guestPostRates = new Map<string, RateWindow>();   // per guest username
-const guestDailyRates = new Map<string, RateWindow>();  // per guest username
-const guestDmRates = new Map<string, RateWindow>();     // per guest username
+const guestPostRates = new Map<string, RateWindow>(); // per guest username
+const guestDailyRates = new Map<string, RateWindow>(); // per guest username
+const guestDmRates = new Map<string, RateWindow>(); // per guest username
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -70,7 +70,12 @@ const LIMITS = {
   dmsPerHour: 100,
 };
 
-function checkRate(map: Map<string, RateWindow>, key: string, limit: number, windowMs: number): { allowed: boolean; remaining: number; retryAfterMs?: number } {
+function checkRate(
+  map: Map<string, RateWindow>,
+  key: string,
+  limit: number,
+  windowMs: number,
+): { allowed: boolean; remaining: number; retryAfterMs?: number } {
   const now = Date.now();
   const entry = map.get(key);
 
@@ -94,7 +99,10 @@ function checkRate(map: Map<string, RateWindow>, key: string, limit: number, win
 export function checkGuestPostRate(username: string): { allowed: boolean; error?: string } {
   const hourly = checkRate(guestPostRates, username, LIMITS.postsPerHour, HOUR_MS);
   if (!hourly.allowed) {
-    return { allowed: false, error: `You're posting a bit fast! Take a breather and try again shortly.` };
+    return {
+      allowed: false,
+      error: `You're posting a bit fast! Take a breather and try again shortly.`,
+    };
   }
 
   const daily = checkRate(guestDailyRates, username, LIMITS.postsPerDay, DAY_MS);
@@ -111,7 +119,10 @@ export function checkGuestPostRate(username: string): { allowed: boolean; error?
 export function checkGuestDmRate(username: string): { allowed: boolean; error?: string } {
   const hourly = checkRate(guestDmRates, username, LIMITS.dmsPerHour, HOUR_MS);
   if (!hourly.allowed) {
-    return { allowed: false, error: `You're sending messages a bit fast! Take a breather and try again shortly.` };
+    return {
+      allowed: false,
+      error: `You're sending messages a bit fast! Take a breather and try again shortly.`,
+    };
   }
   return { allowed: true };
 }
@@ -121,12 +132,15 @@ export function checkGuestDmRate(username: string): { allowed: boolean; error?: 
 // ============================================================================
 
 const GUEST_MAX_POST_LENGTH = 4000; // characters
-const GUEST_MAX_DM_LENGTH = 2000;   // characters
+const GUEST_MAX_DM_LENGTH = 2000; // characters
 
 /**
  * Check content length for guest posts.
  */
-export function checkGuestContentLength(content: string, type: 'post' | 'dm'): { allowed: boolean; error?: string } {
+export function checkGuestContentLength(
+  content: string,
+  type: 'post' | 'dm',
+): { allowed: boolean; error?: string } {
   const limit = type === 'post' ? GUEST_MAX_POST_LENGTH : GUEST_MAX_DM_LENGTH;
   if (content.length > limit) {
     return { allowed: false, error: `Message too long (${content.length}/${limit} characters)` };

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -12,7 +12,12 @@ import { db, sqlite, oracleDocuments, indexingStatus } from '../db/index.ts';
 import { REPO_ROOT } from '../config.ts';
 import { logSearch, logDocumentAccess, logLearning } from './logging.ts';
 import type { SearchResult, SearchResponse } from './types.ts';
-import { getVectorStoreByModel, ensureVectorStoreConnected, getEmbeddingModels, EMBEDDING_MODELS } from '../vector/factory.ts';
+import {
+  getVectorStoreByModel,
+  ensureVectorStoreConnected,
+  getEmbeddingModels,
+  EMBEDDING_MODELS,
+} from '../vector/factory.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
 import { detectProject } from './project-detect.ts';
 import { coerceConcepts } from '../tools/learn.ts';
@@ -32,15 +37,18 @@ export async function handleSearch(
   limit: number = 10,
   offset: number = 0,
   mode: 'hybrid' | 'fts' | 'vector' = 'hybrid',
-  project?: string,  // If set: project + universal. If null/undefined: universal only
-  cwd?: string,      // Auto-detect project from cwd if project not specified
-  model?: string     // Embedding model: 'bge-m3' (default, multilingual) or 'nomic' (fast)
+  project?: string, // If set: project + universal. If null/undefined: universal only
+  cwd?: string, // Auto-detect project from cwd if project not specified
+  model?: string, // Embedding model: 'bge-m3' (default, multilingual) or 'nomic' (fast)
 ): Promise<SearchResponse & { mode?: string; warning?: string; model?: string }> {
   // Auto-detect project from cwd if not explicitly specified
   const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
   const startTime = Date.now();
   // Remove FTS5 special characters: ? * + - ( ) ^ ~ " ' : (colon is column prefix)
-  const safeQuery = query.replace(/[?*+\-()^~"':]/g, ' ').replace(/\s+/g, ' ').trim();
+  const safeQuery = query
+    .replace(/[?*+\-()^~"':]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 
   let warning: string | undefined;
 
@@ -50,9 +58,7 @@ export async function handleSearch(
 
   // Project filter: if project specified, include project + universal (NULL)
   // If no project, return ALL documents (no filter)
-  const projectFilter = resolvedProject
-    ? '(d.project = ? OR d.project IS NULL)'
-    : '1=1';
+  const projectFilter = resolvedProject ? '(d.project = ? OR d.project IS NULL)' : '1=1';
   const projectParams = resolvedProject ? [resolvedProject] : [];
 
   // FTS5 search must use raw SQL (Drizzle doesn't support virtual tables)
@@ -82,7 +88,7 @@ export async function handleSearch(
         concepts: JSON.parse(row.concepts || '[]'),
         project: row.project,
         source: 'fts' as const,
-        score: normalizeRank(row.score)
+        score: normalizeRank(row.score),
       }));
     } else {
       const countStmt = sqlite.prepare(`
@@ -109,7 +115,7 @@ export async function handleSearch(
         concepts: JSON.parse(row.concepts || '[]'),
         project: row.project,
         source: 'fts' as const,
-        score: normalizeRank(row.score)
+        score: normalizeRank(row.score),
       }));
     }
   }
@@ -136,12 +142,13 @@ export async function handleSearch(
         if (!chromaResults.ids || chromaResults.ids.length === 0) return [];
 
         // Get project metadata
-        const rows = db.select({ id: oracleDocuments.id, project: oracleDocuments.project })
+        const rows = db
+          .select({ id: oracleDocuments.id, project: oracleDocuments.project })
           .from(oracleDocuments)
           .where(inArray(oracleDocuments.id, chromaResults.ids))
           .all();
         const projectMap = new Map<string, string | null>();
-        rows.forEach(r => projectMap.set(r.id, r.project));
+        rows.forEach((r) => projectMap.set(r.id, r.project));
 
         return chromaResults.ids
           .map((id: string, i: number) => {
@@ -158,14 +165,14 @@ export async function handleSearch(
               source: 'vector' as const,
               score: similarity,
               distance,
-              model: modelName
+              model: modelName,
             };
           })
-          .filter(r => {
+          .filter((r) => {
             if (!resolvedProject) return true;
             return r.project === resolvedProject || r.project === null;
           });
-      })
+      }),
     );
 
     // Merge results from all models
@@ -190,16 +197,20 @@ export async function handleSearch(
           bestByDoc.set(r.id, {
             ...r,
             score: Math.min(1, (r.score || 0) + multiBoost),
-            source: existing ? 'hybrid' as const : r.source,
+            source: existing ? ('hybrid' as const) : r.source,
           });
         }
       }
       vectorResults = Array.from(bestByDoc.values());
-      console.log(`[Multi] Merged ${vectorResults.length} unique results from ${modelsToQuery.length} models`);
+      console.log(
+        `[Multi] Merged ${vectorResults.length} unique results from ${modelsToQuery.length} models`,
+      );
     }
 
     if (vectorResults.length > 0) {
-      console.log(`[Vector] ${vectorResults.length} results, top scores: ${vectorResults.slice(0, 3).map(r => r.score?.toFixed(3))}`);
+      console.log(
+        `[Vector] ${vectorResults.length} results, top scores: ${vectorResults.slice(0, 3).map((r) => r.score?.toFixed(3))}`,
+      );
     }
   }
 
@@ -214,7 +225,10 @@ export async function handleSearch(
       const stats = await client.getStats();
       if (stats.count > 0) total = stats.count;
     } catch (error) {
-      console.warn('[Hybrid] getStats for vector-only total failed:', error instanceof Error ? error.message : String(error));
+      console.warn(
+        '[Hybrid] getStats for vector-only total failed:',
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 
@@ -224,7 +238,7 @@ export async function handleSearch(
   // Log search
   const searchTime = Date.now() - startTime;
   logSearch(query, type, mode, total, searchTime, results);
-  results.forEach(r => logDocumentAccess(r.id, 'search'));
+  results.forEach((r) => logDocumentAccess(r.id, 'search'));
 
   return {
     results,
@@ -233,7 +247,7 @@ export async function handleSearch(
     limit,
     mode,
     ...(model === 'multi' ? { model: 'multi' } : model && EMBEDDING_MODELS[model] ? { model } : {}),
-    ...(warning && { warning })
+    ...(warning && { warning }),
   };
 }
 
@@ -269,7 +283,7 @@ function combineSearchResults(fts: SearchResult[], vector: SearchResult[]): Sear
         score: Math.min(1, maxScore + bonus), // Cap at 1.0
         source: 'hybrid' as const,
         distance: r.distance,
-        model: r.model
+        model: r.model,
       });
     } else {
       seen.set(r.id, r);
@@ -285,17 +299,15 @@ function combineSearchResults(fts: SearchResult[], vector: SearchResult[]): Sear
  */
 export function handleReflect() {
   // Get random document using Drizzle
-  const randomDoc = db.select({
-    id: oracleDocuments.id,
-    type: oracleDocuments.type,
-    sourceFile: oracleDocuments.sourceFile,
-    concepts: oracleDocuments.concepts
-  })
+  const randomDoc = db
+    .select({
+      id: oracleDocuments.id,
+      type: oracleDocuments.type,
+      sourceFile: oracleDocuments.sourceFile,
+      concepts: oracleDocuments.concepts,
+    })
     .from(oracleDocuments)
-    .where(or(
-      eq(oracleDocuments.type, 'principle'),
-      eq(oracleDocuments.type, 'learning')
-    ))
+    .where(or(eq(oracleDocuments.type, 'principle'), eq(oracleDocuments.type, 'learning')))
     .orderBy(sql`RANDOM()`)
     .limit(1)
     .get();
@@ -305,9 +317,11 @@ export function handleReflect() {
   }
 
   // Get content from FTS (must use raw SQL)
-  const content = sqlite.prepare(`
+  const content = sqlite
+    .prepare(`
     SELECT content FROM oracle_fts WHERE id = ?
-  `).get(randomDoc.id) as { content: string } | undefined;
+  `)
+    .get(randomDoc.id) as { content: string } | undefined;
 
   if (!content) {
     return { error: 'Document content not found in FTS index' };
@@ -318,7 +332,7 @@ export function handleReflect() {
     type: randomDoc.type,
     content: content.content,
     source_file: randomDoc.sourceFile,
-    concepts: JSON.parse(randomDoc.concepts || '[]')
+    concepts: JSON.parse(randomDoc.concepts || '[]'),
   };
 }
 
@@ -329,7 +343,12 @@ export function handleReflect() {
  * Note: Uses raw SQL for FTS JOIN since Drizzle doesn't support virtual tables.
  * Count queries use Drizzle where possible.
  */
-export function handleList(type: string = 'all', limit: number = 10, offset: number = 0, groupByFile: boolean = true): SearchResponse {
+export function handleList(
+  type: string = 'all',
+  limit: number = 10,
+  offset: number = 0,
+  groupByFile: boolean = true,
+): SearchResponse {
   // Validate
   if (limit < 1 || limit > 100) limit = 10;
   if (offset < 0) offset = 0;
@@ -338,7 +357,8 @@ export function handleList(type: string = 'all', limit: number = 10, offset: num
     // Group by source_file to avoid duplicate entries from same file
     if (type === 'all') {
       // Count distinct files using Drizzle
-      const countResult = db.select({ total: sql<number>`count(distinct ${oracleDocuments.sourceFile})` })
+      const countResult = db
+        .select({ total: sql<number>`count(distinct ${oracleDocuments.sourceFile})` })
         .from(oracleDocuments)
         .get();
       const total = countResult?.total || 0;
@@ -359,13 +379,14 @@ export function handleList(type: string = 'all', limit: number = 10, offset: num
         source_file: row.source_file,
         concepts: row.concepts ? JSON.parse(row.concepts) : [],
         project: row.project,
-        indexed_at: row.indexed_at
+        indexed_at: row.indexed_at,
       }));
 
       return { results, total, offset, limit };
     } else {
       // Count distinct files for type using Drizzle
-      const countResult = db.select({ total: sql<number>`count(distinct ${oracleDocuments.sourceFile})` })
+      const countResult = db
+        .select({ total: sql<number>`count(distinct ${oracleDocuments.sourceFile})` })
         .from(oracleDocuments)
         .where(eq(oracleDocuments.type, type))
         .get();
@@ -388,7 +409,7 @@ export function handleList(type: string = 'all', limit: number = 10, offset: num
         source_file: row.source_file,
         concepts: JSON.parse(row.concepts || '[]'),
         project: row.project,
-        indexed_at: row.indexed_at
+        indexed_at: row.indexed_at,
       }));
 
       return { results, total, offset, limit };
@@ -398,9 +419,7 @@ export function handleList(type: string = 'all', limit: number = 10, offset: num
   // Original behavior without grouping
   if (type === 'all') {
     // Count using Drizzle
-    const countResult = db.select({ total: sql<number>`count(*)` })
-      .from(oracleDocuments)
-      .get();
+    const countResult = db.select({ total: sql<number>`count(*)` }).from(oracleDocuments).get();
     const total = countResult?.total || 0;
 
     // Need raw SQL for FTS JOIN
@@ -418,13 +437,14 @@ export function handleList(type: string = 'all', limit: number = 10, offset: num
       source_file: row.source_file,
       concepts: row.concepts ? JSON.parse(row.concepts) : [],
       project: row.project,
-      indexed_at: row.indexed_at
+      indexed_at: row.indexed_at,
     }));
 
     return { results, total, offset, limit };
   } else {
     // Count using Drizzle
-    const countResult = db.select({ total: sql<number>`count(*)` })
+    const countResult = db
+      .select({ total: sql<number>`count(*)` })
       .from(oracleDocuments)
       .where(eq(oracleDocuments.type, type))
       .get();
@@ -446,7 +466,7 @@ export function handleList(type: string = 'all', limit: number = 10, offset: num
       source_file: row.source_file,
       concepts: JSON.parse(row.concepts || '[]'),
       project: row.project,
-      indexed_at: row.indexed_at
+      indexed_at: row.indexed_at,
     }));
 
     return { results, total, offset, limit };
@@ -458,22 +478,22 @@ export function handleList(type: string = 'all', limit: number = 10, offset: num
  */
 export function handleStats(dbPath: string) {
   // Total documents using Drizzle
-  const totalDocsResult = db.select({ count: sql<number>`count(*)` })
-    .from(oracleDocuments)
-    .get();
+  const totalDocsResult = db.select({ count: sql<number>`count(*)` }).from(oracleDocuments).get();
   const totalDocs = totalDocsResult?.count || 0;
 
   // Count by type using Drizzle
-  const byTypeResults = db.select({
-    type: oracleDocuments.type,
-    count: sql<number>`count(*)`
-  })
+  const byTypeResults = db
+    .select({
+      type: oracleDocuments.type,
+      count: sql<number>`count(*)`,
+    })
     .from(oracleDocuments)
     .groupBy(oracleDocuments.type)
     .all();
 
   // Get last indexed timestamp using Drizzle
-  const lastIndexedResult = db.select({ lastIndexed: sql<number | null>`max(${oracleDocuments.indexedAt})` })
+  const lastIndexedResult = db
+    .select({ lastIndexed: sql<number | null>`max(${oracleDocuments.indexedAt})` })
     .from(oracleDocuments)
     .get();
 
@@ -487,14 +507,20 @@ export function handleStats(dbPath: string) {
     : null;
 
   // Get indexing status using Drizzle
-  let idxStatus = { is_indexing: false, progress_current: 0, progress_total: 0, completed_at: null as number | null };
+  let idxStatus = {
+    is_indexing: false,
+    progress_current: 0,
+    progress_total: 0,
+    completed_at: null as number | null,
+  };
   try {
-    const status = db.select({
-      isIndexing: indexingStatus.isIndexing,
-      progressCurrent: indexingStatus.progressCurrent,
-      progressTotal: indexingStatus.progressTotal,
-      completedAt: indexingStatus.completedAt
-    })
+    const status = db
+      .select({
+        isIndexing: indexingStatus.isIndexing,
+        progressCurrent: indexingStatus.progressCurrent,
+        progressTotal: indexingStatus.progressTotal,
+        completedAt: indexingStatus.completedAt,
+      })
       .from(indexingStatus)
       .where(eq(indexingStatus.id, 1))
       .get();
@@ -504,7 +530,7 @@ export function handleStats(dbPath: string) {
         is_indexing: status.isIndexing === 1,
         progress_current: status.progressCurrent || 0,
         progress_total: status.progressTotal || 0,
-        completed_at: status.completedAt
+        completed_at: status.completedAt,
       };
     }
   } catch (e) {
@@ -512,10 +538,11 @@ export function handleStats(dbPath: string) {
   }
 
   // Unique files by type (deduped by source_file)
-  const uniqueByType = db.select({
-    type: oracleDocuments.type,
-    count: sql<number>`count(DISTINCT ${oracleDocuments.sourceFile})`
-  })
+  const uniqueByType = db
+    .select({
+      type: oracleDocuments.type,
+      count: sql<number>`count(DISTINCT ${oracleDocuments.sourceFile})`,
+    })
     .from(oracleDocuments)
     .groupBy(oracleDocuments.type)
     .all();
@@ -528,15 +555,18 @@ export function handleStats(dbPath: string) {
     index_age_hours: indexAgeHours ? Math.round(indexAgeHours * 10) / 10 : null,
     is_stale: indexAgeHours ? indexAgeHours > 24 : true,
     is_indexing: idxStatus.is_indexing,
-    indexing_progress: idxStatus.is_indexing ? {
-      current: idxStatus.progress_current,
-      total: idxStatus.progress_total,
-      percent: idxStatus.progress_total > 0
-        ? Math.round((idxStatus.progress_current / idxStatus.progress_total) * 100)
-        : 0
-    } : null,
+    indexing_progress: idxStatus.is_indexing
+      ? {
+          current: idxStatus.progress_current,
+          total: idxStatus.progress_total,
+          percent:
+            idxStatus.progress_total > 0
+              ? Math.round((idxStatus.progress_current / idxStatus.progress_total) * 100)
+              : 0,
+        }
+      : null,
     indexing_completed_at: idxStatus.completed_at,
-    database: dbPath
+    database: dbPath,
   };
 }
 
@@ -553,25 +583,28 @@ export function handleGraph(limitPerType = 310) {
     type: oracleDocuments.type,
     sourceFile: oracleDocuments.sourceFile,
     concepts: oracleDocuments.concepts,
-    project: oracleDocuments.project
+    project: oracleDocuments.project,
   };
 
   // Get random sample from each type
-  const principles = db.select(selectFields)
+  const principles = db
+    .select(selectFields)
     .from(oracleDocuments)
     .where(eq(oracleDocuments.type, 'principle'))
     .orderBy(sql`RANDOM()`)
     .limit(perType)
     .all();
 
-  const learnings = db.select(selectFields)
+  const learnings = db
+    .select(selectFields)
     .from(oracleDocuments)
     .where(eq(oracleDocuments.type, 'learning'))
     .orderBy(sql`RANDOM()`)
     .limit(perType)
     .all();
 
-  const retros = db.select(selectFields)
+  const retros = db
+    .select(selectFields)
     .from(oracleDocuments)
     .where(eq(oracleDocuments.type, 'retro'))
     .orderBy(sql`RANDOM()`)
@@ -581,12 +614,12 @@ export function handleGraph(limitPerType = 310) {
   const docs = [...principles, ...learnings, ...retros];
 
   // Build nodes
-  const nodes = docs.map(doc => ({
+  const nodes = docs.map((doc) => ({
     id: doc.id,
     type: doc.type,
     source_file: doc.sourceFile,
     project: doc.project,
-    concepts: JSON.parse(doc.concepts || '[]')
+    concepts: JSON.parse(doc.concepts || '[]'),
   }));
 
   // Build links based on shared concepts (require 2+ shared for stronger connections)
@@ -594,7 +627,7 @@ export function handleGraph(limitPerType = 310) {
   const MAX_LINKS = 5000;
 
   // Pre-compute concept sets
-  const conceptSets = nodes.map(n => new Set(n.concepts));
+  const conceptSets = nodes.map((n) => new Set(n.concepts));
 
   for (let i = 0; i < nodes.length && links.length < MAX_LINKS; i++) {
     for (let j = i + 1; j < nodes.length && links.length < MAX_LINKS; j++) {
@@ -604,7 +637,7 @@ export function handleGraph(limitPerType = 310) {
         links.push({
           source: nodes[i].id,
           target: nodes[j].id,
-          weight: sharedCount
+          weight: sharedCount,
         });
       }
     }
@@ -619,7 +652,7 @@ export function handleGraph(limitPerType = 310) {
 export async function handleSimilar(
   docId: string,
   limit: number = 5,
-  model?: string
+  model?: string,
 ): Promise<{ results: SearchResult[]; docId: string }> {
   try {
     const client = await getVectorStore(model && EMBEDDING_MODELS[model] ? model : undefined);
@@ -630,18 +663,19 @@ export async function handleSimilar(
     }
 
     // Enrich with SQLite data (concepts, project)
-    const rows = db.select({
-      id: oracleDocuments.id,
-      type: oracleDocuments.type,
-      sourceFile: oracleDocuments.sourceFile,
-      concepts: oracleDocuments.concepts,
-      project: oracleDocuments.project
-    })
+    const rows = db
+      .select({
+        id: oracleDocuments.id,
+        type: oracleDocuments.type,
+        sourceFile: oracleDocuments.sourceFile,
+        concepts: oracleDocuments.concepts,
+        project: oracleDocuments.project,
+      })
       .from(oracleDocuments)
       .where(inArray(oracleDocuments.id, chromaResults.ids))
       .all();
 
-    const docMap = new Map(rows.map(r => [r.id, r]));
+    const docMap = new Map(rows.map((r) => [r.id, r]));
 
     const results: SearchResult[] = chromaResults.ids.map((id: string, i: number) => {
       const distance = chromaResults.distances?.[i] || 1;
@@ -656,7 +690,7 @@ export async function handleSimilar(
         concepts: doc?.concepts ? JSON.parse(doc.concepts) : [],
         project: doc?.project,
         source: 'vector' as const,
-        score: similarity
+        score: similarity,
       };
     });
 
@@ -703,20 +737,21 @@ export async function handleMap(): Promise<{
   total: number;
 }> {
   // Return cached result if fresh
-  if (mapCache && (Date.now() - mapCache.timestamp) < MAP_CACHE_TTL) {
+  if (mapCache && Date.now() - mapCache.timestamp < MAP_CACHE_TTL) {
     return mapCache.data;
   }
 
   try {
     // Get all docs from SQLite (no ChromaDB dependency)
-    const allDocs = db.select({
-      id: oracleDocuments.id,
-      type: oracleDocuments.type,
-      sourceFile: oracleDocuments.sourceFile,
-      concepts: oracleDocuments.concepts,
-      project: oracleDocuments.project,
-      createdAt: oracleDocuments.createdAt
-    })
+    const allDocs = db
+      .select({
+        id: oracleDocuments.id,
+        type: oracleDocuments.type,
+        sourceFile: oracleDocuments.sourceFile,
+        concepts: oracleDocuments.concepts,
+        project: oracleDocuments.project,
+        createdAt: oracleDocuments.createdAt,
+      })
       .from(oracleDocuments)
       .all();
 
@@ -725,15 +760,18 @@ export async function handleMap(): Promise<{
     }
 
     // Deduplicate by source_file — merge concepts and collect chunk IDs
-    const fileMap = new Map<string, {
-      id: string;
-      type: string;
-      sourceFile: string;
-      allConcepts: string[];
-      chunkIds: string[];
-      project: string | null;
-      createdAt: number | null;
-    }>();
+    const fileMap = new Map<
+      string,
+      {
+        id: string;
+        type: string;
+        sourceFile: string;
+        allConcepts: string[];
+        chunkIds: string[];
+        project: string | null;
+        createdAt: number | null;
+      }
+    >();
     for (const doc of allDocs) {
       const key = doc.sourceFile;
       const existing = fileMap.get(key);
@@ -746,7 +784,7 @@ export async function handleMap(): Promise<{
           allConcepts: concepts,
           chunkIds: [doc.id],
           project: doc.project || null,
-          createdAt: doc.createdAt
+          createdAt: doc.createdAt,
         });
       } else {
         existing.chunkIds.push(doc.id);
@@ -803,7 +841,7 @@ export async function handleMap(): Promise<{
         project: doc.project,
         x,
         y,
-        created_at: doc.createdAt ? new Date(doc.createdAt).toISOString() : null
+        created_at: doc.createdAt ? new Date(doc.createdAt).toISOString() : null,
       };
     });
 
@@ -826,7 +864,6 @@ function simpleHash(str: string): number {
   }
   return ((hash >>> 0) % 10000) / 10000;
 }
-
 
 // ============================================================================
 // 3D Knowledge Map — Real PCA from LanceDB embeddings
@@ -869,7 +906,7 @@ export async function handleMap3d(model?: string): Promise<{
 }> {
   const modelKey = model || 'bge-m3';
   const cached = map3dCaches.get(modelKey);
-  if (cached && (Date.now() - cached.timestamp) < MAP3D_CACHE_TTL) {
+  if (cached && Date.now() - cached.timestamp < MAP3D_CACHE_TTL) {
     return cached.data;
   }
 
@@ -890,7 +927,16 @@ export async function handleMap3d(model?: string): Promise<{
     console.timeEnd('[Map3D] Load embeddings');
 
     if (embeddings.length === 0) {
-      return { documents: [], total: 0, pca_info: { variance_explained: [], n_vectors: 0, n_dimensions: 0, computed_at: new Date().toISOString() } };
+      return {
+        documents: [],
+        total: 0,
+        pca_info: {
+          variance_explained: [],
+          n_vectors: 0,
+          n_dimensions: 0,
+          computed_at: new Date().toISOString(),
+        },
+      };
     }
 
     const n = embeddings.length;
@@ -899,26 +945,30 @@ export async function handleMap3d(model?: string): Promise<{
 
     // Step 2: Build metadata lookup from SQLite
     console.time('[Map3D] Metadata lookup');
-    const docLookup = new Map<string, {
-      type: string;
-      sourceFile: string;
-      concepts: string[];
-      project: string | null;
-      createdAt: number | null;
-    }>();
+    const docLookup = new Map<
+      string,
+      {
+        type: string;
+        sourceFile: string;
+        concepts: string[];
+        project: string | null;
+        createdAt: number | null;
+      }
+    >();
 
     // Batch query SQLite for all doc IDs
     const batchSize = 500;
     for (let i = 0; i < ids.length; i += batchSize) {
       const batch = ids.slice(i, i + batchSize);
-      const rows = db.select({
-        id: oracleDocuments.id,
-        type: oracleDocuments.type,
-        sourceFile: oracleDocuments.sourceFile,
-        concepts: oracleDocuments.concepts,
-        project: oracleDocuments.project,
-        createdAt: oracleDocuments.createdAt,
-      })
+      const rows = db
+        .select({
+          id: oracleDocuments.id,
+          type: oracleDocuments.type,
+          sourceFile: oracleDocuments.sourceFile,
+          concepts: oracleDocuments.concepts,
+          project: oracleDocuments.project,
+          createdAt: oracleDocuments.createdAt,
+        })
         .from(oracleDocuments)
         .where(inArray(oracleDocuments.id, batch))
         .all();
@@ -937,15 +987,18 @@ export async function handleMap3d(model?: string): Promise<{
 
     // Step 3: Deduplicate by source_file (average embeddings for multi-chunk files)
     console.time('[Map3D] Dedup by file');
-    const fileGroups = new Map<string, {
-      ids: string[];
-      vectors: number[][];
-      type: string;
-      sourceFile: string;
-      concepts: string[];
-      project: string | null;
-      createdAt: number | null;
-    }>();
+    const fileGroups = new Map<
+      string,
+      {
+        ids: string[];
+        vectors: number[][];
+        type: string;
+        sourceFile: string;
+        concepts: string[];
+        project: string | null;
+        createdAt: number | null;
+      }
+    >();
 
     for (let i = 0; i < n; i++) {
       const id = ids[i];
@@ -978,7 +1031,7 @@ export async function handleMap3d(model?: string): Promise<{
 
     // Average the vectors for each file
     const files = Array.from(fileGroups.values());
-    const avgVectors: number[][] = files.map(f => {
+    const avgVectors: number[][] = files.map((f) => {
       if (f.vectors.length === 1) return f.vectors[0];
       const avg = new Array(d).fill(0);
       for (const v of f.vectors) {
@@ -1005,7 +1058,7 @@ export async function handleMap3d(model?: string): Promise<{
     for (let j = 0; j < d; j++) mean[j] /= nFiles;
 
     // 4b. Center the data (in-place for memory efficiency)
-    const centered = avgVectors.map(v => {
+    const centered = avgVectors.map((v) => {
       const c = new Float64Array(d);
       for (let j = 0; j < d; j++) c[j] = v[j] - mean[j];
       return c;
@@ -1093,10 +1146,12 @@ export async function handleMap3d(model?: string): Promise<{
 
     // Compute variance explained
     const totalVariance = eigenvalues.reduce((a, b) => a + b, 0);
-    const varianceExplained = eigenvalues.map(e => +(e / (totalVariance || 1)).toFixed(4));
+    const varianceExplained = eigenvalues.map((e) => +(e / (totalVariance || 1)).toFixed(4));
 
     console.timeEnd('[Map3D] PCA');
-    console.error(`[Map3D] Variance explained: ${varianceExplained.map(v => (v * 100).toFixed(1) + '%').join(', ')}`);
+    console.error(
+      `[Map3D] Variance explained: ${varianceExplained.map((v) => (v * 100).toFixed(1) + '%').join(', ')}`,
+    );
 
     // Step 5: Project all vectors onto 3 PCs
     console.time('[Map3D] Project');
@@ -1104,7 +1159,9 @@ export async function handleMap3d(model?: string): Promise<{
 
     for (let i = 0; i < nFiles; i++) {
       const v = centered[i];
-      let x = 0, y = 0, z = 0;
+      let x = 0,
+        y = 0,
+        z = 0;
       for (let j = 0; j < d; j++) {
         x += v[j] * components[0][j];
         y += v[j] * components[1][j];
@@ -1114,13 +1171,19 @@ export async function handleMap3d(model?: string): Promise<{
     }
 
     // Normalize to [-1, 1] range for the frontend
-    let minX = Infinity, maxX = -Infinity;
-    let minY = Infinity, maxY = -Infinity;
-    let minZ = Infinity, maxZ = -Infinity;
+    let minX = Infinity,
+      maxX = -Infinity;
+    let minY = Infinity,
+      maxY = -Infinity;
+    let minZ = Infinity,
+      maxZ = -Infinity;
     for (const p of projected) {
-      if (p.x < minX) minX = p.x; if (p.x > maxX) maxX = p.x;
-      if (p.y < minY) minY = p.y; if (p.y > maxY) maxY = p.y;
-      if (p.z < minZ) minZ = p.z; if (p.z > maxZ) maxZ = p.z;
+      if (p.x < minX) minX = p.x;
+      if (p.x > maxX) maxX = p.x;
+      if (p.y < minY) minY = p.y;
+      if (p.y > maxY) maxY = p.y;
+      if (p.z < minZ) minZ = p.z;
+      if (p.z > maxZ) maxZ = p.z;
     }
     const rangeX = maxX - minX || 1;
     const rangeY = maxY - minY || 1;
@@ -1182,11 +1245,23 @@ export async function handleMap3d(model?: string): Promise<{
  */
 export async function handleVectorStats(): Promise<{
   vector: { enabled: boolean; count: number; collection: string };
-  vectors?: Array<{ key: string; model: string; collection: string; count: number; enabled: boolean }>;
+  vectors?: Array<{
+    key: string;
+    model: string;
+    collection: string;
+    count: number;
+    enabled: boolean;
+  }>;
 }> {
   const timeout = parseInt(process.env.ORACLE_CHROMA_TIMEOUT || '5000', 10);
   const models = getEmbeddingModels();
-  const engines: Array<{ key: string; model: string; collection: string; count: number; enabled: boolean }> = [];
+  const engines: Array<{
+    key: string;
+    model: string;
+    collection: string;
+    count: number;
+    enabled: boolean;
+  }> = [];
 
   // Query all registered engines in parallel
   await Promise.all(
@@ -1196,23 +1271,35 @@ export async function handleVectorStats(): Promise<{
         const stats = await Promise.race([
           store.getStats(),
           new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error('timeout')), timeout)
+            setTimeout(() => reject(new Error('timeout')), timeout),
           ),
         ]);
-        engines.push({ key, model: preset.model, collection: preset.collection, count: stats.count, enabled: true });
+        engines.push({
+          key,
+          model: preset.model,
+          collection: preset.collection,
+          count: stats.count,
+          enabled: true,
+        });
       } catch {
-        engines.push({ key, model: preset.model, collection: preset.collection, count: 0, enabled: false });
+        engines.push({
+          key,
+          model: preset.model,
+          collection: preset.collection,
+          count: 0,
+          enabled: false,
+        });
       }
-    })
+    }),
   );
 
   // Primary = bge-m3 (backward compat)
-  const primary = engines.find(e => e.key === 'bge-m3') || engines[0];
+  const primary = engines.find((e) => e.key === 'bge-m3') || engines[0];
   return {
     vector: {
       enabled: primary?.enabled ?? false,
       count: primary?.count ?? 0,
-      collection: primary?.collection ?? 'oracle_knowledge_bge_m3'
+      collection: primary?.collection ?? 'oracle_knowledge_bge_m3',
     },
     vectors: engines,
   };
@@ -1230,7 +1317,7 @@ export function handleLearn(
   concepts?: string[],
   origin?: string,
   project?: string,
-  cwd?: string
+  cwd?: string,
 ) {
   // Auto-detect project from cwd if not explicitly specified
   const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
@@ -1274,7 +1361,7 @@ export function handleLearn(
     '',
     '---',
     '*Added via Oracle Learn*',
-    ''
+    '',
   ].join('\n');
 
   // Write file
@@ -1286,28 +1373,28 @@ export function handleLearn(
   const conceptsList = coerceConcepts(concepts);
 
   // Insert into database with provenance using Drizzle
-  db.insert(oracleDocuments).values({
-    id,
-    type: 'learning',
-    sourceFile: `ψ/memory/learnings/${filename}`,
-    concepts: JSON.stringify(conceptsList),
-    createdAt: now.getTime(),
-    updatedAt: now.getTime(),
-    indexedAt: now.getTime(),
-    origin: origin || null,          // origin: null = universal/mother
-    project: resolvedProject || null, // project: null = universal (auto-detected from cwd)
-    createdBy: 'oracle_learn'
-  }).run();
+  db.insert(oracleDocuments)
+    .values({
+      id,
+      type: 'learning',
+      sourceFile: `ψ/memory/learnings/${filename}`,
+      concepts: JSON.stringify(conceptsList),
+      createdAt: now.getTime(),
+      updatedAt: now.getTime(),
+      indexedAt: now.getTime(),
+      origin: origin || null, // origin: null = universal/mother
+      project: resolvedProject || null, // project: null = universal (auto-detected from cwd)
+      createdBy: 'oracle_learn',
+    })
+    .run();
 
   // Insert into FTS (must use raw SQL - Drizzle doesn't support virtual tables)
-  sqlite.prepare(`
+  sqlite
+    .prepare(`
     INSERT INTO oracle_fts (id, content, concepts)
     VALUES (?, ?, ?)
-  `).run(
-    id,
-    content,
-    conceptsList.join(' ')
-  );
+  `)
+    .run(id, content, conceptsList.join(' '));
 
   // Log the learning
   logLearning(id, pattern, source || 'Oracle Learn', conceptsList);
@@ -1315,6 +1402,6 @@ export function handleLearn(
   return {
     success: true,
     file: `ψ/memory/learnings/${filename}`,
-    id
+    id,
   };
 }

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -17,29 +17,34 @@ export function logSearch(
   resultsCount: number,
   searchTimeMs: number,
   results: SearchResult[] = [],
-  project?: string
+  project?: string,
 ) {
   try {
     // Store top 5 results as JSON (id, type, score, snippet)
-    const resultsJson = results.length > 0
-      ? JSON.stringify(results.slice(0, 5).map(r => ({
-          id: r.id,
-          type: r.type,
-          score: r.score,
-          snippet: r.content?.substring(0, 100)
-        })))
-      : null;
+    const resultsJson =
+      results.length > 0
+        ? JSON.stringify(
+            results.slice(0, 5).map((r) => ({
+              id: r.id,
+              type: r.type,
+              score: r.score,
+              snippet: r.content?.substring(0, 100),
+            })),
+          )
+        : null;
 
-    db.insert(searchLog).values({
-      query,
-      type,
-      mode,
-      resultsCount,
-      searchTimeMs,
-      createdAt: Date.now(),
-      project: project || null,
-      results: resultsJson,
-    }).run();
+    db.insert(searchLog)
+      .values({
+        query,
+        type,
+        mode,
+        resultsCount,
+        searchTimeMs,
+        createdAt: Date.now(),
+        project: project || null,
+        results: resultsJson,
+      })
+      .run();
 
     // Comprehensive console logging
     console.log(`\n${'='.repeat(60)}`);
@@ -59,9 +64,17 @@ export function logSearch(
 
     // Log any unexpected fields
     if (results.length > 0) {
-      const expectedFields = ['id', 'type', 'content', 'source_file', 'concepts', 'source', 'score'];
+      const expectedFields = [
+        'id',
+        'type',
+        'content',
+        'source_file',
+        'concepts',
+        'source',
+        'score',
+      ];
       const firstResult = results[0] as unknown as Record<string, unknown>;
-      const unknownFields = Object.keys(firstResult).filter(k => !expectedFields.includes(k));
+      const unknownFields = Object.keys(firstResult).filter((k) => !expectedFields.includes(k));
       if (unknownFields.length > 0) {
         console.log(`  [UNKNOWN FIELDS]: ${unknownFields.join(', ')}`);
       }
@@ -77,12 +90,14 @@ export function logSearch(
  */
 export function logDocumentAccess(documentId: string, accessType: string, project?: string) {
   try {
-    db.insert(documentAccess).values({
-      documentId,
-      accessType,
-      createdAt: Date.now(),
-      project: project || null,
-    }).run();
+    db.insert(documentAccess)
+      .values({
+        documentId,
+        accessType,
+        createdAt: Date.now(),
+        project: project || null,
+      })
+      .run();
   } catch (e) {
     console.error('Failed to log access:', e);
   }
@@ -91,18 +106,25 @@ export function logDocumentAccess(documentId: string, accessType: string, projec
 /**
  * Log learning addition
  */
-export function logLearning(documentId: string, patternPreview: string, source: string, concepts: string[], project?: string) {
+export function logLearning(
+  documentId: string,
+  patternPreview: string,
+  source: string,
+  concepts: string[],
+  project?: string,
+) {
   try {
-    db.insert(learnLog).values({
-      documentId,
-      patternPreview: patternPreview.substring(0, 100),
-      source: source || 'Oracle Learn',
-      concepts: JSON.stringify(concepts),
-      createdAt: Date.now(),
-      project: project || null,
-    }).run();
+    db.insert(learnLog)
+      .values({
+        documentId,
+        patternPreview: patternPreview.substring(0, 100),
+        source: source || 'Oracle Learn',
+        concepts: JSON.stringify(concepts),
+        createdAt: Date.now(),
+        project: project || null,
+      })
+      .run();
   } catch (e) {
     console.error('Failed to log learning:', e);
   }
 }
-

--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -7,7 +7,16 @@ export const healthRoute = createRoute({
   summary: 'Server health check',
   responses: {
     200: {
-      content: { 'application/json': { schema: z.object({ status: z.string(), server: z.string(), port: z.number(), oracleV2: z.string() }) } },
+      content: {
+        'application/json': {
+          schema: z.object({
+            status: z.string(),
+            server: z.string(),
+            port: z.number(),
+            oracleV2: z.string(),
+          }),
+        },
+      },
       description: 'Server is healthy',
     },
   },
@@ -34,7 +43,8 @@ export const authStatusRoute = createRoute({
           }),
         },
       },
-      description: 'Auth status response (owner branch carries hasPassword/localBypass/isLocal; guest branch carries guestName/guestUsername)',
+      description:
+        'Auth status response (owner branch carries hasPassword/localBypass/isLocal; guest branch carries guestName/guestUsername)',
     },
   },
 });
@@ -70,15 +80,21 @@ export const authLoginRoute = createRoute({
       description: 'Login successful',
     },
     400: {
-      content: { 'application/json': { schema: z.object({ success: z.literal(false), error: z.string() }) } },
+      content: {
+        'application/json': { schema: z.object({ success: z.literal(false), error: z.string() }) },
+      },
       description: 'Missing password or no password configured',
     },
     401: {
-      content: { 'application/json': { schema: z.object({ success: z.literal(false), error: z.string() }) } },
+      content: {
+        'application/json': { schema: z.object({ success: z.literal(false), error: z.string() }) },
+      },
       description: 'Invalid credentials',
     },
     429: {
-      content: { 'application/json': { schema: z.object({ success: z.literal(false), error: z.string() }) } },
+      content: {
+        'application/json': { schema: z.object({ success: z.literal(false), error: z.string() }) },
+      },
       description: 'Rate limited',
     },
   },
@@ -111,11 +127,13 @@ export const emojiListRoute = createRoute({
       content: {
         'application/json': {
           schema: z.object({
-            emoji: z.array(z.object({
-              emoji: z.string(),
-              added_by: z.string().nullable(),
-              created_at: z.number(),
-            })),
+            emoji: z.array(
+              z.object({
+                emoji: z.string(),
+                added_by: z.string().nullable(),
+                created_at: z.number(),
+              }),
+            ),
             total: z.number(),
           }),
         },
@@ -287,17 +305,19 @@ export const queueListRoute = createRoute({
       content: {
         'application/json': {
           schema: z.object({
-            items: z.array(z.object({
-              thread_id: z.number(),
-              title: z.string(),
-              thread_status: z.string().nullable(),
-              queue_status: z.string().nullable(),
-              tagged_by: z.string().nullable(),
-              tagged_at: z.string().nullable(),
-              summary: z.string().nullable(),
-              message_count: z.number(),
-              created_at: z.string(),
-            })),
+            items: z.array(
+              z.object({
+                thread_id: z.number(),
+                title: z.string(),
+                thread_status: z.string().nullable(),
+                queue_status: z.string().nullable(),
+                tagged_by: z.string().nullable(),
+                tagged_at: z.string().nullable(),
+                summary: z.string().nullable(),
+                message_count: z.number(),
+                created_at: z.string(),
+              }),
+            ),
             total: z.number(),
           }),
         },
@@ -410,20 +430,22 @@ export const supersedeListRoute = createRoute({
       content: {
         'application/json': {
           schema: z.object({
-            supersessions: z.array(z.object({
-              id: z.number(),
-              old_path: z.string(),
-              old_id: z.string().nullable(),
-              old_title: z.string().nullable(),
-              old_type: z.string().nullable(),
-              new_path: z.string().nullable(),
-              new_id: z.string().nullable(),
-              new_title: z.string().nullable(),
-              reason: z.string().nullable(),
-              superseded_at: z.string(),
-              superseded_by: z.string().nullable(),
-              project: z.string().nullable(),
-            })),
+            supersessions: z.array(
+              z.object({
+                id: z.number(),
+                old_path: z.string(),
+                old_id: z.string().nullable(),
+                old_title: z.string().nullable(),
+                old_type: z.string().nullable(),
+                new_path: z.string().nullable(),
+                new_id: z.string().nullable(),
+                new_title: z.string().nullable(),
+                reason: z.string().nullable(),
+                superseded_at: z.string(),
+                superseded_by: z.string().nullable(),
+                project: z.string().nullable(),
+              }),
+            ),
             total: z.number(),
             limit: z.number(),
             offset: z.number(),
@@ -450,16 +472,20 @@ export const supersedeChainRoute = createRoute({
       content: {
         'application/json': {
           schema: z.object({
-            superseded_by: z.array(z.object({
-              new_path: z.string().nullable(),
-              reason: z.string().nullable(),
-              superseded_at: z.string(),
-            })),
-            supersedes: z.array(z.object({
-              old_path: z.string(),
-              reason: z.string().nullable(),
-              superseded_at: z.string(),
-            })),
+            superseded_by: z.array(
+              z.object({
+                new_path: z.string().nullable(),
+                reason: z.string().nullable(),
+                superseded_at: z.string(),
+              }),
+            ),
+            supersedes: z.array(
+              z.object({
+                old_path: z.string(),
+                reason: z.string().nullable(),
+                superseded_at: z.string(),
+              }),
+            ),
           }),
         },
       },
@@ -535,7 +561,8 @@ export const remoteStatusRoute = createRoute({
           }),
         },
       },
-      description: 'Whether a beast window is linked into the remote tmux session and which beast (if any)',
+      description:
+        'Whether a beast window is linked into the remote tmux session and which beast (if any)',
     },
   },
 });
@@ -620,25 +647,27 @@ export const packListRoute = createRoute({
       content: {
         'application/json': {
           schema: z.object({
-            beasts: z.array(z.object({
-              name: z.string(),
-              displayName: z.string(),
-              animal: z.string(),
-              avatarUrl: z.string().nullable(),
-              bio: z.string().nullable(),
-              interests: z.string().nullable(),
-              themeColor: z.string().nullable(),
-              role: z.string().nullable(),
-              birthdate: z.string().nullable(),
-              sex: z.string().nullable(),
-              restStatus: z.string().nullable(),
-              createdAt: z.number(),
-              updatedAt: z.number(),
-              online: z.boolean(),
-              status: z.string(),
-              contextPct: z.number().nullable(),
-              sessionName: z.string(),
-            })),
+            beasts: z.array(
+              z.object({
+                name: z.string(),
+                displayName: z.string(),
+                animal: z.string(),
+                avatarUrl: z.string().nullable(),
+                bio: z.string().nullable(),
+                interests: z.string().nullable(),
+                themeColor: z.string().nullable(),
+                role: z.string().nullable(),
+                birthdate: z.string().nullable(),
+                sex: z.string().nullable(),
+                restStatus: z.string().nullable(),
+                createdAt: z.number(),
+                updatedAt: z.number(),
+                online: z.boolean(),
+                status: z.string(),
+                contextPct: z.number().nullable(),
+                sessionName: z.string(),
+              }),
+            ),
             owner: z.object({
               name: z.string(),
               online: z.boolean(),
@@ -674,7 +703,6 @@ export const packSpinnerVerbsRoute = createRoute({
     },
   },
 });
-
 
 export const OPENAPI_INFO = {
   openapi: '3.0.0' as const,

--- a/src/server/project-detect.ts
+++ b/src/server/project-detect.ts
@@ -53,4 +53,3 @@ export function detectProject(cwd?: string): string | null {
     return null;
   }
 }
-

--- a/src/server/rbac.ts
+++ b/src/server/rbac.ts
@@ -16,8 +16,8 @@ export type Role = 'owner' | 'beast' | 'guest';
  * Based on Talon's endpoint audit (thread #420, msg #5759).
  */
 interface AllowlistEntry {
-  method: string;       // HTTP method or '*' for any
-  pattern: RegExp;      // URL path pattern
+  method: string; // HTTP method or '*' for any
+  pattern: RegExp; // URL path pattern
 }
 
 const GUEST_ALLOWLIST: AllowlistEntry[] = [
@@ -58,8 +58,8 @@ const GUEST_ALLOWLIST: AllowlistEntry[] = [
  * Check if a request is allowed for a guest.
  */
 function isGuestAllowed(method: string, path: string): boolean {
-  return GUEST_ALLOWLIST.some(entry =>
-    (entry.method === '*' || entry.method === method) && entry.pattern.test(path)
+  return GUEST_ALLOWLIST.some(
+    (entry) => (entry.method === '*' || entry.method === method) && entry.pattern.test(path),
   );
 }
 
@@ -88,7 +88,10 @@ export function rbacMiddleware() {
       const path = c.req.path;
 
       if (!isGuestAllowed(method, path)) {
-        return c.json({ error: 'Forbidden', message: 'Guests do not have access to this resource' }, 403);
+        return c.json(
+          { error: 'Forbidden', message: 'Guests do not have access to this resource' },
+          403,
+        );
       }
     }
 
@@ -100,5 +103,5 @@ export function rbacMiddleware() {
  * Get the allowlist for testing/introspection.
  */
 export function getGuestAllowlist(): { method: string; pattern: string }[] {
-  return GUEST_ALLOWLIST.map(e => ({ method: e.method, pattern: e.pattern.source }));
+  return GUEST_ALLOWLIST.map((e) => ({ method: e.method, pattern: e.pattern.source }));
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -3,21 +3,41 @@ import type { Context } from 'hono';
 import type { OpenAPIHono } from '@hono/zod-openapi';
 import type { Database } from 'bun:sqlite';
 import {
-  SESSION_COOKIE_NAME, SESSION_DURATION_MS, GUEST_SESSION_DURATION_MS,
-  LOGIN_RATE_LIMIT, LOGIN_RATE_WINDOW_MS, WEB_PRESENCE_TIMEOUT_MS,
-  getRateLimit, clearRateLimit,
-  generateSessionToken, parseSessionToken, isAuthenticated, isLocalNetwork,
+  SESSION_COOKIE_NAME,
+  SESSION_DURATION_MS,
+  GUEST_SESSION_DURATION_MS,
+  LOGIN_RATE_LIMIT,
+  LOGIN_RATE_WINDOW_MS,
+  WEB_PRESENCE_TIMEOUT_MS,
+  getRateLimit,
+  clearRateLimit,
+  generateSessionToken,
+  parseSessionToken,
+  isAuthenticated,
+  isLocalNetwork,
 } from '../server.ts';
 import {
-  createGuest, listGuests, getGuest, getGuestByUsername,
-  updateGuest, deleteGuest, banGuest, unbanGuest,
-  isGuestActive, recordFailedAttempt, recordSuccessfulLogin,
+  createGuest,
+  listGuests,
+  getGuest,
+  getGuestByUsername,
+  updateGuest,
+  deleteGuest,
+  banGuest,
+  unbanGuest,
+  isGuestActive,
+  recordFailedAttempt,
+  recordSuccessfulLogin,
   resetGuestPassword,
 } from './guest-accounts.ts';
 import { logSecurityEvent } from './security-logger.ts';
 import {
-  createToken, listTokens, revokeToken, rotateToken,
-  selfRotateToken, getTokenInfo,
+  createToken,
+  listTokens,
+  revokeToken,
+  rotateToken,
+  selfRotateToken,
+  getTokenInfo,
 } from './beast-tokens.ts';
 import { getSetting } from '../db/index.ts';
 import { authStatusRoute, authLoginRoute, authLogoutRoute } from './openapi.ts';
@@ -34,7 +54,11 @@ interface ServerRoutesHelpers {
   webPresence: Map<string, { identity: string; role: string; lastSeen: number }>;
 }
 
-export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: ServerRoutesHelpers): void {
+export function registerServerRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: ServerRoutesHelpers,
+): void {
   const { hasSessionAuth, wsBroadcast, webPresence } = helpers;
   const sqlite: Database = sqliteDb;
 
@@ -42,9 +66,12 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
   // helpers (getRateLimit, clearRateLimit) stay in server.ts because they are
   // also used by middleware elsewhere.
   function setRateLimit(ip: string, count: number, firstAttempt: number): void {
-    sqlite.prepare('INSERT OR REPLACE INTO login_rate_limits (ip, count, first_attempt_at) VALUES (?, ?, ?)').run(ip, count, firstAttempt);
+    sqlite
+      .prepare(
+        'INSERT OR REPLACE INTO login_rate_limits (ip, count, first_attempt_at) VALUES (?, ?, ?)',
+      )
+      .run(ip, count, firstAttempt);
   }
-
 
   // ============================================================================
   // /api/auth/* (status, login, logout)
@@ -59,13 +86,13 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     const localBypass = getSetting('auth_local_bypass') !== 'false';
     const isLocal = isLocalNetwork(c);
     const authenticated = isAuthenticated(c);
-  
+
     // Parse session token to get role info for frontend nav scoping
     const sessionCookie = getCookie(c, SESSION_COOKIE_NAME);
     const session = parseSessionToken(sessionCookie || '');
-    const role = session.valid ? (session.role || 'owner') : (authenticated ? 'owner' : undefined);
+    const role = session.valid ? session.role || 'owner' : authenticated ? 'owner' : undefined;
     const guestUsername = session.valid && session.role === 'guest' ? session.data : undefined;
-  
+
     // Strip internal auth details from guest responses (Bertus security review)
     if (role === 'guest') {
       // Look up display name and check account status
@@ -82,28 +109,37 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
         }
       }
       // Conditional spread to match schema optional-property shape (not required-with-undefined).
-      return c.json({
-        authenticated: guestActive,
-        authEnabled,
-        ...(guestActive && role ? { role } : {}),
-        ...(guestActive && guestDisplayName ? { guestName: guestDisplayName } : {}),
-        ...(guestActive && guestUsername ? { guestUsername } : {}),
-      }, 200);
+      return c.json(
+        {
+          authenticated: guestActive,
+          authEnabled,
+          ...(guestActive && role ? { role } : {}),
+          ...(guestActive && guestDisplayName ? { guestName: guestDisplayName } : {}),
+          ...(guestActive && guestUsername ? { guestUsername } : {}),
+        },
+        200,
+      );
     }
 
-    return c.json({
-      authenticated,
-      authEnabled,
-      hasPassword,
-      localBypass,
-      isLocal,
-      ...(role ? { role } : {}),
-    }, 200);
+    return c.json(
+      {
+        authenticated,
+        authEnabled,
+        hasPassword,
+        localBypass,
+        isLocal,
+        ...(role ? { role } : {}),
+      },
+      200,
+    );
   }) as any);
 
   // Cast: see authStatusRoute note above re multi-branch response-shape narrowing.
   app.openapi(authLoginRoute, (async (c: Context) => {
-    const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || '127.0.0.1';
+    const ip =
+      c.req.header('x-real-ip') ||
+      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+      '127.0.0.1';
     const now = Date.now();
     const attempts = getRateLimit(ip);
     if (attempts) {
@@ -121,26 +157,32 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
           ipSource: ip,
           requestId: (c.get as any)('requestId'),
         });
-        return c.json({ success: false, error: `Too many login attempts. Try again in ${Math.ceil(retryAfter / 60)} minutes.` }, 429);
+        return c.json(
+          {
+            success: false,
+            error: `Too many login attempts. Try again in ${Math.ceil(retryAfter / 60)} minutes.`,
+          },
+          429,
+        );
       }
     }
-  
+
     const body = await c.req.json();
     const { password, username } = body;
-  
+
     if (!password) {
       return c.json({ success: false, error: 'Password required' }, 400);
     }
-  
+
     // Try guest login first if username is provided
     if (username) {
       const guest = getGuestByUsername(sqlite, username);
-  
+
       // Always run bcrypt even if user doesn't exist (timing attack mitigation)
       const dummyHash = '$2b$12$LJ3m4ys3Ls.yBVBMGIiu2OiEfO/JsU1TOiIYxlhfPHQsGxJF6mYr2';
       const hashToVerify = guest?.password_hash || dummyHash;
       const validPassword = await Bun.password.verify(password, hashToVerify);
-  
+
       if (!guest || !validPassword) {
         const existing = getRateLimit(ip);
         const newCount = (existing?.count || 0) + 1;
@@ -158,13 +200,13 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
         });
         return c.json({ success: false, error: 'Invalid username or password' }, 401);
       }
-  
+
       // Check if guest account is active (not expired, disabled, or locked)
       const status = isGuestActive(guest);
       if (!status.active) {
         return c.json({ success: false, error: status.reason }, 401);
       }
-  
+
       // Successful guest login
       clearRateLimit(ip);
       recordSuccessfulLogin(sqlite, guest.id);
@@ -178,25 +220,25 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
         ipSource: ip,
         requestId: (c.get as any)('requestId'),
       });
-  
+
       const token = generateSessionToken('guest', guest.username);
       setCookie(c, SESSION_COOKIE_NAME, token, {
         httpOnly: true,
         secure: true,
         sameSite: 'Lax',
         maxAge: GUEST_SESSION_DURATION_MS / 1000,
-        path: '/'
+        path: '/',
       });
-  
+
       return c.json({ success: true, role: 'guest', display_name: guest.display_name });
     }
-  
+
     // Owner login (password only, no username)
     const storedHash = getSetting('auth_password_hash');
     if (!storedHash) {
       return c.json({ success: false, error: 'No password configured' }, 400);
     }
-  
+
     // Verify password using Bun's built-in password functions
     const valid = await Bun.password.verify(password, storedHash);
     if (!valid) {
@@ -214,7 +256,7 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       });
       return c.json({ success: false, error: 'Invalid password' }, 401);
     }
-  
+
     // Successful owner login clears rate limit
     clearRateLimit(ip);
     logSecurityEvent({
@@ -226,7 +268,7 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       ipSource: ip,
       requestId: (c.get as any)('requestId'),
     });
-  
+
     // Set session cookie
     const token = generateSessionToken('owner');
     const isHttps = c.req.url.startsWith('https') || c.req.header('x-forwarded-proto') === 'https';
@@ -235,15 +277,18 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       secure: true, // Always behind HTTPS via Caddy
       sameSite: 'Lax',
       maxAge: SESSION_DURATION_MS / 1000,
-      path: '/'
+      path: '/',
     });
-  
+
     return c.json({ success: true, role: 'owner' });
   }) as any);
 
   // Logout
   app.openapi(authLogoutRoute, (c) => {
-    const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+    const ip =
+      c.req.header('x-real-ip') ||
+      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+      'local';
     logSecurityEvent({
       eventType: 'session_destroyed',
       severity: 'info',
@@ -265,14 +310,14 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
+
     const body = await c.req.json();
     const { username, password, display_name, expires_at } = body;
-  
+
     if (!username || !password) {
       return c.json({ error: 'Username and password are required' }, 400);
     }
-  
+
     try {
       const guest = await createGuest(sqlite, username, password, display_name, expires_at);
       const { password_hash, ...safe } = guest;
@@ -284,24 +329,38 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       return c.json({ error: err.message || 'Failed to create guest' }, 400);
     }
   });
-  
+
   // List guest accounts
   app.get('/api/guests', (c) => {
     if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
-    const guests = listGuests(sqlite).map(g => {
+
+    const guests = listGuests(sqlite).map((g) => {
       const displayName = g.display_name || g.username;
       const guestTag = `[guest] ${displayName}`.toLowerCase();
-      const msgCount = (sqlite.prepare('SELECT COUNT(*) as c FROM dm_messages WHERE LOWER(sender) = ?').get(guestTag) as any)?.c || 0;
-      const threadCount = (sqlite.prepare("SELECT COUNT(DISTINCT thread_id) as c FROM forum_messages WHERE LOWER(author) LIKE '%[guest]%' AND LOWER(author) LIKE ?").get(`%${g.username}%`) as any)?.c || 0;
+      const msgCount =
+        (
+          sqlite
+            .prepare('SELECT COUNT(*) as c FROM dm_messages WHERE LOWER(sender) = ?')
+            .get(guestTag) as any
+        )?.c || 0;
+      const threadCount =
+        (
+          sqlite
+            .prepare(
+              "SELECT COUNT(DISTINCT thread_id) as c FROM forum_messages WHERE LOWER(author) LIKE '%[guest]%' AND LOWER(author) LIKE ?",
+            )
+            .get(`%${g.username}%`) as any
+        )?.c || 0;
       // Use WS presence map for real-time status; fall back to last_active_at DB window
       const presence = webPresence.get(g.username);
       const nowMs = Date.now();
       const online = presence
-        ? (nowMs - presence.lastSeen) < WEB_PRESENCE_TIMEOUT_MS
-        : (g.last_active_at ? (nowMs - new Date(g.last_active_at + 'Z').getTime()) < 5 * 60 * 1000 : false);
+        ? nowMs - presence.lastSeen < WEB_PRESENCE_TIMEOUT_MS
+        : g.last_active_at
+          ? nowMs - new Date(g.last_active_at + 'Z').getTime() < 5 * 60 * 1000
+          : false;
       return {
         ...g,
         online,
@@ -309,73 +368,81 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
         threads_participated: threadCount,
       };
     });
-    const onlineCount = guests.filter(g => g.online).length;
+    const onlineCount = guests.filter((g) => g.online).length;
     return c.json({ guests, total: guests.length, online_count: onlineCount });
   });
-  
+
   // Get single guest account
   app.get('/api/guests/:id', (c) => {
     if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
+
     const id = parseInt(c.req.param('id'), 10);
     const guest = getGuest(sqlite, id);
     if (!guest) return c.json({ error: 'Guest not found' }, 404);
-  
+
     const { password_hash, ...safe } = guest;
-  
+
     // Activity summary: count DMs sent and forum threads participated (T#570)
     const guestTag = `[Guest] ${guest.display_name || guest.username}`;
     const guestTagAlt = `[Guest] ${guest.username}`;
-    const dmCount = (sqlite.prepare(
-      `SELECT COUNT(*) as count FROM dm_messages WHERE sender = ? OR sender = ?`
-    ).get(guestTag, guestTagAlt) as any)?.count || 0;
-    const threadCount = (sqlite.prepare(
-      `SELECT COUNT(DISTINCT thread_id) as count FROM forum_messages WHERE author = ? OR author = ?`
-    ).get(guestTag, guestTagAlt) as any)?.count || 0;
-  
+    const dmCount =
+      (
+        sqlite
+          .prepare(`SELECT COUNT(*) as count FROM dm_messages WHERE sender = ? OR sender = ?`)
+          .get(guestTag, guestTagAlt) as any
+      )?.count || 0;
+    const threadCount =
+      (
+        sqlite
+          .prepare(
+            `SELECT COUNT(DISTINCT thread_id) as count FROM forum_messages WHERE author = ? OR author = ?`,
+          )
+          .get(guestTag, guestTagAlt) as any
+      )?.count || 0;
+
     const GUEST_ONLINE_THRESHOLD_MS = 5 * 60 * 1000;
     const online = guest.last_active_at
-      ? (Date.now() - new Date(guest.last_active_at + 'Z').getTime()) < GUEST_ONLINE_THRESHOLD_MS
+      ? Date.now() - new Date(guest.last_active_at + 'Z').getTime() < GUEST_ONLINE_THRESHOLD_MS
       : false;
-  
+
     return c.json({ ...safe, online, message_count: dmCount, threads_participated: threadCount });
   });
-  
+
   // Update guest account (expiry, disable, display name)
   app.patch('/api/guests/:id', (c) => {
     if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
+
     const id = parseInt(c.req.param('id'), 10);
-    return c.req.json().then(body => {
+    return c.req.json().then((body) => {
       const updated = updateGuest(sqlite, id, {
         display_name: body.display_name,
         expires_at: body.expires_at,
         disabled_at: body.disabled_at,
       });
       if (!updated) return c.json({ error: 'Guest not found' }, 404);
-  
+
       const { password_hash, ...safe } = updated;
       return c.json(safe);
     });
   });
-  
+
   // Owner reset guest password (T#566)
   app.patch('/api/guests/:id/password', async (c) => {
     if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
+
     const id = parseInt(c.req.param('id'), 10);
     const guest = getGuest(sqlite, id);
     if (!guest) return c.json({ error: 'Guest not found' }, 404);
-  
+
     const body = await c.req.json();
     if (!body.password) return c.json({ error: 'password required' }, 400);
-  
+
     try {
       await resetGuestPassword(sqlite, id, body.password);
       return c.json({ success: true });
@@ -383,28 +450,28 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       return c.json({ error: err.message }, 400);
     }
   });
-  
+
   // Delete guest account (T#570 — with cascade notification)
   app.delete('/api/guests/:id', (c) => {
     if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
+
     const id = parseInt(c.req.param('id'), 10);
     const guest = getGuest(sqlite, id);
     if (!guest) return c.json({ error: 'Guest not found' }, 404);
-  
+
     const deleted = deleteGuest(sqlite, id);
     if (!deleted) return c.json({ error: 'Failed to delete guest' }, 500);
-  
+
     // Broadcast session invalidation — connected clients will see this and redirect to login
     // Note: HMAC-signed cookies cannot be server-side revoked, but guest login check
     // will fail since the account no longer exists in the DB
     wsBroadcast('guest_deleted', { username: guest.username });
-  
+
     return c.json({ success: true });
   });
-  
+
   // Ban guest account (T#616 — spec #36)
   app.post('/api/guests/:id/ban', async (c) => {
     // Owner session OR Beast token (Bertus needs to ban directly)
@@ -413,20 +480,20 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     if (!isOwner && !isBeast) {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
+
     const id = parseInt(c.req.param('id'), 10);
     const guest = getGuest(sqlite, id);
     if (!guest) return c.json({ error: 'Guest not found' }, 404);
     if (guest.banned_at) return c.json({ error: 'Guest is already banned' }, 409);
-  
+
     const body = await c.req.json();
     // Derive banned_by from authenticated session, not request body
     const bannedBy = isBeast ? (c.get as any)('actor') : 'owner';
     const reason = body.reason || 'No reason provided';
-  
+
     const updated = banGuest(sqlite, id, bannedBy, reason);
     if (!updated) return c.json({ error: 'Failed to ban guest' }, 500);
-  
+
     logSecurityEvent({
       eventType: 'guest_banned',
       severity: 'warning',
@@ -436,29 +503,29 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       details: { guest_id: id, username: guest.username, reason, banned_by: bannedBy },
       requestId: (c.get as any)('requestId'),
     });
-  
+
     const { password_hash, ...safe } = updated;
     return c.json(safe);
   });
-  
+
   // Unban guest account (T#616 — spec #36)
   app.post('/api/guests/:id/unban', async (c) => {
     // Owner session only — unbanning is a sensitive operation
     if (!hasSessionAuth(c) || (c.get as any)('role') === 'guest') {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
+
     const id = parseInt(c.req.param('id'), 10);
     const guest = getGuest(sqlite, id);
     if (!guest) return c.json({ error: 'Guest not found' }, 404);
     if (!guest.banned_at) return c.json({ error: 'Guest is not banned' }, 409);
-  
+
     const body = await c.req.json();
     const reason = body.reason || 'No reason provided';
-  
+
     const updated = unbanGuest(sqlite, id);
     if (!updated) return c.json({ error: 'Failed to unban guest' }, 500);
-  
+
     logSecurityEvent({
       eventType: 'guest_unbanned',
       severity: 'info',
@@ -468,7 +535,7 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       details: { guest_id: id, username: guest.username, reason },
       requestId: (c.get as any)('requestId'),
     });
-  
+
     const { password_hash, ...safe } = updated;
     return c.json(safe);
   });
@@ -485,18 +552,18 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     if (c.req.query('as')) {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
+
     const body = await c.req.json();
     const { beast, ttl_hours } = body;
     if (!beast || typeof beast !== 'string') {
       return c.json({ error: 'beast name required' }, 400);
     }
-  
+
     const result = createToken(beast, 'gorn', ttl_hours);
     if ('error' in result) {
       return c.json({ error: result.error }, 400);
     }
-  
+
     return c.json({
       token: result.token,
       id: result.id,
@@ -504,7 +571,7 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       beast,
     });
   });
-  
+
   // List tokens — Gorn session auth only (no hashes exposed)
   app.get('/api/auth/tokens', (c) => {
     if (!hasSessionAuth(c)) {
@@ -512,7 +579,7 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     }
     return c.json({ tokens: listTokens() });
   });
-  
+
   // Revoke token — Gorn session auth only
   app.delete('/api/auth/tokens/:id', (c) => {
     if (!hasSessionAuth(c)) {
@@ -522,30 +589,30 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     if (isNaN(tokenId)) {
       return c.json({ error: 'Invalid token ID' }, 400);
     }
-  
+
     const result = revokeToken(tokenId, 'gorn');
     if (!result.success) {
       return c.json({ error: result.error }, 404);
     }
     return c.json({ revoked: true });
   });
-  
+
   // Rotate token — owner-driven (existing endpoint, kept for owner UI workflow).
   // Beast-self chain-aware rotation lives at POST /api/auth/rotate (Spec #52).
   app.post('/api/auth/tokens/rotate', (c) => {
     const authMethod = (c.get as any)('authMethod');
     const beast = (c.get as any)('actor') as string;
     const tokenId = (c.get as any)('tokenId') as number;
-  
+
     if (authMethod !== 'token' || !beast || !tokenId) {
       return c.json({ error: 'forbidden' }, 403);
     }
-  
+
     const result = rotateToken(tokenId, beast);
     if ('error' in result) {
       return c.json({ error: result.error }, 500);
     }
-  
+
     return c.json({
       token: result.token,
       id: result.id,
@@ -553,7 +620,7 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       beast,
     });
   });
-  
+
   // Spec #51 Phase 3 — Beast-self token info read.
   // Returns timing fields the Beast needs to monitor its own token lifecycle:
   // expires_at, max_lifetime_at, refresh_window_starts_at, self_rotate_door_closes_at,
@@ -566,18 +633,18 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     const authMethod = (c.get as any)('authMethod');
     const beast = (c.get as any)('actor') as string;
     const tokenId = (c.get as any)('tokenId') as number;
-  
+
     if (authMethod !== 'token' || !beast || !tokenId) {
       return c.json({ error: 'Bearer-token Beast identity required' }, 403);
     }
-  
+
     const info = getTokenInfo(tokenId);
     if (!info) {
       return c.json({ error: 'Token not found or revoked' }, 404);
     }
     return c.json(info);
   });
-  
+
   // Spec #52 — Beast-self chain-aware rotation.
   // Beast presents CURRENT VALID token via Bearer auth; server issues fresh token,
   // chain-links old → new (rotated_at + next_token_id). Replay on the old token
@@ -592,20 +659,24 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
     const authMethod = (c.get as any)('authMethod');
     const beast = (c.get as any)('actor') as string;
     const tokenId = (c.get as any)('tokenId') as number;
-  
+
     if (authMethod !== 'token' || !beast || !tokenId) {
       return c.json({ error: 'Bearer-token Beast identity required' }, 403);
     }
-  
+
     const result = selfRotateToken(tokenId, beast);
     if ('error' in result) {
-      const status = result.code === 'rotate_window_expired' ? 403
-        : result.code === 'rotation_locked' ? 409
-        : result.code === 'token_not_found' ? 401
-        : 500;
+      const status =
+        result.code === 'rotate_window_expired'
+          ? 403
+          : result.code === 'rotation_locked'
+            ? 409
+            : result.code === 'token_not_found'
+              ? 401
+              : 500;
       return c.json({ error: result.error, code: result.code }, status);
     }
-  
+
     return c.json({
       token: result.token,
       id: result.id,
@@ -613,5 +684,4 @@ export function registerServerRoutes(app: OpenAPIHono, sqliteDb: Database, helpe
       beast,
     });
   });
-
 }

--- a/src/server/security-logger.ts
+++ b/src/server/security-logger.ts
@@ -16,26 +16,26 @@ import { randomUUID } from 'crypto';
 // ============================================================================
 
 export type SecurityEventType =
-  | 'auth_failure'           // Failed login attempt
-  | 'auth_success'           // Successful login (info-level, for correlation)
-  | 'permission_denied'      // 403 response
-  | 'rate_limited'           // Rate limit triggered (429)
-  | 'token_created'          // OAuth token stored
-  | 'token_refreshed'        // OAuth token refreshed
-  | 'token_revoked'          // OAuth token revoked/disconnected
-  | 'settings_changed'       // Auth/security settings modified
-  | 'impersonation_blocked'  // ?as= spoofing blocked on protected endpoint
-  | 'session_destroyed'      // Session logout
-  | 'alert_triggered'        // Threshold alert fired by checkAlertThresholds
-  | 'token_validated'        // Beast token validated (sampled, T#546)
-  | 'guest_banned'           // Guest account banned (T#616)
-  | 'guest_unbanned'         // Guest account unbanned (T#616)
-  | 'token_max_lifetime_reached'      // Spec #51 — refresh chain hit MAX_LIFETIME
-  | 'token_rotated_admin'             // Spec #51/#52 — owner-driven rotation (POST /api/auth/tokens/rotate)
-  | 'token_self_rotated'              // Spec #52 — Beast-self rotation (POST /api/auth/rotate)
-  | 'token_rotation_grace_used'       // Spec #52 — stale-in-flight grace window absorbed
-  | 'token_chain_compromised'         // Spec #52 — rotation-detection trip; chain revoked
-  | 'token_chain_revoked'             // Spec #52 — owner-revoke walked the chain
+  | 'auth_failure' // Failed login attempt
+  | 'auth_success' // Successful login (info-level, for correlation)
+  | 'permission_denied' // 403 response
+  | 'rate_limited' // Rate limit triggered (429)
+  | 'token_created' // OAuth token stored
+  | 'token_refreshed' // OAuth token refreshed
+  | 'token_revoked' // OAuth token revoked/disconnected
+  | 'settings_changed' // Auth/security settings modified
+  | 'impersonation_blocked' // ?as= spoofing blocked on protected endpoint
+  | 'session_destroyed' // Session logout
+  | 'alert_triggered' // Threshold alert fired by checkAlertThresholds
+  | 'token_validated' // Beast token validated (sampled, T#546)
+  | 'guest_banned' // Guest account banned (T#616)
+  | 'guest_unbanned' // Guest account unbanned (T#616)
+  | 'token_max_lifetime_reached' // Spec #51 — refresh chain hit MAX_LIFETIME
+  | 'token_rotated_admin' // Spec #51/#52 — owner-driven rotation (POST /api/auth/tokens/rotate)
+  | 'token_self_rotated' // Spec #52 — Beast-self rotation (POST /api/auth/rotate)
+  | 'token_rotation_grace_used' // Spec #52 — stale-in-flight grace window absorbed
+  | 'token_chain_compromised' // Spec #52 — rotation-detection trip; chain revoked
+  | 'token_chain_revoked' // Spec #52 — owner-revoke walked the chain
   | 'token_rotation_attempted_invalid'; // Spec #52 — rotate attempted with invalid/expired/locked token
 
 export type SecuritySeverity = 'info' | 'warning' | 'critical';
@@ -68,12 +68,20 @@ try {
     ip_source TEXT,
     request_id TEXT
   )`);
-  sqlite.exec(`CREATE INDEX IF NOT EXISTS idx_security_events_timestamp ON security_events(timestamp)`);
+  sqlite.exec(
+    `CREATE INDEX IF NOT EXISTS idx_security_events_timestamp ON security_events(timestamp)`,
+  );
   sqlite.exec(`CREATE INDEX IF NOT EXISTS idx_security_events_type ON security_events(event_type)`);
-  sqlite.exec(`CREATE INDEX IF NOT EXISTS idx_security_events_severity ON security_events(severity)`);
+  sqlite.exec(
+    `CREATE INDEX IF NOT EXISTS idx_security_events_severity ON security_events(severity)`,
+  );
   sqlite.exec(`CREATE INDEX IF NOT EXISTS idx_security_events_actor ON security_events(actor)`);
-  sqlite.exec(`CREATE INDEX IF NOT EXISTS idx_security_events_request_id ON security_events(request_id)`);
-} catch { /* table exists */ }
+  sqlite.exec(
+    `CREATE INDEX IF NOT EXISTS idx_security_events_request_id ON security_events(request_id)`,
+  );
+} catch {
+  /* table exists */
+}
 
 // ============================================================================
 // Prepared statements (reused for performance)
@@ -81,12 +89,12 @@ try {
 
 const insertStmt = sqlite.prepare(
   `INSERT INTO security_events (timestamp, event_type, severity, actor, actor_type, target, details, ip_source, request_id)
-   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 );
 
 const countRecentByTypeStmt = sqlite.prepare(
   `SELECT COUNT(*) as count FROM security_events
-   WHERE event_type = ? AND ip_source = ? AND timestamp > ?`
+   WHERE event_type = ? AND ip_source = ? AND timestamp > ?`,
 );
 
 // ============================================================================
@@ -124,8 +132,8 @@ export function logSecurityEvent(event: SecurityEvent): void {
 // ============================================================================
 
 const ALERT_THRESHOLDS = {
-  auth_failure: { count: 5, windowSeconds: 300 },      // 5 failures in 5 min
-  rate_limited: { count: 3, windowSeconds: 300 },       // 3 rate limits in 5 min
+  auth_failure: { count: 5, windowSeconds: 300 }, // 5 failures in 5 min
+  rate_limited: { count: 3, windowSeconds: 300 }, // 3 rate limits in 5 min
   permission_denied: { count: 10, windowSeconds: 300 }, // 10 denials in 5 min
 } as const;
 
@@ -135,11 +143,9 @@ function checkAlertThresholds(event: SecurityEvent, now: number): void {
 
   try {
     const cutoff = now - threshold.windowSeconds;
-    const result = countRecentByTypeStmt.get(
-      event.eventType,
-      event.ipSource,
-      cutoff
-    ) as { count: number } | undefined;
+    const result = countRecentByTypeStmt.get(event.eventType, event.ipSource, cutoff) as
+      | { count: number }
+      | undefined;
 
     if (result && result.count >= threshold.count) {
       const msg = `[SecurityAlert] ${event.eventType} threshold exceeded: ${result.count} events from ${event.ipSource} in ${threshold.windowSeconds}s (actor: ${event.actor || 'unknown'})`;
@@ -163,7 +169,9 @@ function checkAlertThresholds(event: SecurityEvent, now: number): void {
           event.ipSource,
           event.requestId || null,
         );
-      } catch { /* don't recurse on failure */ }
+      } catch {
+        /* don't recurse on failure */
+      }
     }
   } catch {
     // Alert check is best-effort
@@ -193,10 +201,10 @@ export const SECURITY_RETENTION_DAYS = 90;
  */
 export function pruneSecurityEvents(): number {
   try {
-    const cutoffSeconds = Math.floor(Date.now() / 1000) - (SECURITY_RETENTION_DAYS * 24 * 60 * 60);
-    const result = sqlite.prepare(
-      `DELETE FROM security_events WHERE timestamp < ?`
-    ).run(cutoffSeconds);
+    const cutoffSeconds = Math.floor(Date.now() / 1000) - SECURITY_RETENTION_DAYS * 24 * 60 * 60;
+    const result = sqlite
+      .prepare(`DELETE FROM security_events WHERE timestamp < ?`)
+      .run(cutoffSeconds);
     return result.changes || 0;
   } catch (err) {
     console.error(`[SecurityLogger] Prune failed: ${err}`);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -100,4 +100,3 @@ export interface DashboardGrowth {
     searches: number;
   }>;
 }
-

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -9,10 +9,7 @@ import type { ServerResponse } from 'http';
  * Wrap an async handler for use in synchronous HTTP server
  * Handles errors and JSON responses automatically
  */
-export function asyncHandler<T>(
-  res: ServerResponse,
-  handler: () => Promise<T>
-): void {
+export function asyncHandler<T>(res: ServerResponse, handler: () => Promise<T>): void {
   (async () => {
     try {
       const result = await handler();
@@ -21,9 +18,11 @@ export function asyncHandler<T>(
     } catch (error) {
       res.statusCode = 500;
       res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({
-        error: error instanceof Error ? error.message : 'Internal server error'
-      }));
+      res.end(
+        JSON.stringify({
+          error: error instanceof Error ? error.message : 'Internal server error',
+        }),
+      );
     }
   })();
 }
@@ -35,7 +34,7 @@ export function asyncHandler<T>(
 export function validateRequired(
   res: ServerResponse,
   params: Record<string, any>,
-  required: string[]
+  required: string[],
 ): string | null {
   for (const param of required) {
     if (!params[param]) {
@@ -59,7 +58,7 @@ export function asyncHandlerWithValidation<T>(
   res: ServerResponse,
   params: Record<string, any>,
   required: string[],
-  handler: () => Promise<T>
+  handler: () => Promise<T>,
 ): void {
   if (validateRequired(res, params, required)) {
     return; // Response already sent

--- a/src/settings/routes.ts
+++ b/src/settings/routes.ts
@@ -18,12 +18,15 @@ export function registerSettingsRoutes(app: OpenAPIHono, helpers: SettingsHelper
     const hasPassword = !!getSetting('auth_password_hash');
     const vaultRepo = getSetting('vault_repo');
 
-    return c.json({
-      authEnabled,
-      localBypass,
-      hasPassword,
-      vaultRepo
-    }, 200);
+    return c.json(
+      {
+        authEnabled,
+        localBypass,
+        hasPassword,
+        vaultRepo,
+      },
+      200,
+    );
   });
 
   // Update settings (Gorn only — reject beast API calls)
@@ -34,7 +37,10 @@ export function registerSettingsRoutes(app: OpenAPIHono, helpers: SettingsHelper
     // Only allow from browser sessions (Gorn) or local requests, not beast API calls
     const asParam = c.req.query('as');
     if (asParam) {
-      const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+      const ip =
+        c.req.header('x-real-ip') ||
+        c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+        'local';
       logSecurityEvent({
         eventType: 'impersonation_blocked',
         severity: 'warning',
@@ -102,10 +108,15 @@ export function registerSettingsRoutes(app: OpenAPIHono, helpers: SettingsHelper
     const changes: string[] = [];
     if (body.newPassword) changes.push('password_changed');
     if (body.removePassword) changes.push('password_removed');
-    if (typeof body.authEnabled === 'boolean') changes.push(`auth_${body.authEnabled ? 'enabled' : 'disabled'}`);
-    if (typeof body.localBypass === 'boolean') changes.push(`local_bypass_${body.localBypass ? 'enabled' : 'disabled'}`);
+    if (typeof body.authEnabled === 'boolean')
+      changes.push(`auth_${body.authEnabled ? 'enabled' : 'disabled'}`);
+    if (typeof body.localBypass === 'boolean')
+      changes.push(`local_bypass_${body.localBypass ? 'enabled' : 'disabled'}`);
     if (changes.length > 0) {
-      const ip = c.req.header('x-real-ip') || c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+      const ip =
+        c.req.header('x-real-ip') ||
+        c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+        'local';
       logSecurityEvent({
         eventType: 'settings_changed',
         severity: 'warning',
@@ -118,11 +129,14 @@ export function registerSettingsRoutes(app: OpenAPIHono, helpers: SettingsHelper
       });
     }
 
-    return c.json({
-      success: true,
-      authEnabled: getSetting('auth_enabled') === 'true',
-      localBypass: getSetting('auth_local_bypass') !== 'false',
-      hasPassword: !!getSetting('auth_password_hash')
-    }, 200);
+    return c.json(
+      {
+        success: true,
+        authEnabled: getSetting('auth_enabled') === 'true',
+        localBypass: getSetting('auth_local_bypass') !== 'false',
+        hasPassword: !!getSetting('auth_password_hash'),
+      },
+      200,
+    );
   }) as any);
 }

--- a/src/specs/routes.ts
+++ b/src/specs/routes.ts
@@ -18,7 +18,11 @@ interface SpecsHelpers {
   wsBroadcast: (event: string, data: any) => void;
 }
 
-export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: SpecsHelpers): void {
+export function registerSpecsRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: SpecsHelpers,
+): void {
   const { hasSessionAuth, requireBeastIdentity, isTrustedRequest, wsBroadcast } = helpers;
   const sqlite: Database = sqliteDb;
 
@@ -27,7 +31,9 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // ============================================================================
 
   // Create spec_reviews table
-  try { sqlite.prepare(`
+  try {
+    sqlite
+      .prepare(`
     CREATE TABLE IF NOT EXISTS spec_reviews (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       repo TEXT NOT NULL,
@@ -42,13 +48,22 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       updated_at TEXT NOT NULL,
       UNIQUE(repo, file_path)
     )
-  `).run(); } catch { /* exists */ }
+  `)
+      .run();
+  } catch {
+    /* exists */
+  }
 
   // Migration: add thread_id to spec_reviews (T#413)
-  try { sqlite.prepare('ALTER TABLE spec_reviews ADD COLUMN thread_id INTEGER').run(); } catch { /* exists */ }
+  try {
+    sqlite.prepare('ALTER TABLE spec_reviews ADD COLUMN thread_id INTEGER').run();
+  } catch {
+    /* exists */
+  }
 
   // T#425: spec multi-linking junction table (many-to-many for tasks + threads)
-  sqlite.prepare(`
+  sqlite
+    .prepare(`
     CREATE TABLE IF NOT EXISTS spec_links (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       spec_id INTEGER NOT NULL REFERENCES spec_reviews(id),
@@ -57,14 +72,31 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       created_at TEXT NOT NULL,
       UNIQUE(spec_id, link_type, link_id)
     )
-  `).run();
-  try { sqlite.prepare('CREATE INDEX IF NOT EXISTS idx_spec_links_spec ON spec_links(spec_id)').run(); } catch { /* exists */ }
-  try { sqlite.prepare('CREATE INDEX IF NOT EXISTS idx_spec_links_target ON spec_links(link_type, link_id)').run(); } catch { /* exists */ }
+  `)
+    .run();
+  try {
+    sqlite.prepare('CREATE INDEX IF NOT EXISTS idx_spec_links_spec ON spec_links(spec_id)').run();
+  } catch {
+    /* exists */
+  }
+  try {
+    sqlite
+      .prepare('CREATE INDEX IF NOT EXISTS idx_spec_links_target ON spec_links(link_type, link_id)')
+      .run();
+  } catch {
+    /* exists */
+  }
 
   // Migrate existing spec_reviews task_id/thread_id into spec_links
   try {
-    const specsWithLinks = sqlite.prepare("SELECT id, task_id, thread_id FROM spec_reviews WHERE task_id IS NOT NULL OR thread_id IS NOT NULL").all() as any[];
-    const insertLink = sqlite.prepare('INSERT OR IGNORE INTO spec_links (spec_id, link_type, link_id, created_at) VALUES (?, ?, ?, ?)');
+    const specsWithLinks = sqlite
+      .prepare(
+        'SELECT id, task_id, thread_id FROM spec_reviews WHERE task_id IS NOT NULL OR thread_id IS NOT NULL',
+      )
+      .all() as any[];
+    const insertLink = sqlite.prepare(
+      'INSERT OR IGNORE INTO spec_links (spec_id, link_type, link_id, created_at) VALUES (?, ?, ?, ?)',
+    );
     for (const s of specsWithLinks) {
       if (s.task_id) {
         const taskNum = parseInt(String(s.task_id).replace(/\D/g, ''), 10);
@@ -72,9 +104,31 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       }
       if (s.thread_id) insertLink.run(s.id, 'thread', s.thread_id, new Date().toISOString());
     }
-  } catch { /* migration already done or no data */ }
+  } catch {
+    /* migration already done or no data */
+  }
 
-  const ALLOWED_SPEC_REPOS = ['denbook', 'supply-chain-tool', 'karo', 'zaghnal', 'gnarl', 'bertus', 'flint', 'pip', 'dex', 'talon', 'quill', 'sable', 'nyx', 'vigil', 'rax', 'leonard', 'mara', 'snap', 'beast-blueprint'];
+  const ALLOWED_SPEC_REPOS = [
+    'denbook',
+    'supply-chain-tool',
+    'karo',
+    'zaghnal',
+    'gnarl',
+    'bertus',
+    'flint',
+    'pip',
+    'dex',
+    'talon',
+    'quill',
+    'sable',
+    'nyx',
+    'vigil',
+    'rax',
+    'leonard',
+    'mara',
+    'snap',
+    'beast-blueprint',
+  ];
 
   function resolveSpecPath(repo: string, filePath: string): string | null {
     if (!ALLOWED_SPEC_REPOS.includes(repo)) return null;
@@ -88,7 +142,8 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   }
 
   // T#754 / Spec #57 Phase 1 — spec_versions table for amendment + version chain
-  sqlite.prepare(`
+  sqlite
+    .prepare(`
     CREATE TABLE IF NOT EXISTS spec_versions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       spec_id INTEGER NOT NULL REFERENCES spec_reviews(id),
@@ -100,28 +155,57 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       created_at TEXT NOT NULL,
       UNIQUE(spec_id, version)
     )
-  `).run();
-  try { sqlite.prepare('CREATE INDEX IF NOT EXISTS idx_spec_versions_spec ON spec_versions(spec_id)').run(); } catch { /* exists */ }
+  `)
+    .run();
+  try {
+    sqlite
+      .prepare('CREATE INDEX IF NOT EXISTS idx_spec_versions_spec ON spec_versions(spec_id)')
+      .run();
+  } catch {
+    /* exists */
+  }
 
   // Add current_version to spec_reviews (default v1, snapshot tracking pointer)
-  try { sqlite.prepare("ALTER TABLE spec_reviews ADD COLUMN current_version TEXT DEFAULT 'v1'").run(); } catch { /* exists */ }
+  try {
+    sqlite.prepare("ALTER TABLE spec_reviews ADD COLUMN current_version TEXT DEFAULT 'v1'").run();
+  } catch {
+    /* exists */
+  }
 
   // Backfill: every existing approved spec gets v1 row in spec_versions if not present.
   // Skips specs whose markdown file is not on disk (consistent with /content endpoint).
   try {
-    const approvedSpecs = sqlite.prepare("SELECT id, repo, file_path, reviewed_at, updated_at FROM spec_reviews WHERE status = 'approved'").all() as any[];
+    const approvedSpecs = sqlite
+      .prepare(
+        "SELECT id, repo, file_path, reviewed_at, updated_at FROM spec_reviews WHERE status = 'approved'",
+      )
+      .all() as any[];
     const insertVersion = sqlite.prepare(
-      'INSERT OR IGNORE INTO spec_versions (spec_id, version, content, stamped_at, stamped_by, change_summary, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+      'INSERT OR IGNORE INTO spec_versions (spec_id, version, content, stamped_at, stamped_by, change_summary, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
     );
     const nowIso = new Date().toISOString();
     for (const s of approvedSpecs) {
       const resolved = resolveSpecPath(s.repo, s.file_path);
       if (!resolved) continue;
       let content: string;
-      try { content = fs.readFileSync(resolved, 'utf-8'); } catch { continue; }
-      insertVersion.run(s.id, 'v1', content, s.reviewed_at || s.updated_at, 'gorn', 'v1 (initial approval, backfilled)', nowIso);
+      try {
+        content = fs.readFileSync(resolved, 'utf-8');
+      } catch {
+        continue;
+      }
+      insertVersion.run(
+        s.id,
+        'v1',
+        content,
+        s.reviewed_at || s.updated_at,
+        'gorn',
+        'v1 (initial approval, backfilled)',
+        nowIso,
+      );
     }
-  } catch { /* backfill safe to skip on re-run */ }
+  } catch {
+    /* backfill safe to skip on re-run */
+  }
 
   // Helper: parse 'vN' to N, return null if not a vN string
   function parseVersionN(version: string): number | null {
@@ -131,7 +215,9 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   // Helper: get next version label after the highest existing version for a spec
   function nextVersionFor(specId: number): string {
-    const rows = sqlite.prepare('SELECT version FROM spec_versions WHERE spec_id = ?').all(specId) as any[];
+    const rows = sqlite
+      .prepare('SELECT version FROM spec_versions WHERE spec_id = ?')
+      .all(specId) as any[];
     let max = 0;
     for (const r of rows) {
       const n = parseVersionN(r.version);
@@ -146,15 +232,24 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const repo = c.req.query('repo');
     let query = 'SELECT * FROM spec_reviews WHERE 1=1';
     const params: any[] = [];
-    if (status) { query += ' AND status = ?'; params.push(status); }
-    if (repo) { query += ' AND repo = ?'; params.push(repo); }
-    query += ' ORDER BY CASE status WHEN \'pending\' THEN 0 WHEN \'rejected\' THEN 1 WHEN \'approved\' THEN 2 END, updated_at DESC';
+    if (status) {
+      query += ' AND status = ?';
+      params.push(status);
+    }
+    if (repo) {
+      query += ' AND repo = ?';
+      params.push(repo);
+    }
+    query +=
+      " ORDER BY CASE status WHEN 'pending' THEN 0 WHEN 'rejected' THEN 1 WHEN 'approved' THEN 2 END, updated_at DESC";
     const specs = sqlite.prepare(query).all(...params) as any[];
     // Attach links to each spec (T#425)
     for (const spec of specs) {
-      const links = sqlite.prepare('SELECT link_type, link_id FROM spec_links WHERE spec_id = ?').all(spec.id) as any[];
-      spec.linked_tasks = links.filter(l => l.link_type === 'task').map(l => l.link_id);
-      spec.linked_threads = links.filter(l => l.link_type === 'thread').map(l => l.link_id);
+      const links = sqlite
+        .prepare('SELECT link_type, link_id FROM spec_links WHERE spec_id = ?')
+        .all(spec.id) as any[];
+      spec.linked_tasks = links.filter((l) => l.link_type === 'task').map((l) => l.link_id);
+      spec.linked_threads = links.filter((l) => l.link_type === 'thread').map((l) => l.link_id);
     }
     return c.json({ specs });
   });
@@ -166,27 +261,45 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
     const resolved = resolveSpecPath(spec.repo, spec.file_path);
     if (resolved) {
-      try { spec.content = fs.readFileSync(resolved, 'utf-8'); } catch { spec.content = null; }
+      try {
+        spec.content = fs.readFileSync(resolved, 'utf-8');
+      } catch {
+        spec.content = null;
+      }
     }
     // Attach linked tasks and threads (T#425)
-    const links = sqlite.prepare('SELECT * FROM spec_links WHERE spec_id = ? ORDER BY link_type, link_id').all(id) as any[];
-    spec.linked_tasks = links.filter(l => l.link_type === 'task').map(l => l.link_id);
-    spec.linked_threads = links.filter(l => l.link_type === 'thread').map(l => l.link_id);
+    const links = sqlite
+      .prepare('SELECT * FROM spec_links WHERE spec_id = ? ORDER BY link_type, link_id')
+      .all(id) as any[];
+    spec.linked_tasks = links.filter((l) => l.link_type === 'task').map((l) => l.link_id);
+    spec.linked_threads = links.filter((l) => l.link_type === 'thread').map((l) => l.link_id);
     return c.json(spec);
   });
 
   // GET /api/specs/:id/content — raw markdown content from repo (or historical version via ?version=vN)
   app.get('/api/specs/:id/content', (c) => {
     const id = parseInt(c.req.param('id'), 10);
-    const spec = sqlite.prepare('SELECT repo, file_path, current_version FROM spec_reviews WHERE id = ?').get(id) as any;
+    const spec = sqlite
+      .prepare('SELECT repo, file_path, current_version FROM spec_reviews WHERE id = ?')
+      .get(id) as any;
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
 
     // T#755 / Spec #57 Phase 2: serve historical version if ?version=vN specified
     const versionParam = c.req.query('version');
     if (versionParam) {
-      const row = sqlite.prepare('SELECT * FROM spec_versions WHERE spec_id = ? AND version = ?').get(id, versionParam) as any;
+      const row = sqlite
+        .prepare('SELECT * FROM spec_versions WHERE spec_id = ? AND version = ?')
+        .get(id, versionParam) as any;
       if (!row) return c.json({ error: `Version ${versionParam} not found for spec #${id}` }, 404);
-      return c.json({ content: row.content, version: row.version, stamped_at: row.stamped_at, stamped_by: row.stamped_by, change_summary: row.change_summary, file_path: spec.file_path, repo: spec.repo });
+      return c.json({
+        content: row.content,
+        version: row.version,
+        stamped_at: row.stamped_at,
+        stamped_by: row.stamped_by,
+        change_summary: row.change_summary,
+        file_path: spec.file_path,
+        repo: spec.repo,
+      });
     }
 
     // Default: serve current on-disk content
@@ -194,7 +307,12 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     if (!resolved) return c.json({ error: 'Invalid spec path' }, 400);
     try {
       const content = fs.readFileSync(resolved, 'utf-8');
-      return c.json({ content, file_path: spec.file_path, repo: spec.repo, current_version: spec.current_version || 'v1' });
+      return c.json({
+        content,
+        file_path: spec.file_path,
+        repo: spec.repo,
+        current_version: spec.current_version || 'v1',
+      });
     } catch {
       return c.json({ error: 'Spec file not found on disk' }, 404);
     }
@@ -203,18 +321,24 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // T#755 / Spec #57 Phase 2: GET /api/specs/:id/versions — list all version snapshots
   app.get('/api/specs/:id/versions', (c) => {
     const id = parseInt(c.req.param('id'), 10);
-    const spec = sqlite.prepare('SELECT id, current_version FROM spec_reviews WHERE id = ?').get(id) as any;
+    const spec = sqlite
+      .prepare('SELECT id, current_version FROM spec_reviews WHERE id = ?')
+      .get(id) as any;
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
-    const versions = sqlite.prepare(
-      'SELECT version, stamped_at, stamped_by, change_summary, created_at FROM spec_versions WHERE spec_id = ? ORDER BY created_at ASC'
-    ).all(id) as any[];
+    const versions = sqlite
+      .prepare(
+        'SELECT version, stamped_at, stamped_by, change_summary, created_at FROM spec_versions WHERE spec_id = ? ORDER BY created_at ASC',
+      )
+      .all(id) as any[];
     return c.json({ spec_id: id, current_version: spec.current_version || 'v1', versions });
   });
 
   // GET /api/specs/:id/history — git log for spec file
   app.get('/api/specs/:id/history', (c) => {
     const id = parseInt(c.req.param('id'), 10);
-    const spec = sqlite.prepare('SELECT repo, file_path FROM spec_reviews WHERE id = ?').get(id) as any;
+    const spec = sqlite
+      .prepare('SELECT repo, file_path FROM spec_reviews WHERE id = ?')
+      .get(id) as any;
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
     const repoDir = path.resolve(`/home/gorn/workspace/${spec.repo}`);
     if (!ALLOWED_SPEC_REPOS.includes(spec.repo)) return c.json({ error: 'Invalid repo' }, 400);
@@ -222,11 +346,20 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       const { execSync } = require('child_process');
       const log = execSync(
         `git log --format='{"hash":"%H","short":"%h","date":"%aI","subject":"%s","author":"%an"}' -- "${spec.file_path}"`,
-        { cwd: repoDir, encoding: 'utf-8', timeout: 5000 }
+        { cwd: repoDir, encoding: 'utf-8', timeout: 5000 },
       ).trim();
-      const versions = log ? log.split('\n').map((line: string) => {
-        try { return JSON.parse(line); } catch { return null; }
-      }).filter(Boolean) : [];
+      const versions = log
+        ? log
+            .split('\n')
+            .map((line: string) => {
+              try {
+                return JSON.parse(line);
+              } catch {
+                return null;
+              }
+            })
+            .filter(Boolean)
+        : [];
       return c.json({ versions, file_path: spec.file_path, repo: spec.repo });
     } catch {
       return c.json({ versions: [], file_path: spec.file_path, repo: spec.repo });
@@ -236,23 +369,26 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // GET /api/specs/:id/diff — diff between two versions of spec file
   app.get('/api/specs/:id/diff', (c) => {
     const id = parseInt(c.req.param('id'), 10);
-    const spec = sqlite.prepare('SELECT repo, file_path FROM spec_reviews WHERE id = ?').get(id) as any;
+    const spec = sqlite
+      .prepare('SELECT repo, file_path FROM spec_reviews WHERE id = ?')
+      .get(id) as any;
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
     if (!ALLOWED_SPEC_REPOS.includes(spec.repo)) return c.json({ error: 'Invalid repo' }, 400);
     const from = c.req.query('from');
     const to = c.req.query('to') || 'HEAD';
     if (!from) return c.json({ error: 'from query param required (commit hash)' }, 400);
     // Validate hashes are hex only (prevent injection)
-    if (!/^[a-f0-9]+$/i.test(from) || !/^[a-f0-9]+$/i.test(to) && to !== 'HEAD') {
+    if (!/^[a-f0-9]+$/i.test(from) || (!/^[a-f0-9]+$/i.test(to) && to !== 'HEAD')) {
       return c.json({ error: 'Invalid commit hash' }, 400);
     }
     const repoDir = path.resolve(`/home/gorn/workspace/${spec.repo}`);
     try {
       const { execSync } = require('child_process');
-      const diff = execSync(
-        `git diff ${from} ${to} -- "${spec.file_path}"`,
-        { cwd: repoDir, encoding: 'utf-8', timeout: 5000 }
-      );
+      const diff = execSync(`git diff ${from} ${to} -- "${spec.file_path}"`, {
+        cwd: repoDir,
+        encoding: 'utf-8',
+        timeout: 5000,
+      });
       return c.json({ diff, from, to, file_path: spec.file_path, repo: spec.repo });
     } catch {
       return c.json({ diff: '', from, to, file_path: spec.file_path, repo: spec.repo });
@@ -268,7 +404,13 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         return c.json({ error: 'repo, file_path, title required' }, 400);
       }
       if (!task_id && !thread_id) {
-        return c.json({ error: 'At least one of task_id or thread_id is required. Link your spec to a task or forum thread.' }, 400);
+        return c.json(
+          {
+            error:
+              'At least one of task_id or thread_id is required. Link your spec to a task or forum thread.',
+          },
+          400,
+        );
       }
       if (!ALLOWED_SPEC_REPOS.includes(repo)) {
         return c.json({ error: `Invalid repo. Allowed: ${ALLOWED_SPEC_REPOS.join(', ')}` }, 400);
@@ -276,36 +418,72 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       // T#718 — derive author from auth, reject client-asserted mismatch
       const caller = requireBeastIdentity(c);
       if (!caller) {
-        return c.json({ error: 'Beast identity required — bearer-token or owner session', requiresAuth: true }, 401);
+        return c.json(
+          { error: 'Beast identity required — bearer-token or owner session', requiresAuth: true },
+          401,
+        );
       }
       if (data.author && data.author.toLowerCase() !== caller) {
-        return c.json({ error: 'Author impersonation blocked. body.author must match authenticated caller or be omitted.' }, 403);
+        return c.json(
+          {
+            error:
+              'Author impersonation blocked. body.author must match authenticated caller or be omitted.',
+          },
+          403,
+        );
       }
       const author = caller;
       const now = new Date().toISOString();
-      const result = sqlite.prepare(
-        'INSERT INTO spec_reviews (repo, file_path, task_id, thread_id, title, author, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
-      ).run(repo, file_path, task_id || null, thread_id || null, title, author, 'pending', now, now);
-      const spec = sqlite.prepare('SELECT * FROM spec_reviews WHERE id = ?').get((result as any).lastInsertRowid) as any;
+      const result = sqlite
+        .prepare(
+          'INSERT INTO spec_reviews (repo, file_path, task_id, thread_id, title, author, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        )
+        .run(
+          repo,
+          file_path,
+          task_id || null,
+          thread_id || null,
+          title,
+          author,
+          'pending',
+          now,
+          now,
+        );
+      const spec = sqlite
+        .prepare('SELECT * FROM spec_reviews WHERE id = ?')
+        .get((result as any).lastInsertRowid) as any;
       // Auto-link spec to task if task_id provided
       if (task_id) {
         const taskIdNum = parseInt(String(task_id).replace(/\D/g, ''), 10);
         if (!isNaN(taskIdNum)) {
-          sqlite.prepare('UPDATE tasks SET spec_id = ?, updated_at = ? WHERE id = ?').run(spec.id, now, taskIdNum);
-          sqlite.prepare('INSERT OR IGNORE INTO spec_links (spec_id, link_type, link_id, created_at) VALUES (?, ?, ?, ?)').run(spec.id, 'task', taskIdNum, now);
+          sqlite
+            .prepare('UPDATE tasks SET spec_id = ?, updated_at = ? WHERE id = ?')
+            .run(spec.id, now, taskIdNum);
+          sqlite
+            .prepare(
+              'INSERT OR IGNORE INTO spec_links (spec_id, link_type, link_id, created_at) VALUES (?, ?, ?, ?)',
+            )
+            .run(spec.id, 'task', taskIdNum, now);
         }
       }
       // Auto-link spec to thread if thread_id provided (T#425)
       if (thread_id) {
-        sqlite.prepare('INSERT OR IGNORE INTO spec_links (spec_id, link_type, link_id, created_at) VALUES (?, ?, ?, ?)').run(spec.id, 'thread', parseInt(thread_id), now);
+        sqlite
+          .prepare(
+            'INSERT OR IGNORE INTO spec_links (spec_id, link_type, link_id, created_at) VALUES (?, ?, ?, ?)',
+          )
+          .run(spec.id, 'thread', parseInt(thread_id), now);
       }
-          const specFilePath = path.join(import.meta.dirname || __dirname, '..', spec.file_path);
-      const specContent = fs.existsSync(specFilePath) ? fs.readFileSync(specFilePath, 'utf-8') : spec.title;
+      const specFilePath = path.join(import.meta.dirname || __dirname, '..', spec.file_path);
+      const specContent = fs.existsSync(specFilePath)
+        ? fs.readFileSync(specFilePath, 'utf-8')
+        : spec.title;
       searchIndexUpsert('spec', spec.id, spec.title, specContent, spec.author, now);
       wsBroadcast('spec_submitted', { id: spec.id });
       return c.json(spec, 201);
     } catch (e: any) {
-      if (e?.message?.includes('UNIQUE')) return c.json({ error: 'Spec already registered for this repo + path' }, 409);
+      if (e?.message?.includes('UNIQUE'))
+        return c.json({ error: 'Spec already registered for this repo + path' }, 409);
       return c.json({ error: 'Invalid JSON' }, 400);
     }
   });
@@ -338,16 +516,26 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         const resolved = resolveSpecPath(spec.repo, spec.file_path);
         if (!resolved) return c.json({ error: 'Cannot snapshot — invalid spec path' }, 500);
         let content: string;
-        try { content = fs.readFileSync(resolved, 'utf-8'); } catch { return c.json({ error: 'Cannot snapshot — spec file not found on disk' }, 500); }
+        try {
+          content = fs.readFileSync(resolved, 'utf-8');
+        } catch {
+          return c.json({ error: 'Cannot snapshot — spec file not found on disk' }, 500);
+        }
         newVersion = nextVersionFor(id);
-        sqlite.prepare(
-          'INSERT INTO spec_versions (spec_id, version, content, stamped_at, stamped_by, change_summary, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-        ).run(id, newVersion, content, now, 'gorn', feedback || null, now);
-        sqlite.prepare('UPDATE spec_reviews SET current_version = ? WHERE id = ?').run(newVersion, id);
+        sqlite
+          .prepare(
+            'INSERT INTO spec_versions (spec_id, version, content, stamped_at, stamped_by, change_summary, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+          )
+          .run(id, newVersion, content, now, 'gorn', feedback || null, now);
+        sqlite
+          .prepare('UPDATE spec_reviews SET current_version = ? WHERE id = ?')
+          .run(newVersion, id);
       }
-      sqlite.prepare(
-        'UPDATE spec_reviews SET status = ?, reviewer_feedback = ?, reviewed_at = ?, updated_at = ? WHERE id = ?'
-      ).run(status, feedback || null, now, now, id);
+      sqlite
+        .prepare(
+          'UPDATE spec_reviews SET status = ?, reviewer_feedback = ?, reviewed_at = ?, updated_at = ? WHERE id = ?',
+        )
+        .run(status, feedback || null, now, now, id);
       const updated = sqlite.prepare('SELECT * FROM spec_reviews WHERE id = ?').get(id) as any;
       wsBroadcast('spec_reviewed', { id: (updated as any).id, action });
       // Notify spec participants (assignee, creator, author, commenters)
@@ -358,36 +546,59 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
         if (spec.task_id) {
           const taskIdNum = parseInt(spec.task_id.replace(/\D/g, ''), 10);
           if (!isNaN(taskIdNum)) {
-            const task = sqlite.prepare('SELECT assigned_to, created_by, title FROM tasks WHERE id = ?').get(taskIdNum) as any;
+            const task = sqlite
+              .prepare('SELECT assigned_to, created_by, title FROM tasks WHERE id = ?')
+              .get(taskIdNum) as any;
             if (task?.assigned_to) toNotify.add(task.assigned_to.toLowerCase());
             if (task?.created_by) toNotify.add(task.created_by.toLowerCase());
           }
         }
-        const specParticipants = sqlite.prepare('SELECT DISTINCT author FROM spec_comments WHERE spec_id = ?').all(id) as any[];
-        for (const p of specParticipants) { if (p.author) toNotify.add(p.author.toLowerCase()); }
-        toNotify.delete('gorn');
-        const commentContent = action === 'approve'
-          ? `Spec approved by Gorn.${feedback ? ` ${feedback}` : ''} Implementation unblocked.`
-          : `Spec rejected by Gorn: ${feedback}`;
-        if (toNotify.size > 0) {
-          notifyMentioned([...toNotify], 0, `Spec #${id}: ${spec.title}`, 'gorn', `Spec ${action}d: ${commentContent.slice(0, 100)}`, {
-            type: 'Specs', label: `Spec #${id}`, hint: `Use /spec to view spec details.`,
-          });
+        const specParticipants = sqlite
+          .prepare('SELECT DISTINCT author FROM spec_comments WHERE spec_id = ?')
+          .all(id) as any[];
+        for (const p of specParticipants) {
+          if (p.author) toNotify.add(p.author.toLowerCase());
         }
-      } catch { /* notification failure is non-critical */ }
+        toNotify.delete('gorn');
+        const commentContent =
+          action === 'approve'
+            ? `Spec approved by Gorn.${feedback ? ` ${feedback}` : ''} Implementation unblocked.`
+            : `Spec rejected by Gorn: ${feedback}`;
+        if (toNotify.size > 0) {
+          notifyMentioned(
+            [...toNotify],
+            0,
+            `Spec #${id}: ${spec.title}`,
+            'gorn',
+            `Spec ${action}d: ${commentContent.slice(0, 100)}`,
+            {
+              type: 'Specs',
+              label: `Spec #${id}`,
+              hint: `Use /spec to view spec details.`,
+            },
+          );
+        }
+      } catch {
+        /* notification failure is non-critical */
+      }
 
       // Auto-post to ALL linked forum threads (per Gorn: threads only, no task comments)
-      const linkedThreads = sqlite.prepare("SELECT link_id FROM spec_links WHERE spec_id = ? AND link_type = 'thread'").all(id) as any[];
+      const linkedThreads = sqlite
+        .prepare("SELECT link_id FROM spec_links WHERE spec_id = ? AND link_type = 'thread'")
+        .all(id) as any[];
       // Also include legacy thread_id
       const threadIds = new Set<number>(linkedThreads.map((l: any) => l.link_id));
       if (updated.thread_id) threadIds.add(updated.thread_id);
       for (const threadId of threadIds) {
         try {
-          const threadMsg = action === 'approve'
-            ? `Spec #${id} **approved** by Gorn.${feedback ? ` ${feedback}` : ''} Implementation unblocked.`
-            : `Spec #${id} **rejected** by Gorn: ${feedback}`;
+          const threadMsg =
+            action === 'approve'
+              ? `Spec #${id} **approved** by Gorn.${feedback ? ` ${feedback}` : ''} Implementation unblocked.`
+              : `Spec #${id} **rejected** by Gorn: ${feedback}`;
           addMessage(threadId, 'claude', threadMsg, { author: 'system' });
-        } catch { /* thread post failure is non-critical */ }
+        } catch {
+          /* thread post failure is non-critical */
+        }
       }
 
       return c.json(updated);
@@ -401,8 +612,14 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const specId = parseInt(c.req.param('id'), 10);
     const spec = sqlite.prepare('SELECT id FROM spec_reviews WHERE id = ?').get(specId);
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
-    const links = sqlite.prepare('SELECT * FROM spec_links WHERE spec_id = ? ORDER BY link_type, link_id').all(specId) as any[];
-    return c.json({ links, linked_tasks: links.filter(l => l.link_type === 'task').map(l => l.link_id), linked_threads: links.filter(l => l.link_type === 'thread').map(l => l.link_id) });
+    const links = sqlite
+      .prepare('SELECT * FROM spec_links WHERE spec_id = ? ORDER BY link_type, link_id')
+      .all(specId) as any[];
+    return c.json({
+      links,
+      linked_tasks: links.filter((l) => l.link_type === 'task').map((l) => l.link_id),
+      linked_threads: links.filter((l) => l.link_type === 'thread').map((l) => l.link_id),
+    });
   });
 
   // POST /api/specs/:id/link — add a task or thread link (T#425)
@@ -413,17 +630,31 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     try {
       const data = await c.req.json();
       const { link_type, link_id } = data;
-      if (!link_type || !['task', 'thread'].includes(link_type)) return c.json({ error: 'link_type must be task or thread' }, 400);
-      if (!link_id || isNaN(parseInt(link_id))) return c.json({ error: 'link_id required (integer)' }, 400);
+      if (!link_type || !['task', 'thread'].includes(link_type))
+        return c.json({ error: 'link_type must be task or thread' }, 400);
+      if (!link_id || isNaN(parseInt(link_id)))
+        return c.json({ error: 'link_id required (integer)' }, 400);
       const now = new Date().toISOString();
-      sqlite.prepare('INSERT OR IGNORE INTO spec_links (spec_id, link_type, link_id, created_at) VALUES (?, ?, ?, ?)').run(specId, link_type, parseInt(link_id), now);
+      sqlite
+        .prepare(
+          'INSERT OR IGNORE INTO spec_links (spec_id, link_type, link_id, created_at) VALUES (?, ?, ?, ?)',
+        )
+        .run(specId, link_type, parseInt(link_id), now);
       // If linking a task, also set spec_id on the task
       if (link_type === 'task') {
-        sqlite.prepare('UPDATE tasks SET spec_id = ?, updated_at = ? WHERE id = ? AND (spec_id IS NULL OR spec_id = ?)').run(specId, now, parseInt(link_id), specId);
+        sqlite
+          .prepare(
+            'UPDATE tasks SET spec_id = ?, updated_at = ? WHERE id = ? AND (spec_id IS NULL OR spec_id = ?)',
+          )
+          .run(specId, now, parseInt(link_id), specId);
       }
-      const links = sqlite.prepare('SELECT * FROM spec_links WHERE spec_id = ?').all(specId) as any[];
+      const links = sqlite
+        .prepare('SELECT * FROM spec_links WHERE spec_id = ?')
+        .all(specId) as any[];
       return c.json({ success: true, links });
-    } catch { return c.json({ error: 'Invalid request' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
   });
 
   // DELETE /api/specs/:id/link — remove a task or thread link (T#425)
@@ -435,27 +666,37 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       const data = await c.req.json();
       const { link_type, link_id } = data;
       if (!link_type || !link_id) return c.json({ error: 'link_type and link_id required' }, 400);
-      sqlite.prepare('DELETE FROM spec_links WHERE spec_id = ? AND link_type = ? AND link_id = ?').run(specId, link_type, parseInt(link_id));
-      const links = sqlite.prepare('SELECT * FROM spec_links WHERE spec_id = ?').all(specId) as any[];
+      sqlite
+        .prepare('DELETE FROM spec_links WHERE spec_id = ? AND link_type = ? AND link_id = ?')
+        .run(specId, link_type, parseInt(link_id));
+      const links = sqlite
+        .prepare('SELECT * FROM spec_links WHERE spec_id = ?')
+        .all(specId) as any[];
       return c.json({ success: true, links });
-    } catch { return c.json({ error: 'Invalid request' }, 400); }
+    } catch {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
   });
 
   // GET /api/specs/by-task/:taskId — find specs linked to a task (T#425)
   app.get('/api/specs/by-task/:taskId', (c) => {
     const taskId = parseInt(c.req.param('taskId'), 10);
-    const specs = sqlite.prepare(
-      "SELECT sr.* FROM spec_reviews sr JOIN spec_links sl ON sr.id = sl.spec_id WHERE sl.link_type = 'task' AND sl.link_id = ? ORDER BY sr.updated_at DESC"
-    ).all(taskId);
+    const specs = sqlite
+      .prepare(
+        "SELECT sr.* FROM spec_reviews sr JOIN spec_links sl ON sr.id = sl.spec_id WHERE sl.link_type = 'task' AND sl.link_id = ? ORDER BY sr.updated_at DESC",
+      )
+      .all(taskId);
     return c.json({ specs });
   });
 
   // GET /api/specs/by-thread/:threadId — find specs linked to a thread (T#425)
   app.get('/api/specs/by-thread/:threadId', (c) => {
     const threadId = parseInt(c.req.param('threadId'), 10);
-    const specs = sqlite.prepare(
-      "SELECT sr.* FROM spec_reviews sr JOIN spec_links sl ON sr.id = sl.spec_id WHERE sl.link_type = 'thread' AND sl.link_id = ? ORDER BY sr.updated_at DESC"
-    ).all(threadId);
+    const specs = sqlite
+      .prepare(
+        "SELECT sr.* FROM spec_reviews sr JOIN spec_links sl ON sr.id = sl.spec_id WHERE sl.link_type = 'thread' AND sl.link_id = ? ORDER BY sr.updated_at DESC",
+      )
+      .all(threadId);
     return c.json({ specs });
   });
 
@@ -464,7 +705,14 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const id = parseInt(c.req.param('id'), 10);
     const spec = sqlite.prepare('SELECT * FROM spec_reviews WHERE id = ?').get(id) as any;
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
-    if (spec.status === 'approved') return c.json({ error: 'Approved specs cannot be resubmitted directly — POST /api/specs/:id/reopen first to enter reopened-amendment state' }, 400);
+    if (spec.status === 'approved')
+      return c.json(
+        {
+          error:
+            'Approved specs cannot be resubmitted directly — POST /api/specs/:id/reopen first to enter reopened-amendment state',
+        },
+        400,
+      );
     // Require identity — only spec author or task assignee can resubmit
     let requester: string;
     try {
@@ -473,29 +721,44 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     } catch {
       requester = (c.req.query('as') || '').toLowerCase();
     }
-    if (!requester) return c.json({ error: 'Identity required: pass author in body or ?as= param' }, 400);
+    if (!requester)
+      return c.json({ error: 'Identity required: pass author in body or ?as= param' }, 400);
     const allowed = new Set<string>();
     if (spec.author) allowed.add(spec.author.toLowerCase());
     if (spec.task_id) {
       const taskIdNum = parseInt(String(spec.task_id).replace(/\D/g, ''), 10);
       if (!isNaN(taskIdNum)) {
-        const task = sqlite.prepare('SELECT assigned_to FROM tasks WHERE id = ?').get(taskIdNum) as any;
+        const task = sqlite
+          .prepare('SELECT assigned_to FROM tasks WHERE id = ?')
+          .get(taskIdNum) as any;
         if (task?.assigned_to) allowed.add(task.assigned_to.toLowerCase());
       }
     }
     if (!allowed.has(requester) && requester !== 'gorn') {
-      return c.json({ error: `Only the spec author (${spec.author}) or task assignee can resubmit` }, 403);
+      return c.json(
+        { error: `Only the spec author (${spec.author}) or task assignee can resubmit` },
+        403,
+      );
     }
     const now = new Date().toISOString();
     // Preserve rejection history as a spec comment before clearing
     if (spec.reviewer_feedback) {
-      sqlite.prepare(
-        'INSERT INTO spec_comments (spec_id, author, content, created_at) VALUES (?, ?, ?, ?)'
-      ).run(id, 'system', `**Previous review (${spec.status})**: ${spec.reviewer_feedback}`, spec.reviewed_at || now);
+      sqlite
+        .prepare(
+          'INSERT INTO spec_comments (spec_id, author, content, created_at) VALUES (?, ?, ?, ?)',
+        )
+        .run(
+          id,
+          'system',
+          `**Previous review (${spec.status})**: ${spec.reviewer_feedback}`,
+          spec.reviewed_at || now,
+        );
     }
-    sqlite.prepare(
-      'UPDATE spec_reviews SET status = ?, reviewer_feedback = NULL, reviewed_at = NULL, updated_at = ? WHERE id = ?'
-    ).run('pending', now, id);
+    sqlite
+      .prepare(
+        'UPDATE spec_reviews SET status = ?, reviewer_feedback = NULL, reviewed_at = NULL, updated_at = ? WHERE id = ?',
+      )
+      .run('pending', now, id);
     const updated = sqlite.prepare('SELECT * FROM spec_reviews WHERE id = ?').get(id);
     wsBroadcast('spec_resubmitted', { id: (updated as any).id });
     return c.json(updated);
@@ -509,26 +772,45 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     const spec = sqlite.prepare('SELECT * FROM spec_reviews WHERE id = ?').get(id) as any;
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
     if (spec.status !== 'approved') {
-      return c.json({ error: `Only approved specs can be reopened (current status: ${spec.status})` }, 400);
+      return c.json(
+        { error: `Only approved specs can be reopened (current status: ${spec.status})` },
+        400,
+      );
     }
 
     let body: any = {};
-    try { body = await c.req.json(); } catch { /* allow empty */ }
+    try {
+      body = await c.req.json();
+    } catch {
+      /* allow empty */
+    }
     const reason = (body.reason || '').trim();
     if (!reason) return c.json({ error: 'reason required to reopen an approved spec' }, 400);
 
-    const requester = (body.author || c.req.query('as') || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-    if (!requester) return c.json({ error: 'Identity required: pass author in body or ?as= param' }, 400);
+    const requester = (
+      body.author ||
+      c.req.query('as') ||
+      (hasSessionAuth(c) ? 'gorn' : '')
+    ).toLowerCase();
+    if (!requester)
+      return c.json({ error: 'Identity required: pass author in body or ?as= param' }, 400);
     const allowed = new Set<string>(['sable', 'gorn']);
     if (spec.author) allowed.add(spec.author.toLowerCase());
     if (!allowed.has(requester)) {
-      return c.json({ error: `Only the spec author (${spec.author}), Sable, or Gorn can reopen approved specs` }, 403);
+      return c.json(
+        {
+          error: `Only the spec author (${spec.author}), Sable, or Gorn can reopen approved specs`,
+        },
+        403,
+      );
     }
 
     const resolved = resolveSpecPath(spec.repo, spec.file_path);
     if (!resolved) return c.json({ error: 'Cannot snapshot — invalid spec path' }, 500);
     let content: string;
-    try { content = fs.readFileSync(resolved, 'utf-8'); } catch {
+    try {
+      content = fs.readFileSync(resolved, 'utf-8');
+    } catch {
       return c.json({ error: 'Cannot snapshot — spec file not found on disk' }, 500);
     }
 
@@ -537,19 +819,38 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     // for specs that predate the version chain — backfill should have populated this already
     // but if the file changed since backfill we re-capture the current state).
     const currentVersion: string = spec.current_version || 'v1';
-    sqlite.prepare(
-      'INSERT OR IGNORE INTO spec_versions (spec_id, version, content, stamped_at, stamped_by, change_summary, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-    ).run(id, currentVersion, content, spec.reviewed_at || spec.updated_at, 'gorn', `${currentVersion} (snapshot at reopen)`, now);
+    sqlite
+      .prepare(
+        'INSERT OR IGNORE INTO spec_versions (spec_id, version, content, stamped_at, stamped_by, change_summary, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      )
+      .run(
+        id,
+        currentVersion,
+        content,
+        spec.reviewed_at || spec.updated_at,
+        'gorn',
+        `${currentVersion} (snapshot at reopen)`,
+        now,
+      );
 
     // Transition status; preserve current_version pointer (still points at currentVersion until next stamp).
-    sqlite.prepare(
-      "UPDATE spec_reviews SET status = 'reopened-amendment', reviewer_feedback = NULL, reviewed_at = NULL, updated_at = ? WHERE id = ?"
-    ).run(now, id);
+    sqlite
+      .prepare(
+        "UPDATE spec_reviews SET status = 'reopened-amendment', reviewer_feedback = NULL, reviewed_at = NULL, updated_at = ? WHERE id = ?",
+      )
+      .run(now, id);
 
     // Record reopen as a spec comment for audit trail.
-    sqlite.prepare(
-      'INSERT INTO spec_comments (spec_id, author, content, created_at) VALUES (?, ?, ?, ?)'
-    ).run(id, requester, `**Spec reopened for amendment** (snapshot ${currentVersion}). Reason: ${reason}`, now);
+    sqlite
+      .prepare(
+        'INSERT INTO spec_comments (spec_id, author, content, created_at) VALUES (?, ?, ?, ?)',
+      )
+      .run(
+        id,
+        requester,
+        `**Spec reopened for amendment** (snapshot ${currentVersion}). Reason: ${reason}`,
+        now,
+      );
 
     const updated = sqlite.prepare('SELECT * FROM spec_reviews WHERE id = ?').get(id);
     wsBroadcast('spec_reopened', { id: (updated as any).id });
@@ -575,7 +876,9 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   // Spec Comments (T#332)
   // ============================================================================
 
-  try { sqlite.prepare(`
+  try {
+    sqlite
+      .prepare(`
     CREATE TABLE IF NOT EXISTS spec_comments (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       spec_id INTEGER NOT NULL,
@@ -583,7 +886,11 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       content TEXT NOT NULL,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )
-  `).run(); } catch { /* exists */ }
+  `)
+      .run();
+  } catch {
+    /* exists */
+  }
 
   // GET /api/specs/:id/comments
   app.get('/api/specs/:id/comments', (c) => {
@@ -593,9 +900,15 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
     const limit = Math.min(100, parseInt(c.req.query('limit') || '30', 10));
     const offset = Math.max(0, parseInt(c.req.query('offset') || '0', 10));
-    const total = (sqlite.prepare('SELECT COUNT(*) as c FROM spec_comments WHERE spec_id = ?').get(id) as any).c;
+    const total = (
+      sqlite.prepare('SELECT COUNT(*) as c FROM spec_comments WHERE spec_id = ?').get(id) as any
+    ).c;
     // Return most recent comments: order DESC for pagination, then reverse for display
-    const comments = sqlite.prepare('SELECT * FROM spec_comments WHERE spec_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?').all(id, limit, offset) as any[];
+    const comments = sqlite
+      .prepare(
+        'SELECT * FROM spec_comments WHERE spec_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?',
+      )
+      .all(id, limit, offset) as any[];
     comments.reverse();
     return c.json({ comments, total });
   });
@@ -613,39 +926,55 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   app.post('/api/specs/:id/comments', async (c) => {
     const id = parseInt(c.req.param('id'), 10);
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
-    const spec = sqlite.prepare('SELECT id, title, author FROM spec_reviews WHERE id = ?').get(id) as any;
+    const spec = sqlite
+      .prepare('SELECT id, title, author FROM spec_reviews WHERE id = ?')
+      .get(id) as any;
     if (!spec) return c.json({ error: 'Spec not found' }, 404);
 
     try {
       const data = await c.req.json();
-      const author = (c.req.query('as') || data.author || (hasSessionAuth(c) ? 'gorn' : '')).toLowerCase();
-      if (!author) return c.json({ error: 'Identity required: pass ?as=beast or author in body' }, 400);
+      const author = (
+        c.req.query('as') ||
+        data.author ||
+        (hasSessionAuth(c) ? 'gorn' : '')
+      ).toLowerCase();
+      if (!author)
+        return c.json({ error: 'Identity required: pass ?as=beast or author in body' }, 400);
       if (!data.content?.trim()) return c.json({ error: 'content required' }, 400);
 
       const contentText = data.content.trim();
-      const result = sqlite.prepare(
-        'INSERT INTO spec_comments (spec_id, author, content) VALUES (?, ?, ?)'
-      ).run(id, author, contentText);
+      const result = sqlite
+        .prepare('INSERT INTO spec_comments (spec_id, author, content) VALUES (?, ?, ?)')
+        .run(id, author, contentText);
 
-      const comment = sqlite.prepare('SELECT * FROM spec_comments WHERE id = ?').get((result as any).lastInsertRowid);
-      wsBroadcast('spec_comment', { action: 'comment', spec_id: id, comment_id: (comment as any).id });
+      const comment = sqlite
+        .prepare('SELECT * FROM spec_comments WHERE id = ?')
+        .get((result as any).lastInsertRowid);
+      wsBroadcast('spec_comment', {
+        action: 'comment',
+        spec_id: id,
+        comment_id: (comment as any).id,
+      });
 
       // Notify spec author + previous commenters + @mentions
       try {
         const { parseMentions, notifyMentioned } = await import('../forum/mentions.ts');
         const toNotify = new Set<string>();
         // Spec author
-        if (spec.author && spec.author.toLowerCase() !== author) toNotify.add(spec.author.toLowerCase());
+        if (spec.author && spec.author.toLowerCase() !== author)
+          toNotify.add(spec.author.toLowerCase());
         // Previous commenters
-        const prevCommenters = sqlite.prepare(
-          'SELECT DISTINCT author FROM spec_comments WHERE spec_id = ? AND author != ?'
-        ).all(id, author) as any[];
+        const prevCommenters = sqlite
+          .prepare('SELECT DISTINCT author FROM spec_comments WHERE spec_id = ? AND author != ?')
+          .all(id, author) as any[];
         for (const pc of prevCommenters) toNotify.add(pc.author.toLowerCase());
         // @mentions in comment content
         const mentions = parseMentions(contentText, 0);
         for (const m of mentions) toNotify.add(m.toLowerCase());
         toNotify.delete(author);
-        toNotify.delete('gorn'); toNotify.delete('human'); toNotify.delete('user');
+        toNotify.delete('gorn');
+        toNotify.delete('human');
+        toNotify.delete('user');
         if (toNotify.size > 0) {
           notifyMentioned(
             [...toNotify],
@@ -653,16 +982,20 @@ export function registerSpecsRoutes(app: OpenAPIHono, sqliteDb: Database, helper
             `Spec #${id}: ${spec.title || 'Untitled'}`,
             author,
             `New comment on spec #${id}: ${contentText.slice(0, 100)}`,
-            { type: 'Spec comment', label: `spec #${id}`, hint: `Use /spec ${id} to view. Reply with: curl -X POST http://localhost:47778/api/specs/${id}/comments?as=<you> -H 'Content-Type: application/json' -d '{\"content\":\"your reply\"}'` }
+            {
+              type: 'Spec comment',
+              label: `spec #${id}`,
+              hint: `Use /spec ${id} to view. Reply with: curl -X POST http://localhost:47778/api/specs/${id}/comments?as=<you> -H 'Content-Type: application/json' -d '{\"content\":\"your reply\"}'`,
+            },
           );
         }
-      } catch { /* notification failure is non-critical */ }
+      } catch {
+        /* notification failure is non-critical */
+      }
 
       return c.json(comment, 201);
     } catch {
       return c.json({ error: 'Invalid request' }, 400);
     }
   });
-
-
 }

--- a/src/supersede/routes.ts
+++ b/src/supersede/routes.ts
@@ -22,14 +22,16 @@ export function registerSupersedeRoutes(app: OpenAPIHono) {
     const whereClause = project ? eq(supersedeLog.project, project) : undefined;
 
     // Get total count using Drizzle
-    const countResult = db.select({ total: sql<number>`count(*)` })
+    const countResult = db
+      .select({ total: sql<number>`count(*)` })
       .from(supersedeLog)
       .where(whereClause)
       .get();
     const total = countResult?.total || 0;
 
     // Get logs using Drizzle
-    const logs = db.select()
+    const logs = db
+      .select()
       .from(supersedeLog)
       .where(whereClause)
       .orderBy(desc(supersedeLog.supersededAt))
@@ -37,25 +39,28 @@ export function registerSupersedeRoutes(app: OpenAPIHono) {
       .offset(offset)
       .all();
 
-    return c.json({
-      supersessions: logs.map(log => ({
-        id: log.id,
-        old_path: log.oldPath,
-        old_id: log.oldId,
-        old_title: log.oldTitle,
-        old_type: log.oldType,
-        new_path: log.newPath,
-        new_id: log.newId,
-        new_title: log.newTitle,
-        reason: log.reason,
-        superseded_at: new Date(log.supersededAt).toISOString(),
-        superseded_by: log.supersededBy,
-        project: log.project
-      })),
-      total,
-      limit,
-      offset
-    }, 200);
+    return c.json(
+      {
+        supersessions: logs.map((log) => ({
+          id: log.id,
+          old_path: log.oldPath,
+          old_id: log.oldId,
+          old_title: log.oldTitle,
+          old_type: log.oldType,
+          new_path: log.newPath,
+          new_id: log.newId,
+          new_title: log.newTitle,
+          reason: log.reason,
+          superseded_at: new Date(log.supersededAt).toISOString(),
+          superseded_by: log.supersededBy,
+          project: log.project,
+        })),
+        total,
+        limit,
+        offset,
+      },
+      200,
+    );
   }) as any);
 
   // Get supersede chain for a document (what superseded what)
@@ -63,30 +68,35 @@ export function registerSupersedeRoutes(app: OpenAPIHono) {
     const docPath = decodeURIComponent(c.req.param('path') ?? '');
 
     // Find all supersessions where this doc was old or new using Drizzle
-    const asOld = db.select()
+    const asOld = db
+      .select()
       .from(supersedeLog)
       .where(eq(supersedeLog.oldPath, docPath))
       .orderBy(supersedeLog.supersededAt)
       .all();
 
-    const asNew = db.select()
+    const asNew = db
+      .select()
       .from(supersedeLog)
       .where(eq(supersedeLog.newPath, docPath))
       .orderBy(supersedeLog.supersededAt)
       .all();
 
-    return c.json({
-      superseded_by: asOld.map(log => ({
-        new_path: log.newPath,
-        reason: log.reason,
-        superseded_at: new Date(log.supersededAt).toISOString()
-      })),
-      supersedes: asNew.map(log => ({
-        old_path: log.oldPath,
-        reason: log.reason,
-        superseded_at: new Date(log.supersededAt).toISOString()
-      }))
-    }, 200);
+    return c.json(
+      {
+        superseded_by: asOld.map((log) => ({
+          new_path: log.newPath,
+          reason: log.reason,
+          superseded_at: new Date(log.supersededAt).toISOString(),
+        })),
+        supersedes: asNew.map((log) => ({
+          old_path: log.oldPath,
+          reason: log.reason,
+          superseded_at: new Date(log.supersededAt).toISOString(),
+        })),
+      },
+      200,
+    );
   }) as any);
 
   // Log a new supersession
@@ -100,28 +110,38 @@ export function registerSupersedeRoutes(app: OpenAPIHono) {
         return c.json({ error: 'Missing required field: old_path' }, 400);
       }
 
-      const result = db.insert(supersedeLog).values({
-        oldPath: data.old_path,
-        oldId: data.old_id || null,
-        oldTitle: data.old_title || null,
-        oldType: data.old_type || null,
-        newPath: data.new_path || null,
-        newId: data.new_id || null,
-        newTitle: data.new_title || null,
-        reason: data.reason || null,
-        supersededAt: Date.now(),
-        supersededBy: data.superseded_by || 'user',
-        project: data.project || null
-      }).returning({ id: supersedeLog.id }).get();
+      const result = db
+        .insert(supersedeLog)
+        .values({
+          oldPath: data.old_path,
+          oldId: data.old_id || null,
+          oldTitle: data.old_title || null,
+          oldType: data.old_type || null,
+          newPath: data.new_path || null,
+          newId: data.new_id || null,
+          newTitle: data.new_title || null,
+          reason: data.reason || null,
+          supersededAt: Date.now(),
+          supersededBy: data.superseded_by || 'user',
+          project: data.project || null,
+        })
+        .returning({ id: supersedeLog.id })
+        .get();
 
-      return c.json({
-        id: result.id,
-        message: 'Supersession logged'
-      }, 201);
+      return c.json(
+        {
+          id: result.id,
+          message: 'Supersession logged',
+        },
+        201,
+      );
     } catch (error) {
-      return c.json({
-        error: error instanceof Error ? error.message : 'Unknown error'
-      }, 500);
+      return c.json(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        500,
+      );
     }
   }) as any);
 }

--- a/src/teams/routes.ts
+++ b/src/teams/routes.ts
@@ -13,7 +13,8 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
   function validateTeamName(name: string): string | null {
     if (!name || name.trim().length === 0) return 'name required';
     if (name.length > 100) return 'name too long (max 100 chars)';
-    if (!/^[a-zA-Z0-9 _-]+$/.test(name)) return 'name contains invalid characters (use letters, numbers, spaces, hyphens only)';
+    if (!/^[a-zA-Z0-9 _-]+$/.test(name))
+      return 'name contains invalid characters (use letters, numbers, spaces, hyphens only)';
     return null;
   }
 
@@ -24,19 +25,23 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
 
   // Helper: check if beast exists
   function beastExists(name: string): boolean {
-    const row = sqlite.prepare('SELECT name FROM beast_profiles WHERE name = ?').get(name.toLowerCase());
+    const row = sqlite
+      .prepare('SELECT name FROM beast_profiles WHERE name = ?')
+      .get(name.toLowerCase());
     return !!row;
   }
 
   // GET /api/teams — list all teams with member counts
   app.get('/api/teams', (c) => {
-    const teams = sqlite.prepare(`
+    const teams = sqlite
+      .prepare(`
       SELECT t.*, COUNT(tm.beast) as member_count
       FROM teams t
       LEFT JOIN team_members tm ON tm.team_id = t.id
       GROUP BY t.id
       ORDER BY t.name
-    `).all() as any[];
+    `)
+      .all() as any[];
     return c.json({ teams, total: teams.length });
   });
 
@@ -49,11 +54,13 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const name = sanitizeInput(data.name);
     const description = data.description ? sanitizeInput(data.description) : null;
     try {
-      const result = sqlite.prepare(
-        'INSERT INTO teams (name, description, created_by) VALUES (?, ?, ?)'
-      ).run(name, description, data.created_by);
+      const result = sqlite
+        .prepare('INSERT INTO teams (name, description, created_by) VALUES (?, ?, ?)')
+        .run(name, description, data.created_by);
       // Auto-add creator as lead
-      sqlite.prepare('INSERT INTO team_members (team_id, beast, role) VALUES (?, ?, ?)').run(result.lastInsertRowid, data.created_by, 'lead');
+      sqlite
+        .prepare('INSERT INTO team_members (team_id, beast, role) VALUES (?, ?, ?)')
+        .run(result.lastInsertRowid, data.created_by, 'lead');
       const team = sqlite.prepare('SELECT * FROM teams WHERE id = ?').get(result.lastInsertRowid);
       return c.json(team, 201);
     } catch (e: any) {
@@ -68,8 +75,12 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
     const team = sqlite.prepare('SELECT * FROM teams WHERE id = ?').get(id) as any;
     if (!team) return c.json({ error: 'Team not found' }, 404);
-    const members = sqlite.prepare('SELECT beast, role, joined_at FROM team_members WHERE team_id = ?').all(id);
-    const projects = sqlite.prepare('SELECT project_id FROM team_projects WHERE team_id = ?').all(id);
+    const members = sqlite
+      .prepare('SELECT beast, role, joined_at FROM team_members WHERE team_id = ?')
+      .all(id);
+    const projects = sqlite
+      .prepare('SELECT project_id FROM team_projects WHERE team_id = ?')
+      .all(id);
     return c.json({ ...team, members, projects });
   });
 
@@ -85,7 +96,10 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
       if (nameErr) return c.json({ error: nameErr }, 400);
       sqlite.prepare('UPDATE teams SET name = ? WHERE id = ?').run(sanitizeInput(data.name), id);
     }
-    if (data.description !== undefined) sqlite.prepare('UPDATE teams SET description = ? WHERE id = ?').run(sanitizeInput(data.description || ''), id);
+    if (data.description !== undefined)
+      sqlite
+        .prepare('UPDATE teams SET description = ? WHERE id = ?')
+        .run(sanitizeInput(data.description || ''), id);
     const updated = sqlite.prepare('SELECT * FROM teams WHERE id = ?').get(id);
     return c.json(updated);
   });
@@ -100,10 +114,16 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     if (!data.beast) return c.json({ error: 'beast required' }, 400);
     if (!beastExists(data.beast)) return c.json({ error: `Beast '${data.beast}' not found` }, 404);
     try {
-      sqlite.prepare('INSERT INTO team_members (team_id, beast, role) VALUES (?, ?, ?)').run(id, data.beast.toLowerCase(), data.role || 'member');
-      return c.json({ team_id: id, beast: data.beast.toLowerCase(), role: data.role || 'member' }, 201);
+      sqlite
+        .prepare('INSERT INTO team_members (team_id, beast, role) VALUES (?, ?, ?)')
+        .run(id, data.beast.toLowerCase(), data.role || 'member');
+      return c.json(
+        { team_id: id, beast: data.beast.toLowerCase(), role: data.role || 'member' },
+        201,
+      );
     } catch (e: any) {
-      if (e.message?.includes('UNIQUE') || e.message?.includes('PRIMARY')) return c.json({ error: 'Beast already in team' }, 409);
+      if (e.message?.includes('UNIQUE') || e.message?.includes('PRIMARY'))
+        return c.json({ error: 'Beast already in team' }, 409);
       throw e;
     }
   });
@@ -113,7 +133,9 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const id = parseInt(c.req.param('id'));
     const beast = c.req.param('beast').toLowerCase();
     if (isNaN(id)) return c.json({ error: 'Invalid ID' }, 400);
-    const result = sqlite.prepare('DELETE FROM team_members WHERE team_id = ? AND beast = ?').run(id, beast);
+    const result = sqlite
+      .prepare('DELETE FROM team_members WHERE team_id = ? AND beast = ?')
+      .run(id, beast);
     if (result.changes === 0) return c.json({ error: 'Member not found in team' }, 404);
     return c.json({ removed: beast, team_id: id });
   });
@@ -125,10 +147,13 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const data = await c.req.json();
     if (!data.project_id) return c.json({ error: 'project_id required' }, 400);
     try {
-      sqlite.prepare('INSERT INTO team_projects (team_id, project_id) VALUES (?, ?)').run(id, data.project_id);
+      sqlite
+        .prepare('INSERT INTO team_projects (team_id, project_id) VALUES (?, ?)')
+        .run(id, data.project_id);
       return c.json({ team_id: id, project_id: data.project_id }, 201);
     } catch (e: any) {
-      if (e.message?.includes('UNIQUE') || e.message?.includes('PRIMARY')) return c.json({ error: 'Project already linked' }, 409);
+      if (e.message?.includes('UNIQUE') || e.message?.includes('PRIMARY'))
+        return c.json({ error: 'Project already linked' }, 409);
       throw e;
     }
   });
@@ -138,7 +163,9 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
     const id = parseInt(c.req.param('id'));
     const projectId = parseInt(c.req.param('projectId'));
     if (isNaN(id) || isNaN(projectId)) return c.json({ error: 'Invalid ID' }, 400);
-    const result = sqlite.prepare('DELETE FROM team_projects WHERE team_id = ? AND project_id = ?').run(id, projectId);
+    const result = sqlite
+      .prepare('DELETE FROM team_projects WHERE team_id = ? AND project_id = ?')
+      .run(id, projectId);
     if (result.changes === 0) return c.json({ error: 'Project not linked to team' }, 404);
     return c.json({ removed_project: projectId, team_id: id });
   });
@@ -165,13 +192,15 @@ export function registerTeamsRoutes(app: OpenAPIHono, sqlite: Database, helpers:
   // GET /api/teams/beast/:beast — list teams for a specific Beast
   app.get('/api/teams/beast/:beast', (c) => {
     const beast = c.req.param('beast').toLowerCase();
-    const teams = sqlite.prepare(`
+    const teams = sqlite
+      .prepare(`
       SELECT t.*, tm.role
       FROM teams t
       JOIN team_members tm ON tm.team_id = t.id
       WHERE tm.beast = ?
       ORDER BY t.name
-    `).all(beast) as any[];
+    `)
+      .all(beast) as any[];
     return c.json({ beast, teams, total: teams.length });
   });
 }

--- a/src/telegram/routes.ts
+++ b/src/telegram/routes.ts
@@ -34,11 +34,18 @@ function parseTelegramBots(): TelegramBot[] {
             token: b.token,
             beast: b.beast,
             chatId: b.chatId || TG_CHAT_ID,
-            offset: 0, lastMessageAt: null, messageCount: 0, active: false, timer: null, polling: false,
+            offset: 0,
+            lastMessageAt: null,
+            messageCount: 0,
+            active: false,
+            timer: null,
+            polling: false,
           });
         }
       }
-    } catch (e) { console.error('[Telegram] Failed to parse TELEGRAM_BOTS:', e); }
+    } catch (e) {
+      console.error('[Telegram] Failed to parse TELEGRAM_BOTS:', e);
+    }
   }
 
   if (bots.length === 0) {
@@ -46,8 +53,15 @@ function parseTelegramBots(): TelegramBot[] {
     const beast = process.env.TELEGRAM_FORWARD_TO || 'karo';
     if (token && TG_CHAT_ID) {
       bots.push({
-        token, beast, chatId: TG_CHAT_ID,
-        offset: 0, lastMessageAt: null, messageCount: 0, active: false, timer: null, polling: false,
+        token,
+        beast,
+        chatId: TG_CHAT_ID,
+        offset: 0,
+        lastMessageAt: null,
+        messageCount: 0,
+        active: false,
+        timer: null,
+        polling: false,
       });
     }
   }
@@ -57,7 +71,11 @@ function parseTelegramBots(): TelegramBot[] {
 
 const telegramBots = parseTelegramBots();
 
-async function tgApi(token: string, method: string, params: Record<string, string> = {}): Promise<any> {
+async function tgApi(
+  token: string,
+  method: string,
+  params: Record<string, string> = {},
+): Promise<any> {
   const url = new URL(`https://api.telegram.org/bot${token}/${method}`);
   for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
   const res = await fetch(url.toString());
@@ -68,9 +86,16 @@ async function tgSendReply(token: string, chatId: string, text: string): Promise
   await tgApi(token, 'sendMessage', { chat_id: chatId, text });
 }
 
-async function handleTelegramMessage(bot: TelegramBot, msg: any, sqlite: Database, uploadsDir: string): Promise<void> {
+async function handleTelegramMessage(
+  bot: TelegramBot,
+  msg: any,
+  sqlite: Database,
+  uploadsDir: string,
+): Promise<void> {
   if (String(msg.chat.id) !== bot.chatId) {
-    console.log(`[Telegram:${bot.beast}] Rejected: chat_id ${msg.chat.id} !== expected ${bot.chatId}`);
+    console.log(
+      `[Telegram:${bot.beast}] Rejected: chat_id ${msg.chat.id} !== expected ${bot.chatId}`,
+    );
     return;
   }
 
@@ -88,21 +113,27 @@ async function handleTelegramMessage(bot: TelegramBot, msg: any, sqlite: Databas
       };
       stripEphemeral(sanitized);
       const rawJson = JSON.stringify(sanitized);
-      sqlite.prepare(
-        'INSERT OR IGNORE INTO telegram_messages (chat_id, id, from_id, text, caption, photo_file_id, date_unix, received_at, raw_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
-      ).run(
-        String(msg.chat.id),
-        msgId,
-        msg.from?.id ? String(msg.from.id) : null,
-        msg.text || null,
-        msg.caption || null,
-        msg.photo && msg.photo.length > 0 ? (msg.photo[msg.photo.length - 1].file_id || null) : null,
-        msg.date || Math.floor(Date.now() / 1000),
-        Date.now(),
-        rawJson
-      );
+      sqlite
+        .prepare(
+          'INSERT OR IGNORE INTO telegram_messages (chat_id, id, from_id, text, caption, photo_file_id, date_unix, received_at, raw_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        )
+        .run(
+          String(msg.chat.id),
+          msgId,
+          msg.from?.id ? String(msg.from.id) : null,
+          msg.text || null,
+          msg.caption || null,
+          msg.photo && msg.photo.length > 0
+            ? msg.photo[msg.photo.length - 1].file_id || null
+            : null,
+          msg.date || Math.floor(Date.now() / 1000),
+          Date.now(),
+          rawJson,
+        );
     } else {
-      console.warn(`[Telegram:${bot.beast} T#712] dropping cache — malformed message_id: ${JSON.stringify(msgId)}`);
+      console.warn(
+        `[Telegram:${bot.beast} T#712] dropping cache — malformed message_id: ${JSON.stringify(msgId)}`,
+      );
     }
   } catch (cacheErr) {
     console.warn(`[Telegram:${bot.beast} T#712] dropping cache — persist error:`, cacheErr);
@@ -117,7 +148,8 @@ async function handleTelegramMessage(bot: TelegramBot, msg: any, sqlite: Databas
       const replied = msg.reply_to_message;
       const repliedId = typeof replied.message_id === 'number' ? replied.message_id : '?';
       const repliedText = replied.text || replied.caption || '[media]';
-      const repliedPreview = repliedText.length > 80 ? repliedText.slice(0, 80) + '...' : repliedText;
+      const repliedPreview =
+        repliedText.length > 80 ? repliedText.slice(0, 80) + '...' : repliedText;
       replyContext = `(replying to TG#${repliedId}: "${repliedPreview}")\\n`;
     }
 
@@ -138,25 +170,51 @@ async function handleTelegramMessage(bot: TelegramBot, msg: any, sqlite: Databas
                 const sharp = require('sharp');
                 const metadata = await sharp(buffer).metadata();
                 if (metadata.width && metadata.width > 1920) {
-                  processedBuffer = await sharp(buffer).rotate().resize(1920, null, { withoutEnlargement: true }).jpeg({ quality: 95 }).withMetadata({ orientation: undefined }).toBuffer();
+                  processedBuffer = await sharp(buffer)
+                    .rotate()
+                    .resize(1920, null, { withoutEnlargement: true })
+                    .jpeg({ quality: 95 })
+                    .withMetadata({ orientation: undefined })
+                    .toBuffer();
                   ext = '.jpg';
                 } else {
-                  processedBuffer = await sharp(buffer).rotate().withMetadata({ orientation: undefined }).toBuffer();
+                  processedBuffer = await sharp(buffer)
+                    .rotate()
+                    .withMetadata({ orientation: undefined })
+                    .toBuffer();
                 }
-              } catch { /* sharp not available */ }
+              } catch {
+                /* sharp not available */
+              }
 
               if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir, { recursive: true });
               const filename = `telegram_${crypto.randomUUID()}${ext}`;
               fs.writeFileSync(path.join(uploadsDir, filename), processedBuffer);
               try {
-                sqlite.prepare('INSERT INTO files (filename, original_name, mime_type, size_bytes, uploaded_by, context, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(filename, `telegram_photo${ext}`, ext === '.jpg' ? 'image/jpeg' : 'image/png', processedBuffer.length, 'gorn', 'telegram', Date.now());
-              } catch { /* files table may not have all columns */ }
+                sqlite
+                  .prepare(
+                    'INSERT INTO files (filename, original_name, mime_type, size_bytes, uploaded_by, context, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+                  )
+                  .run(
+                    filename,
+                    `telegram_photo${ext}`,
+                    ext === '.jpg' ? 'image/jpeg' : 'image/png',
+                    processedBuffer.length,
+                    'gorn',
+                    'telegram',
+                    Date.now(),
+                  );
+              } catch {
+                /* files table may not have all columns */
+              }
               photoUrl = `https://denbook.online/api/f/${filename}`;
               console.log(`[Telegram:${bot.beast}] Photo saved: ${filename}`);
             }
           }
         }
-      } catch (e) { console.error(`[Telegram:${bot.beast}] Photo download error:`, e); }
+      } catch (e) {
+        console.error(`[Telegram:${bot.beast}] Photo download error:`, e);
+      }
 
       const caption = msg.caption || '';
       if (photoUrl) {
@@ -169,25 +227,20 @@ async function handleTelegramMessage(bot: TelegramBot, msg: any, sqlite: Databas
           : `[Telegram from Gorn] ${replyContext}Photo received (download failed)`;
       }
       confirmText = `✓ Notified ${bot.beast}`;
-
     } else if (msg.text) {
       notifyText = `[Telegram from Gorn] ${replyContext}${msg.text}`;
       confirmText = `✓ Notified ${bot.beast}`;
-
     } else if (msg.document) {
       const docName = msg.document.file_name || 'unknown';
       notifyText = `[Telegram from Gorn] ${replyContext}Document: ${docName}${msg.caption ? ' — ' + msg.caption : ''}`;
       confirmText = `✓ Notified ${bot.beast}`;
-
     } else if (msg.voice) {
       notifyText = `[Telegram from Gorn] ${replyContext}Voice message`;
       confirmText = `✓ Notified ${bot.beast}`;
-
     } else if (msg.sticker) {
       const emoji = msg.sticker.emoji || '';
       notifyText = `[Telegram from Gorn] ${replyContext}Sticker ${emoji}`;
       confirmText = `✓ Notified ${bot.beast}`;
-
     } else {
       notifyText = `[Telegram from Gorn] ${replyContext}Message received`;
       confirmText = `✓ Notified ${bot.beast}`;
@@ -200,13 +253,16 @@ async function handleTelegramMessage(bot: TelegramBot, msg: any, sqlite: Databas
     console.log(`[Telegram:${bot.beast}] Notified: ${notifyText.slice(0, 80)}`);
     bot.messageCount++;
     bot.lastMessageAt = new Date().toISOString();
-
   } catch (err) {
     console.error(`[Telegram:${bot.beast}] Error handling message:`, err);
   }
 }
 
-async function pollTelegramBot(bot: TelegramBot, sqlite: Database, uploadsDir: string): Promise<void> {
+async function pollTelegramBot(
+  bot: TelegramBot,
+  sqlite: Database,
+  uploadsDir: string,
+): Promise<void> {
   if (bot.polling) return;
   bot.polling = true;
   try {
@@ -221,7 +277,9 @@ async function pollTelegramBot(bot: TelegramBot, sqlite: Database, uploadsDir: s
         bot.offset = update.update_id + 1;
         const msg = update.message;
         if (msg) {
-          console.log(`[Telegram:${bot.beast}] Update ${update.update_id}: chat_id=${msg.chat?.id} from=${msg.from?.username || msg.from?.id} text=${(msg.text || '[non-text]').slice(0, 50)}`);
+          console.log(
+            `[Telegram:${bot.beast}] Update ${update.update_id}: chat_id=${msg.chat?.id} from=${msg.from?.username || msg.from?.id} text=${(msg.text || '[non-text]').slice(0, 50)}`,
+          );
           await handleTelegramMessage(bot, msg, sqlite, uploadsDir);
         }
       }
@@ -237,10 +295,14 @@ const TELEGRAM_READ_MODES: Record<string, 'read'> = {
   sable: 'read',
 };
 
-function isTelegramAuthorized(c: any, hasSessionAuth: (c: Context) => boolean, isTrustedRequest: (c: Context) => boolean): boolean {
+function isTelegramAuthorized(
+  c: any,
+  hasSessionAuth: (c: Context) => boolean,
+  isTrustedRequest: (c: Context) => boolean,
+): boolean {
   if (hasSessionAuth(c)) return true;
   const actor = (c.get as any)('actor') as string | undefined;
-  if (actor && telegramBots.some(b => b.beast === actor)) return true;
+  if (actor && telegramBots.some((b) => b.beast === actor)) return true;
   if (isTrustedRequest(c)) {
     const as = (c.req.query('as') || '').toLowerCase();
     return TELEGRAM_READ_MODES[as] === 'read';
@@ -254,7 +316,11 @@ interface TelegramHelpers {
   uploadsDir: string;
 }
 
-export function registerTelegramRoutes(app: OpenAPIHono, sqlite: Database, helpers: TelegramHelpers) {
+export function registerTelegramRoutes(
+  app: OpenAPIHono,
+  sqlite: Database,
+  helpers: TelegramHelpers,
+) {
   const { hasSessionAuth, isTrustedRequest, uploadsDir } = helpers;
 
   // GET /api/telegram/status — polling status (owner only)
@@ -262,7 +328,7 @@ export function registerTelegramRoutes(app: OpenAPIHono, sqlite: Database, helpe
     if (!hasSessionAuth(c) && !isTrustedRequest(c)) return c.json({ error: 'Auth required' }, 403);
 
     return c.json({
-      bots: telegramBots.map(b => ({
+      bots: telegramBots.map((b) => ({
         beast: b.beast,
         polling: b.active,
         chat_id: b.chatId ? `${b.chatId.slice(0, 4)}****` : null,
@@ -276,21 +342,28 @@ export function registerTelegramRoutes(app: OpenAPIHono, sqlite: Database, helpe
 
   // T#712: GET /api/telegram/message/:id — fetch cached inbound TG message body
   app.get('/api/telegram/message/:id', (c) => {
-    if (!isTelegramAuthorized(c, hasSessionAuth, isTrustedRequest)) return c.json({ error: 'Telegram cache is private' }, 403);
+    if (!isTelegramAuthorized(c, hasSessionAuth, isTrustedRequest))
+      return c.json({ error: 'Telegram cache is private' }, 403);
     const idParam = c.req.param('id');
     const msgId = parseInt(idParam, 10);
     if (!Number.isFinite(msgId) || String(msgId) !== idParam) {
       return c.json({ error: 'id must be an integer' }, 400);
     }
-    const validChatIds = telegramBots.map(b => b.chatId).filter(Boolean);
+    const validChatIds = telegramBots.map((b) => b.chatId).filter(Boolean);
     if (validChatIds.length === 0) return c.json({ error: 'no telegram bots configured' }, 503);
     const placeholders = validChatIds.map(() => '?').join(',');
-    const row = sqlite.prepare(
-      `SELECT chat_id, id, from_id, text, caption, photo_file_id, date_unix, received_at, raw_json FROM telegram_messages WHERE chat_id IN (${placeholders}) AND id = ? LIMIT 1`
-    ).get(...validChatIds, msgId) as any;
+    const row = sqlite
+      .prepare(
+        `SELECT chat_id, id, from_id, text, caption, photo_file_id, date_unix, received_at, raw_json FROM telegram_messages WHERE chat_id IN (${placeholders}) AND id = ? LIMIT 1`,
+      )
+      .get(...validChatIds, msgId) as any;
     if (!row) return c.json({ error: 'message not found' }, 404);
     let raw: any = null;
-    try { raw = JSON.parse(row.raw_json); } catch { /* leave null on parse fail */ }
+    try {
+      raw = JSON.parse(row.raw_json);
+    } catch {
+      /* leave null on parse fail */
+    }
     return c.json({
       chat_id: row.chat_id,
       id: row.id,

--- a/src/tools/__tests__/learn.test.ts
+++ b/src/tools/__tests__/learn.test.ts
@@ -26,7 +26,9 @@ describe('normalizeProject', () => {
 
   it('should normalize local ghq paths', () => {
     expect(normalizeProject('/Users/nat/Code/github.com/owner/repo')).toBe('github.com/owner/repo');
-    expect(normalizeProject('~/Code/github.com/owner/repo/src/file.ts')).toBe('github.com/owner/repo');
+    expect(normalizeProject('~/Code/github.com/owner/repo/src/file.ts')).toBe(
+      'github.com/owner/repo',
+    );
   });
 
   it('should normalize short owner/repo format', () => {
@@ -34,7 +36,9 @@ describe('normalizeProject', () => {
   });
 
   it('should normalize to lowercase', () => {
-    expect(normalizeProject('github.com/Soul-Brews-Studio/Oracle-V2')).toBe('github.com/soul-brews-studio/oracle-v2');
+    expect(normalizeProject('github.com/Soul-Brews-Studio/Oracle-V2')).toBe(
+      'github.com/soul-brews-studio/oracle-v2',
+    );
     expect(normalizeProject('https://github.com/Owner/Repo')).toBe('github.com/owner/repo');
     expect(normalizeProject('Owner/Repo')).toBe('github.com/owner/repo');
   });
@@ -56,18 +60,21 @@ describe('extractProjectFromSource', () => {
   });
 
   it('should extract from "oracle_learn from github.com/owner/repo" format', () => {
-    expect(extractProjectFromSource('oracle_learn from github.com/owner/repo session 42'))
-      .toBe('github.com/owner/repo');
+    expect(extractProjectFromSource('oracle_learn from github.com/owner/repo session 42')).toBe(
+      'github.com/owner/repo',
+    );
   });
 
   it('should extract from "rrr: org/repo" format', () => {
-    expect(extractProjectFromSource('rrr: Soul-Brews-Studio/oracle-v2'))
-      .toBe('github.com/soul-brews-studio/oracle-v2');
+    expect(extractProjectFromSource('rrr: Soul-Brews-Studio/oracle-v2')).toBe(
+      'github.com/soul-brews-studio/oracle-v2',
+    );
   });
 
   it('should extract direct github.com reference', () => {
-    expect(extractProjectFromSource('some text github.com/foo/bar more text'))
-      .toBe('github.com/foo/bar');
+    expect(extractProjectFromSource('some text github.com/foo/bar more text')).toBe(
+      'github.com/foo/bar',
+    );
   });
 
   it('should return null when no project found', () => {

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -112,18 +112,50 @@ describe('parseConceptsFromMetadata', () => {
 
 describe('combineResults', () => {
   const ftsResults = [
-    { id: 'doc1', type: 'principle', content: 'Content 1', source_file: 'f1.md', concepts: ['trust'], score: 0.8, source: 'fts' as const },
-    { id: 'doc2', type: 'learning', content: 'Content 2', source_file: 'f2.md', concepts: ['pattern'], score: 0.6, source: 'fts' as const },
+    {
+      id: 'doc1',
+      type: 'principle',
+      content: 'Content 1',
+      source_file: 'f1.md',
+      concepts: ['trust'],
+      score: 0.8,
+      source: 'fts' as const,
+    },
+    {
+      id: 'doc2',
+      type: 'learning',
+      content: 'Content 2',
+      source_file: 'f2.md',
+      concepts: ['pattern'],
+      score: 0.6,
+      source: 'fts' as const,
+    },
   ];
 
   const vectorResults = [
-    { id: 'doc1', type: 'principle', content: 'Content 1', source_file: 'f1.md', concepts: ['trust'], score: 0.9, source: 'vector' as const },
-    { id: 'doc3', type: 'retro', content: 'Content 3', source_file: 'f3.md', concepts: ['decision'], score: 0.7, source: 'vector' as const },
+    {
+      id: 'doc1',
+      type: 'principle',
+      content: 'Content 1',
+      source_file: 'f1.md',
+      concepts: ['trust'],
+      score: 0.9,
+      source: 'vector' as const,
+    },
+    {
+      id: 'doc3',
+      type: 'retro',
+      content: 'Content 3',
+      source_file: 'f3.md',
+      concepts: ['decision'],
+      score: 0.7,
+      source: 'vector' as const,
+    },
   ];
 
   it('should mark duplicates as hybrid', () => {
     const combined = combineResults(ftsResults, vectorResults);
-    const doc1 = combined.find(r => r.id === 'doc1');
+    const doc1 = combined.find((r) => r.id === 'doc1');
     expect(doc1?.source).toBe('hybrid');
     expect(doc1?.ftsScore).toBe(0.8);
     expect(doc1?.vectorScore).toBe(0.9);
@@ -131,17 +163,17 @@ describe('combineResults', () => {
 
   it('should keep FTS-only as fts source', () => {
     const combined = combineResults(ftsResults, vectorResults);
-    expect(combined.find(r => r.id === 'doc2')?.source).toBe('fts');
+    expect(combined.find((r) => r.id === 'doc2')?.source).toBe('fts');
   });
 
   it('should keep vector-only as vector source', () => {
     const combined = combineResults(ftsResults, vectorResults);
-    expect(combined.find(r => r.id === 'doc3')?.source).toBe('vector');
+    expect(combined.find((r) => r.id === 'doc3')?.source).toBe('vector');
   });
 
   it('should apply 10% boost for hybrid results', () => {
     const combined = combineResults(ftsResults, vectorResults, 0.5, 0.5);
-    const doc1 = combined.find(r => r.id === 'doc1');
+    const doc1 = combined.find((r) => r.id === 'doc1');
     // ((0.5 * 0.8) + (0.5 * 0.9)) * 1.1 = 0.935
     expect(doc1?.score).toBeCloseTo(0.935, 2);
   });

--- a/src/tools/concepts.ts
+++ b/src/tools/concepts.ts
@@ -10,33 +10,49 @@ import type { ToolContext, ToolResponse, OracleConceptsInput } from './types.ts'
 
 export const conceptsToolDef = {
   name: 'oracle_concepts',
-  description: 'List all concept tags in the Oracle knowledge base with document counts. Useful for discovering what topics are covered and filtering searches.',
+  description:
+    'List all concept tags in the Oracle knowledge base with document counts. Useful for discovering what topics are covered and filtering searches.',
   inputSchema: {
     type: 'object',
     properties: {
       limit: {
         type: 'number',
         description: 'Maximum number of concepts to return (default: 50)',
-        default: 50
+        default: 50,
       },
       type: {
         type: 'string',
         enum: ['principle', 'pattern', 'learning', 'retro', 'all'],
         description: 'Filter concepts by document type',
-        default: 'all'
-      }
+        default: 'all',
+      },
     },
-    required: []
-  }
+    required: [],
+  },
 };
 
-export async function handleConcepts(ctx: ToolContext, input: OracleConceptsInput): Promise<ToolResponse> {
+export async function handleConcepts(
+  ctx: ToolContext,
+  input: OracleConceptsInput,
+): Promise<ToolResponse> {
   const { limit = 50, type = 'all' } = input;
 
-  const baseCondition = and(isNotNull(oracleDocuments.concepts), ne(oracleDocuments.concepts, '[]'));
-  const rows = type === 'all'
-    ? ctx.db.select({ concepts: oracleDocuments.concepts }).from(oracleDocuments).where(baseCondition).all()
-    : ctx.db.select({ concepts: oracleDocuments.concepts }).from(oracleDocuments).where(and(baseCondition, eq(oracleDocuments.type, type))).all();
+  const baseCondition = and(
+    isNotNull(oracleDocuments.concepts),
+    ne(oracleDocuments.concepts, '[]'),
+  );
+  const rows =
+    type === 'all'
+      ? ctx.db
+          .select({ concepts: oracleDocuments.concepts })
+          .from(oracleDocuments)
+          .where(baseCondition)
+          .all()
+      : ctx.db
+          .select({ concepts: oracleDocuments.concepts })
+          .from(oracleDocuments)
+          .where(and(baseCondition, eq(oracleDocuments.type, type)))
+          .all();
 
   const conceptCounts = new Map<string, number>();
   for (const row of rows as Array<{ concepts: string }>) {
@@ -51,7 +67,10 @@ export async function handleConcepts(ctx: ToolContext, input: OracleConceptsInpu
       }
     } catch {
       if (typeof row.concepts === 'string') {
-        const concepts = row.concepts.split(',').map(c => c.trim()).filter(Boolean);
+        const concepts = row.concepts
+          .split(',')
+          .map((c) => c.trim())
+          .filter(Boolean);
         for (const concept of concepts) {
           conceptCounts.set(concept, (conceptCounts.get(concept) || 0) + 1);
         }
@@ -65,13 +84,19 @@ export async function handleConcepts(ctx: ToolContext, input: OracleConceptsInpu
     .slice(0, limit);
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        concepts: sortedConcepts,
-        total_unique: conceptCounts.size,
-        filter_type: type,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            concepts: sortedConcepts,
+            total_unique: conceptCounts.size,
+            filter_type: type,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/src/tools/forum.ts
+++ b/src/tools/forum.ts
@@ -49,45 +49,70 @@ export interface OracleThreadUpdateInput {
 
 export const threadToolDef = {
   name: 'oracle_thread',
-  description: 'Send a message to an Oracle discussion thread. Creates a new thread or continues an existing one. Oracle auto-responds from knowledge base. Use for multi-turn consultations.',
+  description:
+    'Send a message to an Oracle discussion thread. Creates a new thread or continues an existing one. Oracle auto-responds from knowledge base. Use for multi-turn consultations.',
   inputSchema: {
     type: 'object',
     properties: {
       message: { type: 'string', description: 'Your question or message' },
-      threadId: { type: 'number', description: 'Thread ID to continue (omit to create new thread)' },
-      title: { type: 'string', description: 'Title for new thread (defaults to first 50 chars of message)' },
-      role: { type: 'string', enum: ['human', 'claude'], description: 'Who is sending (default: human)', default: 'human' },
-      model: { type: 'string', description: 'Model name for Claude calls (e.g., "opus", "sonnet")' },
+      threadId: {
+        type: 'number',
+        description: 'Thread ID to continue (omit to create new thread)',
+      },
+      title: {
+        type: 'string',
+        description: 'Title for new thread (defaults to first 50 chars of message)',
+      },
+      role: {
+        type: 'string',
+        enum: ['human', 'claude'],
+        description: 'Who is sending (default: human)',
+        default: 'human',
+      },
+      model: {
+        type: 'string',
+        description: 'Model name for Claude calls (e.g., "opus", "sonnet")',
+      },
     },
-    required: ['message']
-  }
+    required: ['message'],
+  },
 };
 
 export const threadsToolDef = {
   name: 'oracle_threads',
-  description: 'List Oracle discussion threads. Filter by status to find pending questions or active discussions.',
+  description:
+    'List Oracle discussion threads. Filter by status to find pending questions or active discussions.',
   inputSchema: {
     type: 'object',
     properties: {
-      status: { type: 'string', enum: ['active', 'answered', 'pending', 'closed'], description: 'Filter by thread status' },
-      limit: { type: 'number', description: 'Maximum threads to return (default: 20)', default: 20 },
+      status: {
+        type: 'string',
+        enum: ['active', 'answered', 'pending', 'closed'],
+        description: 'Filter by thread status',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum threads to return (default: 20)',
+        default: 20,
+      },
       offset: { type: 'number', description: 'Pagination offset', default: 0 },
     },
-    required: []
-  }
+    required: [],
+  },
 };
 
 export const threadReadToolDef = {
   name: 'oracle_thread_read',
-  description: 'Read full message history from a thread. Use to review context before continuing a conversation.',
+  description:
+    'Read full message history from a thread. Use to review context before continuing a conversation.',
   inputSchema: {
     type: 'object',
     properties: {
       threadId: { type: 'number', description: 'Thread ID to read' },
       limit: { type: 'number', description: 'Maximum messages to return (default: all)' },
     },
-    required: ['threadId']
-  }
+    required: ['threadId'],
+  },
 };
 
 export const threadUpdateToolDef = {
@@ -97,10 +122,14 @@ export const threadUpdateToolDef = {
     type: 'object',
     properties: {
       threadId: { type: 'number', description: 'Thread ID to update' },
-      status: { type: 'string', enum: ['active', 'closed', 'answered', 'pending'], description: 'New status for the thread' },
+      status: {
+        type: 'string',
+        enum: ['active', 'closed', 'answered', 'pending'],
+        description: 'New status for the thread',
+      },
     },
-    required: ['threadId', 'status']
-  }
+    required: ['threadId', 'status'],
+  },
 };
 
 /** All forum tool definitions for ListTools */
@@ -125,20 +154,28 @@ export async function handleThread(input: OracleThreadInput): Promise<ToolRespon
   });
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        thread_id: result.threadId,
-        message_id: result.messageId,
-        status: result.status,
-        oracle_response: result.oracleResponse ? {
-          content: result.oracleResponse.content,
-          principles_found: result.oracleResponse.principlesFound,
-          patterns_found: result.oracleResponse.patternsFound,
-        } : null,
-        issue_url: result.issueUrl,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            thread_id: result.threadId,
+            message_id: result.messageId,
+            status: result.status,
+            oracle_response: result.oracleResponse
+              ? {
+                  content: result.oracleResponse.content,
+                  principles_found: result.oracleResponse.principlesFound,
+                  patterns_found: result.oracleResponse.patternsFound,
+                }
+              : null,
+            issue_url: result.issueUrl,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }
 
@@ -149,7 +186,7 @@ export async function handleThreads(input: OracleThreadsInput): Promise<ToolResp
     offset: input.offset || 0,
   });
 
-  const threadsWithCounts = result.threads.map(thread => {
+  const threadsWithCounts = result.threads.map((thread) => {
     const { messages } = getMessages(thread.id);
     const lastMessage = messages[messages.length - 1];
     return {
@@ -164,10 +201,12 @@ export async function handleThreads(input: OracleThreadsInput): Promise<ToolResp
   });
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({ threads: threadsWithCounts, total: result.total }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ threads: threadsWithCounts, total: result.total }, null, 2),
+      },
+    ],
   };
 }
 
@@ -175,7 +214,7 @@ export async function handleThreadRead(input: OracleThreadReadInput): Promise<To
   const threadData = getFullThread(input.threadId);
   if (!threadData) throw new Error(`Thread ${input.threadId} not found`);
 
-  let messages = threadData.messages.map(m => ({
+  let messages = threadData.messages.map((m) => ({
     id: m.id,
     role: m.role,
     author: m.author,
@@ -188,16 +227,22 @@ export async function handleThreadRead(input: OracleThreadReadInput): Promise<To
   }
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        thread_id: threadData.thread.id,
-        title: threadData.thread.title,
-        status: threadData.thread.status,
-        message_count: threadData.messages.length,
-        messages,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            thread_id: threadData.thread.id,
+            title: threadData.thread.title,
+            status: threadData.thread.status,
+            message_count: threadData.messages.length,
+            messages,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }
 
@@ -208,14 +253,20 @@ export async function handleThreadUpdate(input: OracleThreadUpdateInput): Promis
   const threadData = getFullThread(input.threadId);
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        success: true,
-        thread_id: input.threadId,
-        status: input.status,
-        title: threadData?.thread.title,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            success: true,
+            thread_id: input.threadId,
+            status: input.status,
+            title: threadData?.thread.title,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -13,37 +13,44 @@ import type { ToolContext, ToolResponse, OracleHandoffInput } from './types.ts';
 
 export const handoffToolDef = {
   name: 'oracle_handoff',
-  description: 'Write session context to the Oracle inbox for future sessions to pick up. Creates a timestamped markdown file in ψ/inbox/handoff/. Use at end of sessions to preserve context.',
+  description:
+    'Write session context to the Oracle inbox for future sessions to pick up. Creates a timestamped markdown file in ψ/inbox/handoff/. Use at end of sessions to preserve context.',
   inputSchema: {
     type: 'object',
     properties: {
       content: {
         type: 'string',
-        description: 'The handoff content (markdown). Include context, progress, next steps.'
+        description: 'The handoff content (markdown). Include context, progress, next steps.',
       },
       slug: {
         type: 'string',
-        description: 'Optional slug for the filename. Auto-generated from content if not provided.'
-      }
+        description: 'Optional slug for the filename. Auto-generated from content if not provided.',
+      },
     },
-    required: ['content']
-  }
+    required: ['content'],
+  },
 };
 
-export async function handleHandoff(ctx: ToolContext, input: OracleHandoffInput): Promise<ToolResponse> {
+export async function handleHandoff(
+  ctx: ToolContext,
+  input: OracleHandoffInput,
+): Promise<ToolResponse> {
   const { content, slug: slugInput } = input;
   const now = new Date();
 
   const dateStr = now.toISOString().split('T')[0];
   const timeStr = `${String(now.getHours()).padStart(2, '0')}-${String(now.getMinutes()).padStart(2, '0')}`;
 
-  const slug = slugInput || content
-    .substring(0, 50)
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '') || 'handoff';
+  const slug =
+    slugInput ||
+    content
+      .substring(0, 50)
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') ||
+    'handoff';
 
   const filename = `${dateStr}_${timeStr}_${slug}.md`;
 
@@ -70,13 +77,19 @@ export async function handleHandoff(ctx: ToolContext, input: OracleHandoffInput)
   console.error(`[MCP:HANDOFF] Written: ${sourceFileRel}`);
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        success: true,
-        file: sourceFileRel,
-        message: `Handoff written${vaultRoot ? ' (vault)' : ''}. Next session can read it with oracle_inbox().`
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            success: true,
+            file: sourceFileRel,
+            message: `Handoff written${vaultRoot ? ' (vault)' : ''}. Next session can read it with oracle_inbox().`,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/src/tools/inbox.ts
+++ b/src/tools/inbox.ts
@@ -10,40 +10,51 @@ import type { ToolContext, ToolResponse, OracleInboxInput } from './types.ts';
 
 export const inboxToolDef = {
   name: 'oracle_inbox',
-  description: 'List and preview pending handoff files from the Oracle inbox. Returns files sorted newest-first with previews.',
+  description:
+    'List and preview pending handoff files from the Oracle inbox. Returns files sorted newest-first with previews.',
   inputSchema: {
     type: 'object',
     properties: {
       limit: {
         type: 'number',
         description: 'Maximum files to return (default: 10)',
-        default: 10
+        default: 10,
       },
       offset: {
         type: 'number',
         description: 'Number of files to skip (for pagination)',
-        default: 0
+        default: 0,
       },
       type: {
         type: 'string',
         enum: ['handoff', 'all'],
         description: 'Filter by inbox type (default: all)',
-        default: 'all'
-      }
-    }
-  }
+        default: 'all',
+      },
+    },
+  },
 };
 
-export async function handleInbox(ctx: ToolContext, input: OracleInboxInput): Promise<ToolResponse> {
+export async function handleInbox(
+  ctx: ToolContext,
+  input: OracleInboxInput,
+): Promise<ToolResponse> {
   const { limit = 10, offset = 0, type = 'all' } = input;
   const inboxDir = path.join(ctx.repoRoot, 'ψ/inbox');
-  const results: Array<{ filename: string; path: string; created: string; preview: string; type: string }> = [];
+  const results: Array<{
+    filename: string;
+    path: string;
+    created: string;
+    preview: string;
+    type: string;
+  }> = [];
 
   if (type === 'all' || type === 'handoff') {
     const handoffDir = path.join(inboxDir, 'handoff');
     if (fs.existsSync(handoffDir)) {
-      const files = fs.readdirSync(handoffDir)
-        .filter(f => f.endsWith('.md'))
+      const files = fs
+        .readdirSync(handoffDir)
+        .filter((f) => f.endsWith('.md'))
         .sort()
         .reverse();
 
@@ -72,9 +83,11 @@ export async function handleInbox(ctx: ToolContext, input: OracleInboxInput): Pr
   console.error(`[MCP:INBOX] ${total} files, returning ${paginated.length} (offset=${offset})`);
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({ files: paginated, total, limit, offset }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ files: paginated, total, limit, offset }, null, 2),
+      },
+    ],
   };
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -66,7 +66,12 @@ export { inboxToolDef, handleInbox } from './inbox.ts';
 export { verifyToolDef, handleVerify } from './verify.ts';
 
 // Schedule
-export { scheduleAddToolDef, handleScheduleAdd, scheduleListToolDef, handleScheduleList } from './schedule.ts';
+export {
+  scheduleAddToolDef,
+  handleScheduleAdd,
+  scheduleListToolDef,
+  handleScheduleList,
+} from './schedule.ts';
 
 // Read
 export { readToolDef, handleRead } from './read.ts';
@@ -96,4 +101,3 @@ export {
   handleTraceUnlink,
   handleTraceChain,
 } from './trace.ts';
-

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -15,36 +15,42 @@ import type { ToolContext, ToolResponse, OracleLearnInput } from './types.ts';
 /** Coerce concepts to string[] — handles string, array, or undefined from MCP input */
 export function coerceConcepts(concepts: unknown): string[] {
   if (Array.isArray(concepts)) return concepts.map(String);
-  if (typeof concepts === 'string') return concepts.split(',').map(s => s.trim()).filter(Boolean);
+  if (typeof concepts === 'string')
+    return concepts
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
   return [];
 }
 
 export const learnToolDef = {
   name: 'oracle_learn',
-  description: 'Add a new pattern or learning to the Oracle knowledge base. Creates a markdown file in ψ/memory/learnings/ and indexes it.',
+  description:
+    'Add a new pattern or learning to the Oracle knowledge base. Creates a markdown file in ψ/memory/learnings/ and indexes it.',
   inputSchema: {
     type: 'object',
     properties: {
       pattern: {
         type: 'string',
-        description: 'The pattern or learning to add (can be multi-line)'
+        description: 'The pattern or learning to add (can be multi-line)',
       },
       source: {
         type: 'string',
-        description: 'Optional source attribution (defaults to "Oracle Learn")'
+        description: 'Optional source attribution (defaults to "Oracle Learn")',
       },
       concepts: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Optional concept tags (e.g., ["git", "safety", "trust"])'
+        description: 'Optional concept tags (e.g., ["git", "safety", "trust"])',
       },
       project: {
         type: 'string',
-        description: 'Source project. Accepts: "github.com/owner/repo", "owner/repo", local path with ghq/Code prefix, or GitHub URL. Auto-normalized to "github.com/owner/repo" format.'
-      }
+        description:
+          'Source project. Accepts: "github.com/owner/repo", "owner/repo", local path with ghq/Code prefix, or GitHub URL. Auto-normalized to "github.com/owner/repo" format.',
+      },
     },
-    required: ['pattern']
-  }
+    required: ['pattern'],
+  },
 };
 
 // ============================================================================
@@ -101,7 +107,10 @@ export function extractProjectFromSource(source?: string): string | null {
 // Handler
 // ============================================================================
 
-export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Promise<ToolResponse> {
+export async function handleLearn(
+  ctx: ToolContext,
+  input: OracleLearnInput,
+): Promise<ToolResponse> {
   const { pattern, source, concepts, project: projectInput } = input;
   const now = new Date();
   const dateStr = now.toISOString().split('T')[0];
@@ -121,9 +130,10 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   if ('needsInit' in vault) console.error(`[Vault] ${vault.hint}`);
   const vaultRoot = 'path' in vault ? vault.path : null;
 
-  const project = normalizeProject(projectInput)
-    || extractProjectFromSource(source)
-    || detectProject(ctx.repoRoot);
+  const project =
+    normalizeProject(projectInput) ||
+    extractProjectFromSource(source) ||
+    detectProject(ctx.repoRoot);
   const projectDir = (project || '_universal').toLowerCase();
 
   let filePath: string;
@@ -161,40 +171,51 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     '',
     '---',
     '*Added via Oracle Learn*',
-    ''
+    '',
   ].join('\n');
 
   fs.writeFileSync(filePath, frontmatter, 'utf-8');
 
   const id = `learning_${dateStr}_${slug}`;
 
-  ctx.db.insert(oracleDocuments).values({
-    id,
-    type: 'learning',
-    sourceFile: sourceFileRel,
-    concepts: JSON.stringify(conceptsList),
-    createdAt: now.getTime(),
-    updatedAt: now.getTime(),
-    indexedAt: now.getTime(),
-    origin: null,
-    project,
-    createdBy: 'oracle_learn',
-  }).run();
+  ctx.db
+    .insert(oracleDocuments)
+    .values({
+      id,
+      type: 'learning',
+      sourceFile: sourceFileRel,
+      concepts: JSON.stringify(conceptsList),
+      createdAt: now.getTime(),
+      updatedAt: now.getTime(),
+      indexedAt: now.getTime(),
+      origin: null,
+      project,
+      createdBy: 'oracle_learn',
+    })
+    .run();
 
-  ctx.sqlite.prepare(`
+  ctx.sqlite
+    .prepare(`
     INSERT INTO oracle_fts (id, content, concepts)
     VALUES (?, ?, ?)
-  `).run(id, frontmatter, conceptsList.join(' '));
+  `)
+    .run(id, frontmatter, conceptsList.join(' '));
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        success: true,
-        file: sourceFileRel,
-        id,
-        message: `Pattern added to Oracle knowledge base${vaultRoot ? ' (vault)' : ''}`
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            success: true,
+            file: sourceFileRel,
+            id,
+            message: `Pattern added to Oracle knowledge base${vaultRoot ? ' (vault)' : ''}`,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -10,7 +10,8 @@ import type { ToolContext, ToolResponse, OracleListInput } from './types.ts';
 
 export const listToolDef = {
   name: 'oracle_list',
-  description: 'List all documents in Oracle knowledge base. Browse without searching - useful for exploring what knowledge exists. Supports pagination and type filtering.',
+  description:
+    'List all documents in Oracle knowledge base. Browse without searching - useful for exploring what knowledge exists. Supports pagination and type filtering.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -18,21 +19,21 @@ export const listToolDef = {
         type: 'string',
         enum: ['principle', 'pattern', 'learning', 'retro', 'all'],
         description: 'Filter by document type',
-        default: 'all'
+        default: 'all',
       },
       limit: {
         type: 'number',
         description: 'Maximum number of documents to return (1-100)',
-        default: 10
+        default: 10,
       },
       offset: {
         type: 'number',
         description: 'Number of documents to skip (for pagination)',
-        default: 0
-      }
+        default: 0,
+      },
     },
-    required: []
-  }
+    required: [],
+  },
 };
 
 export async function handleList(ctx: ToolContext, input: OracleListInput): Promise<ToolResponse> {
@@ -50,20 +51,26 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
     throw new Error(`Invalid type: ${type}. Must be one of: ${validTypes.join(', ')}`);
   }
 
-  const countResult = type === 'all'
-    ? ctx.db.select({ total: sql<number>`count(*)` }).from(oracleDocuments).get()
-    : ctx.db.select({ total: sql<number>`count(*)` }).from(oracleDocuments).where(eq(oracleDocuments.type, type)).get();
+  const countResult =
+    type === 'all'
+      ? ctx.db.select({ total: sql<number>`count(*)` }).from(oracleDocuments).get()
+      : ctx.db
+          .select({ total: sql<number>`count(*)` })
+          .from(oracleDocuments)
+          .where(eq(oracleDocuments.type, type))
+          .get();
   const total = countResult?.total ?? 0;
 
-  const listStmt = type === 'all'
-    ? ctx.sqlite.prepare(`
+  const listStmt =
+    type === 'all'
+      ? ctx.sqlite.prepare(`
         SELECT d.id, d.type, d.source_file, d.concepts, d.indexed_at, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
         ORDER BY d.indexed_at DESC
         LIMIT ? OFFSET ?
       `)
-    : ctx.sqlite.prepare(`
+      : ctx.sqlite.prepare(`
         SELECT d.id, d.type, d.source_file, d.concepts, d.indexed_at, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
@@ -72,9 +79,7 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
         LIMIT ? OFFSET ?
       `);
 
-  const rows = type === 'all'
-    ? listStmt.all(limit, offset)
-    : listStmt.all(type, limit, offset);
+  const rows = type === 'all' ? listStmt.all(limit, offset) : listStmt.all(type, limit, offset);
 
   const documents = (rows as any[]).map((row) => ({
     id: row.id,
@@ -87,9 +92,11 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
   }));
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({ documents, total, limit, offset, type }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ documents, total, limit, offset, type }, null, 2),
+      },
+    ],
   };
 }

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -12,13 +12,15 @@ import type { ToolContext, ToolResponse, OracleReadInput } from './types.ts';
 
 export const readToolDef = {
   name: 'oracle_read',
-  description: 'Read full content of an Oracle document by file path or document ID. Use after oracle_search to retrieve complete file contents. Resolves vault paths, ghq paths, and symlinks server-side.',
+  description:
+    'Read full content of an Oracle document by file path or document ID. Use after oracle_search to retrieve complete file contents. Resolves vault paths, ghq paths, and symlinks server-side.',
   inputSchema: {
     type: 'object',
     properties: {
       file: {
         type: 'string',
-        description: 'Source file path from search results (e.g., "ψ/memory/learnings/file.md" or "github.com/org/repo/ψ/...")',
+        description:
+          'Source file path from search results (e.g., "ψ/memory/learnings/file.md" or "github.com/org/repo/ψ/...")',
       },
       id: {
         type: 'string',
@@ -54,11 +56,7 @@ function extractProject(filePath: string): { project: string; remainder: string 
  * Try to resolve a source_file path to a readable absolute path.
  * Returns the absolute path if found, null otherwise.
  */
-function resolveFilePath(
-  sourceFile: string,
-  repoRoot: string,
-  ghqRoot: string,
-): string | null {
+function resolveFilePath(sourceFile: string, repoRoot: string, ghqRoot: string): string | null {
   // 1. Try direct from repoRoot (handles "ψ/memory/..." paths)
   const directPath = path.join(repoRoot, sourceFile);
   if (fs.existsSync(directPath)) return fs.realpathSync(directPath);
@@ -85,12 +83,16 @@ function isPathAllowed(resolvedPath: string, repoRoot: string, ghqRoot: string):
   try {
     const realGhq = fs.realpathSync(ghqRoot);
     if (resolvedPath.startsWith(realGhq)) return true;
-  } catch { /* ghq root may not exist */ }
+  } catch {
+    /* ghq root may not exist */
+  }
 
   try {
     const realRepo = fs.realpathSync(repoRoot);
     if (resolvedPath.startsWith(realRepo)) return true;
-  } catch { /* unlikely */ }
+  } catch {
+    /* unlikely */
+  }
 
   return false;
 }
@@ -110,9 +112,9 @@ export async function handleRead(ctx: ToolContext, input: OracleReadInput): Prom
 
   // ID lookup: resolve source_file from DB
   if (id) {
-    const row = ctx.sqlite.prepare(
-      'SELECT source_file, project FROM oracle_documents WHERE id = ?'
-    ).get(id) as { source_file: string; project: string | null } | null;
+    const row = ctx.sqlite
+      .prepare('SELECT source_file, project FROM oracle_documents WHERE id = ?')
+      .get(id) as { source_file: string; project: string | null } | null;
 
     if (!row) {
       return {
@@ -131,50 +133,56 @@ export async function handleRead(ctx: ToolContext, input: OracleReadInput): Prom
   if (resolvedPath && isPathAllowed(resolvedPath, ctx.repoRoot, ghqRoot)) {
     const content = fs.readFileSync(resolvedPath, 'utf-8');
     return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          content,
-          source_file: sourceFile,
-          resolved_path: resolvedPath,
-          source: 'file',
-          ...(project ? { project } : {}),
-        }),
-      }],
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            content,
+            source_file: sourceFile,
+            resolved_path: resolvedPath,
+            source: 'file',
+            ...(project ? { project } : {}),
+          }),
+        },
+      ],
     };
   }
 
   // Fallback: try FTS indexed content (if we have an id)
   if (id) {
-    const ftsRow = ctx.sqlite.prepare(
-      'SELECT content FROM oracle_fts WHERE id = ?'
-    ).get(id) as { content: string } | null;
+    const ftsRow = ctx.sqlite.prepare('SELECT content FROM oracle_fts WHERE id = ?').get(id) as {
+      content: string;
+    } | null;
 
     if (ftsRow) {
       return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            content: ftsRow.content,
-            source_file: sourceFile,
-            resolved_path: null,
-            source: 'fts_cache',
-            ...(project ? { project } : {}),
-          }),
-        }],
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              content: ftsRow.content,
+              source_file: sourceFile,
+              resolved_path: null,
+              source: 'fts_cache',
+              ...(project ? { project } : {}),
+            }),
+          },
+        ],
       };
     }
   }
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        error: `File not found: ${sourceFile}`,
-        source_file: sourceFile,
-        ...(project ? { project } : {}),
-      }),
-    }],
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          error: `File not found: ${sourceFile}`,
+          source_file: sourceFile,
+          ...(project ? { project } : {}),
+        }),
+      },
+    ],
     isError: true,
   };
 }

--- a/src/tools/reflect.ts
+++ b/src/tools/reflect.ts
@@ -10,20 +10,25 @@ import type { ToolContext, ToolResponse, OracleReflectInput } from './types.ts';
 
 export const reflectToolDef = {
   name: 'oracle_reflect',
-  description: 'Get a random principle or learning for reflection. Use this for periodic wisdom or to align with Oracle philosophy.',
+  description:
+    'Get a random principle or learning for reflection. Use this for periodic wisdom or to align with Oracle philosophy.',
   inputSchema: {
     type: 'object',
-    properties: {}
-  }
+    properties: {},
+  },
 };
 
-export async function handleReflect(ctx: ToolContext, _input: OracleReflectInput): Promise<ToolResponse> {
-  const randomDoc = ctx.db.select({
-    id: oracleDocuments.id,
-    type: oracleDocuments.type,
-    sourceFile: oracleDocuments.sourceFile,
-    concepts: oracleDocuments.concepts,
-  })
+export async function handleReflect(
+  ctx: ToolContext,
+  _input: OracleReflectInput,
+): Promise<ToolResponse> {
+  const randomDoc = ctx.db
+    .select({
+      id: oracleDocuments.id,
+      type: oracleDocuments.type,
+      sourceFile: oracleDocuments.sourceFile,
+      concepts: oracleDocuments.concepts,
+    })
     .from(oracleDocuments)
     .where(inArray(oracleDocuments.type, ['principle', 'learning']))
     .orderBy(sql`RANDOM()`)
@@ -34,26 +39,34 @@ export async function handleReflect(ctx: ToolContext, _input: OracleReflectInput
     throw new Error('No documents found in Oracle knowledge base');
   }
 
-  const content = ctx.sqlite.prepare(`
+  const content = ctx.sqlite
+    .prepare(`
     SELECT content FROM oracle_fts WHERE id = ?
-  `).get(randomDoc.id) as { content: string } | undefined;
+  `)
+    .get(randomDoc.id) as { content: string } | undefined;
 
   if (!content) {
     throw new Error('Document content not found in FTS index');
   }
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        principle: {
-          id: randomDoc.id,
-          type: randomDoc.type,
-          content: content.content,
-          source_file: randomDoc.sourceFile,
-          concepts: JSON.parse(randomDoc.concepts || '[]')
-        }
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            principle: {
+              id: randomDoc.id,
+              type: randomDoc.type,
+              content: content.content,
+              source_file: randomDoc.sourceFile,
+              concepts: JSON.parse(randomDoc.concepts || '[]'),
+            },
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/src/tools/schedule.ts
+++ b/src/tools/schedule.ts
@@ -16,7 +16,12 @@ import os from 'os';
 import path from 'path';
 import { eq, and, gte, lte, like, asc, or } from 'drizzle-orm';
 import { schedule } from '../db/schema.ts';
-import type { ToolContext, ToolResponse, OracleScheduleAddInput, OracleScheduleListInput } from './types.ts';
+import type {
+  ToolContext,
+  ToolResponse,
+  OracleScheduleAddInput,
+  OracleScheduleListInput,
+} from './types.ts';
 
 const SCHEDULE_REL = 'ψ/inbox/schedule.md';
 
@@ -25,23 +30,66 @@ function getSchedulePath(): string {
 }
 
 const MONTHS: Record<string, number> = {
-  jan: 1, january: 1, feb: 2, february: 2, mar: 3, march: 3,
-  apr: 4, april: 4, may: 5, jun: 6, june: 6,
-  jul: 7, july: 7, aug: 8, august: 8, sep: 9, september: 9,
-  oct: 10, october: 10, nov: 11, november: 11, dec: 12, december: 12,
+  jan: 1,
+  january: 1,
+  feb: 2,
+  february: 2,
+  mar: 3,
+  march: 3,
+  apr: 4,
+  april: 4,
+  may: 5,
+  jun: 6,
+  june: 6,
+  jul: 7,
+  july: 7,
+  aug: 8,
+  august: 8,
+  sep: 9,
+  september: 9,
+  oct: 10,
+  october: 10,
+  nov: 11,
+  november: 11,
+  dec: 12,
+  december: 12,
   // Thai abbreviated months (formal: ม.ค., common: มค.)
-  'ม.ค.': 1, 'มค.': 1, 'มค': 1,
-  'ก.พ.': 2, 'กพ.': 2, 'กพ': 2,
-  'มี.ค.': 3, 'มีค.': 3, 'มีค': 3,
-  'เม.ย.': 4, 'เมย.': 4, 'เมย': 4,
-  'พ.ค.': 5, 'พค.': 5, 'พค': 5,
-  'มิ.ย.': 6, 'มิย.': 6, 'มิย': 6,
-  'ก.ค.': 7, 'กค.': 7, 'กค': 7,
-  'ส.ค.': 8, 'สค.': 8, 'สค': 8,
-  'ก.ย.': 9, 'กย.': 9, 'กย': 9,
-  'ต.ค.': 10, 'ตค.': 10, 'ตค': 10,
-  'พ.ย.': 11, 'พย.': 11, 'พย': 11,
-  'ธ.ค.': 12, 'ธค.': 12, 'ธค': 12,
+  'ม.ค.': 1,
+  'มค.': 1,
+  มค: 1,
+  'ก.พ.': 2,
+  'กพ.': 2,
+  กพ: 2,
+  'มี.ค.': 3,
+  'มีค.': 3,
+  มีค: 3,
+  'เม.ย.': 4,
+  'เมย.': 4,
+  เมย: 4,
+  'พ.ค.': 5,
+  'พค.': 5,
+  พค: 5,
+  'มิ.ย.': 6,
+  'มิย.': 6,
+  มิย: 6,
+  'ก.ค.': 7,
+  'กค.': 7,
+  กค: 7,
+  'ส.ค.': 8,
+  'สค.': 8,
+  สค: 8,
+  'ก.ย.': 9,
+  'กย.': 9,
+  กย: 9,
+  'ต.ค.': 10,
+  'ตค.': 10,
+  ตค: 10,
+  'พ.ย.': 11,
+  'พย.': 11,
+  พย: 11,
+  'ธ.ค.': 12,
+  'ธค.': 12,
+  ธค: 12,
 };
 
 /**
@@ -65,8 +113,9 @@ export function parseDate(input: string): string {
   }
 
   // "5 Mar", "5 March", "5 Mar 2026", "Mar 5", "March 5 2026"
-  const monthNameMatch = trimmed.match(/^(\d{1,2})\s+([A-Za-zก-๙.]+)(?:\s+(\d{4}))?$/i)
-    || trimmed.match(/^([A-Za-zก-๙.]+)\s+(\d{1,2})(?:[,\s]+(\d{4}))?$/i);
+  const monthNameMatch =
+    trimmed.match(/^(\d{1,2})\s+([A-Za-zก-๙.]+)(?:\s+(\d{4}))?$/i) ||
+    trimmed.match(/^([A-Za-zก-๙.]+)\s+(\d{1,2})(?:[,\s]+(\d{4}))?$/i);
   if (monthNameMatch) {
     let day: number, monthStr: string, yearStr: string | undefined;
     if (/^\d/.test(monthNameMatch[1])) {
@@ -91,7 +140,9 @@ export function parseDate(input: string): string {
     const day = parseInt(slashMatch[1]);
     const month = parseInt(slashMatch[2]);
     const year = slashMatch[3]
-      ? (slashMatch[3].length === 2 ? 2000 + parseInt(slashMatch[3]) : parseInt(slashMatch[3]))
+      ? slashMatch[3].length === 2
+        ? 2000 + parseInt(slashMatch[3])
+        : parseInt(slashMatch[3])
       : thisYear;
     if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
       return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
@@ -117,113 +168,131 @@ function fmtLocal(d: Date): string {
 
 export const scheduleAddToolDef = {
   name: 'oracle_schedule_add',
-  description: 'Add an appointment or event to the shared schedule. The schedule is per-human (not per-project) and shared across all Oracles.',
+  description:
+    'Add an appointment or event to the shared schedule. The schedule is per-human (not per-project) and shared across all Oracles.',
   inputSchema: {
     type: 'object',
     properties: {
       date: {
         type: 'string',
-        description: 'Date of the event (e.g. "5 Mar", "2026-03-05", "tomorrow", "28 ก.พ.")'
+        description: 'Date of the event (e.g. "5 Mar", "2026-03-05", "tomorrow", "28 ก.พ.")',
       },
       event: {
         type: 'string',
-        description: 'Event description (e.g. "นัดอ.เศรษฐ์", "Team standup")'
+        description: 'Event description (e.g. "นัดอ.เศรษฐ์", "Team standup")',
       },
       time: {
         type: 'string',
-        description: 'Optional time (e.g. "14:00", "TBD")'
+        description: 'Optional time (e.g. "14:00", "TBD")',
       },
       notes: {
         type: 'string',
-        description: 'Optional notes about the event'
+        description: 'Optional notes about the event',
       },
       recurring: {
         type: 'string',
         description: 'Optional recurrence: "daily", "weekly", "monthly"',
-        enum: ['daily', 'weekly', 'monthly']
-      }
+        enum: ['daily', 'weekly', 'monthly'],
+      },
     },
-    required: ['date', 'event']
-  }
+    required: ['date', 'event'],
+  },
 };
 
 export const scheduleListToolDef = {
   name: 'oracle_schedule_list',
-  description: 'List appointments from the shared schedule. Filter by date, range, or keyword. Defaults to today + 14 days.',
+  description:
+    'List appointments from the shared schedule. Filter by date, range, or keyword. Defaults to today + 14 days.',
   inputSchema: {
     type: 'object',
     properties: {
       date: {
         type: 'string',
-        description: 'Specific date to query (e.g. "2026-03-05", "today", "tomorrow")'
+        description: 'Specific date to query (e.g. "2026-03-05", "today", "tomorrow")',
       },
       from: {
         type: 'string',
-        description: 'Range start date (inclusive). Defaults to today.'
+        description: 'Range start date (inclusive). Defaults to today.',
       },
       to: {
         type: 'string',
-        description: 'Range end date (inclusive). Defaults to 14 days from now.'
+        description: 'Range end date (inclusive). Defaults to 14 days from now.',
       },
       filter: {
         type: 'string',
-        description: 'Keyword to filter events (e.g. "standup", "เศรษฐ์")'
+        description: 'Keyword to filter events (e.g. "standup", "เศรษฐ์")',
       },
       status: {
         type: 'string',
         description: 'Filter by status',
-        enum: ['pending', 'done', 'cancelled', 'all']
+        enum: ['pending', 'done', 'cancelled', 'all'],
       },
       limit: {
         type: 'number',
-        description: 'Max results (default 50)'
-      }
-    }
-  }
+        description: 'Max results (default 50)',
+      },
+    },
+  },
 };
 
 // ============================================================================
 // Handlers
 // ============================================================================
 
-export async function handleScheduleAdd(ctx: ToolContext, input: OracleScheduleAddInput): Promise<ToolResponse> {
+export async function handleScheduleAdd(
+  ctx: ToolContext,
+  input: OracleScheduleAddInput,
+): Promise<ToolResponse> {
   const { event, time, notes } = input;
   const dateCanonical = parseDate(input.date);
   const now = Date.now();
 
-  const result = ctx.db.insert(schedule).values({
-    date: dateCanonical,
-    dateRaw: input.date,
-    time: time || null,
-    event,
-    notes: notes || null,
-    recurring: input.recurring || null,
-    status: 'pending',
-    createdAt: now,
-    updatedAt: now,
-  }).returning({ id: schedule.id }).get();
+  const result = ctx.db
+    .insert(schedule)
+    .values({
+      date: dateCanonical,
+      dateRaw: input.date,
+      time: time || null,
+      event,
+      notes: notes || null,
+      recurring: input.recurring || null,
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: schedule.id })
+    .get();
 
   // Auto-export to schedule.md
   exportScheduleToMarkdown(ctx);
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        success: true,
-        id: result.id,
-        date: dateCanonical,
-        dateRaw: input.date,
-        event,
-        time: time || 'TBD',
-        notes: notes || '',
-        message: 'Event added to schedule'
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            success: true,
+            id: result.id,
+            date: dateCanonical,
+            dateRaw: input.date,
+            event,
+            time: time || 'TBD',
+            notes: notes || '',
+            message: 'Event added to schedule',
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }
 
-export async function handleScheduleList(ctx: ToolContext, input: OracleScheduleListInput): Promise<ToolResponse> {
+export async function handleScheduleList(
+  ctx: ToolContext,
+  input: OracleScheduleListInput,
+): Promise<ToolResponse> {
   const limit = input.limit || 50;
   const statusFilter = input.status || 'pending';
 
@@ -241,25 +310,27 @@ export async function handleScheduleList(ctx: ToolContext, input: OracleSchedule
   } else {
     // Range query
     const from = input.from ? parseDate(input.from) : fmt(new Date());
-    const to = input.to ? parseDate(input.to) : (() => {
-      const d = new Date();
-      d.setDate(d.getDate() + 14);
-      return fmt(d);
-    })();
+    const to = input.to
+      ? parseDate(input.to)
+      : (() => {
+          const d = new Date();
+          d.setDate(d.getDate() + 14);
+          return fmt(d);
+        })();
     conditions.push(gte(schedule.date, from));
     conditions.push(lte(schedule.date, to));
   }
 
   if (input.filter) {
-    conditions.push(or(
-      like(schedule.event, `%${input.filter}%`),
-      like(schedule.notes, `%${input.filter}%`)
-    )!);
+    conditions.push(
+      or(like(schedule.event, `%${input.filter}%`), like(schedule.notes, `%${input.filter}%`))!,
+    );
   }
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
 
-  const events = ctx.db.select()
+  const events = ctx.db
+    .select()
     .from(schedule)
     .where(where)
     .orderBy(asc(schedule.date), asc(schedule.time))
@@ -274,23 +345,29 @@ export async function handleScheduleList(ctx: ToolContext, input: OracleSchedule
   }
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        total: events.length,
-        events: events.map(e => ({
-          id: e.id,
-          date: e.date,
-          dateRaw: e.dateRaw,
-          time: e.time || 'TBD',
-          event: e.event,
-          notes: e.notes,
-          recurring: e.recurring,
-          status: e.status,
-        })),
-        byDate,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            total: events.length,
+            events: events.map((e) => ({
+              id: e.id,
+              date: e.date,
+              dateRaw: e.dateRaw,
+              time: e.time || 'TBD',
+              event: e.event,
+              notes: e.notes,
+              recurring: e.recurring,
+              status: e.status,
+            })),
+            byDate,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }
 
@@ -299,7 +376,8 @@ export async function handleScheduleList(ctx: ToolContext, input: OracleSchedule
 // ============================================================================
 
 function exportScheduleToMarkdown(ctx: ToolContext): void {
-  const events = ctx.db.select()
+  const events = ctx.db
+    .select()
     .from(schedule)
     .where(eq(schedule.status, 'pending'))
     .orderBy(asc(schedule.date), asc(schedule.time))
@@ -329,7 +407,7 @@ function exportScheduleToMarkdown(ctx: ToolContext): void {
   }
 
   // Recurring section
-  const recurring = events.filter(e => e.recurring);
+  const recurring = events.filter((e) => e.recurring);
   if (recurring.length > 0) {
     md += `\n## Recurring\n\n`;
     md += `| Day | Time | Event |\n`;

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -13,52 +13,56 @@ import type { ToolContext, ToolResponse, OracleSearchInput } from './types.ts';
 
 export const searchToolDef = {
   name: 'oracle_search',
-  description: 'Search Oracle knowledge base using hybrid search (FTS5 keywords + ChromaDB vectors). Finds relevant principles, patterns, learnings, or retrospectives. Falls back to FTS5-only if ChromaDB unavailable.',
+  description:
+    'Search Oracle knowledge base using hybrid search (FTS5 keywords + ChromaDB vectors). Finds relevant principles, patterns, learnings, or retrospectives. Falls back to FTS5-only if ChromaDB unavailable.',
   inputSchema: {
     type: 'object',
     properties: {
       query: {
         type: 'string',
-        description: 'Search query (e.g., "nothing deleted", "force push safety")'
+        description: 'Search query (e.g., "nothing deleted", "force push safety")',
       },
       type: {
         type: 'string',
         enum: ['principle', 'pattern', 'learning', 'retro', 'all'],
         description: 'Filter by document type',
-        default: 'all'
+        default: 'all',
       },
       limit: {
         type: 'number',
         description: 'Maximum number of results',
-        default: 5
+        default: 5,
       },
       offset: {
         type: 'number',
         description: 'Number of results to skip (for pagination)',
-        default: 0
+        default: 0,
       },
       mode: {
         type: 'string',
         enum: ['hybrid', 'fts', 'vector'],
         description: 'Search mode: hybrid (default), fts (keywords only), vector (semantic only)',
-        default: 'hybrid'
+        default: 'hybrid',
       },
       project: {
         type: 'string',
-        description: 'Filter by project (e.g., "github.com/owner/repo"). Returns project + universal results.'
+        description:
+          'Filter by project (e.g., "github.com/owner/repo"). Returns project + universal results.',
       },
       cwd: {
         type: 'string',
-        description: 'Auto-detect project from working directory path (follows symlinks to ghq paths)'
+        description:
+          'Auto-detect project from working directory path (follows symlinks to ghq paths)',
       },
       model: {
         type: 'string',
         enum: ['nomic', 'qwen3', 'bge-m3'],
-        description: 'Embedding model: bge-m3 (default, multilingual Thai↔EN, 1024-dim), nomic (fast, 768-dim), or qwen3 (cross-language, 4096-dim)',
-      }
+        description:
+          'Embedding model: bge-m3 (default, multilingual Thai↔EN, 1024-dim), nomic (fast, 768-dim), or qwen3 (cross-language, 4096-dim)',
+      },
     },
-    required: ['query']
-  }
+    required: ['query'],
+  },
 };
 
 // ============================================================================
@@ -119,22 +123,26 @@ export async function vectorSearch(
   query: string,
   type: string,
   limit: number,
-  model?: string
-): Promise<Array<{
-  id: string;
-  type: string;
-  content: string;
-  source_file: string;
-  concepts: string[];
-  score: number;
-  distance: number;
-  model: string;
-  source: 'vector';
-}>> {
+  model?: string,
+): Promise<
+  Array<{
+    id: string;
+    type: string;
+    content: string;
+    source_file: string;
+    concepts: string[];
+    score: number;
+    distance: number;
+    model: string;
+    source: 'vector';
+  }>
+> {
   try {
     const whereFilter = type !== 'all' ? { type } : undefined;
     const store = model ? await ensureVectorStoreConnected(model) : ctx.vectorStore;
-    console.error(`[VectorSearch] Query: "${query.substring(0, 50)}..." limit=${limit} model=${model || 'default'}`);
+    console.error(
+      `[VectorSearch] Query: "${query.substring(0, 50)}..." limit=${limit} model=${model || 'default'}`,
+    );
 
     const results = await store.query(query, limit, whereFilter);
     console.error(`[VectorSearch] Results: ${results.ids?.length || 0} documents`);
@@ -207,7 +215,7 @@ export function combineResults(
     source: 'vector';
   }>,
   ftsWeight: number = 0.5,
-  vectorWeight: number = 0.5
+  vectorWeight: number = 0.5,
 ): Array<{
   id: string;
   type: string;
@@ -221,18 +229,21 @@ export function combineResults(
   distance?: number;
   model?: string;
 }> {
-  const resultMap = new Map<string, {
-    id: string;
-    type: string;
-    content: string;
-    source_file: string;
-    concepts: string[];
-    ftsScore?: number;
-    vectorScore?: number;
-    distance?: number;
-    model?: string;
-    source: 'fts' | 'vector' | 'hybrid';
-  }>();
+  const resultMap = new Map<
+    string,
+    {
+      id: string;
+      type: string;
+      content: string;
+      source_file: string;
+      concepts: string[];
+      ftsScore?: number;
+      vectorScore?: number;
+      distance?: number;
+      model?: string;
+      source: 'fts' | 'vector' | 'hybrid';
+    }
+  >();
 
   // Add FTS results
   for (const result of ftsResults) {
@@ -277,7 +288,7 @@ export function combineResults(
     if (result.source === 'hybrid') {
       const fts = result.ftsScore ?? 0;
       const vec = result.vectorScore ?? 0;
-      score = ((ftsWeight * fts) + (vectorWeight * vec)) * 1.1;
+      score = (ftsWeight * fts + vectorWeight * vec) * 1.1;
     } else if (result.source === 'fts') {
       score = (result.ftsScore ?? 0) * ftsWeight;
     } else {
@@ -307,9 +318,21 @@ export function combineResults(
 // Handler
 // ============================================================================
 
-export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): Promise<ToolResponse> {
+export async function handleSearch(
+  ctx: ToolContext,
+  input: OracleSearchInput,
+): Promise<ToolResponse> {
   const startTime = Date.now();
-  const { query, type = 'all', limit = 5, offset = 0, mode = 'hybrid', project, cwd, model } = input;
+  const {
+    query,
+    type = 'all',
+    limit = 5,
+    offset = 0,
+    mode = 'hybrid',
+    project,
+    cwd,
+    model,
+  } = input;
 
   if (!query || query.trim().length === 0) {
     throw new Error('Query cannot be empty');
@@ -322,9 +345,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
 
   // Project filter: if project specified, include project + universal (NULL)
   // If no project, return ALL documents (no filter)
-  const projectFilter = resolvedProject
-    ? 'AND (d.project = ? OR d.project IS NULL)'
-    : '';
+  const projectFilter = resolvedProject ? 'AND (d.project = ? OR d.project IS NULL)' : '';
   const projectParams = resolvedProject ? [resolvedProject] : [];
 
   let warning: string | undefined;
@@ -424,7 +445,9 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     metadata.warning = warning;
   }
 
-  console.error(`[MCP:SEARCH] "${query}" (${type}, ${mode}, model=${model || 'default'}) → ${results.length} results in ${searchTime}ms`);
+  console.error(
+    `[MCP:SEARCH] "${query}" (${type}, ${mode}, model=${model || 'default'}) → ${results.length} results in ${searchTime}ms`,
+  );
 
   try {
     logSearch(query, type, mode, results.length, searchTime, results);
@@ -433,9 +456,11 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   }
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({ results, total: results.length, query, metadata }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ results, total: results.length, query, metadata }, null, 2),
+      },
+    ],
   };
 }

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -10,19 +10,24 @@ import type { ToolContext, ToolResponse, OracleStatsInput } from './types.ts';
 
 export const statsToolDef = {
   name: 'oracle_stats',
-  description: 'Get Oracle knowledge base statistics and health status. Returns document counts by type, indexing status, and ChromaDB connection status.',
+  description:
+    'Get Oracle knowledge base statistics and health status. Returns document counts by type, indexing status, and ChromaDB connection status.',
   inputSchema: {
     type: 'object',
     properties: {},
-    required: []
-  }
+    required: [],
+  },
 };
 
-export async function handleStats(ctx: ToolContext, _input: OracleStatsInput): Promise<ToolResponse> {
-  const typeCounts = ctx.db.select({
-    type: oracleDocuments.type,
-    count: sql<number>`count(*)`,
-  })
+export async function handleStats(
+  ctx: ToolContext,
+  _input: OracleStatsInput,
+): Promise<ToolResponse> {
+  const typeCounts = ctx.db
+    .select({
+      type: oracleDocuments.type,
+      count: sql<number>`count(*)`,
+    })
     .from(oracleDocuments)
     .groupBy(oracleDocuments.type)
     .all();
@@ -34,15 +39,21 @@ export async function handleStats(ctx: ToolContext, _input: OracleStatsInput): P
     totalDocs += row.count;
   }
 
-  const ftsCount = ctx.sqlite.prepare('SELECT COUNT(*) as count FROM oracle_fts').get() as { count: number };
+  const ftsCount = ctx.sqlite.prepare('SELECT COUNT(*) as count FROM oracle_fts').get() as {
+    count: number;
+  };
 
-  const lastIndexed = ctx.db.select({
-    lastIndexed: sql<number | null>`MAX(indexed_at)`,
-  }).from(oracleDocuments).get();
+  const lastIndexed = ctx.db
+    .select({
+      lastIndexed: sql<number | null>`MAX(indexed_at)`,
+    })
+    .from(oracleDocuments)
+    .get();
 
-  const conceptsResult = ctx.db.select({
-    concepts: oracleDocuments.concepts,
-  })
+  const conceptsResult = ctx.db
+    .select({
+      concepts: oracleDocuments.concepts,
+    })
     .from(oracleDocuments)
     .where(and(isNotNull(oracleDocuments.concepts), ne(oracleDocuments.concepts, '[]')))
     .all();
@@ -60,20 +71,26 @@ export async function handleStats(ctx: ToolContext, _input: OracleStatsInput): P
   }
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        total_documents: totalDocs,
-        by_type: byType,
-        fts_indexed: ftsCount.count,
-        unique_concepts: uniqueConcepts.size,
-        last_indexed: lastIndexed?.lastIndexed
-          ? new Date(lastIndexed.lastIndexed).toISOString()
-          : null,
-        vector_status: ctx.vectorStatus,
-        fts_status: ftsCount.count > 0 ? 'healthy' : 'empty',
-        version: ctx.version,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            total_documents: totalDocs,
+            by_type: byType,
+            fts_indexed: ftsCount.count,
+            unique_concepts: uniqueConcepts.size,
+            last_indexed: lastIndexed?.lastIndexed
+              ? new Date(lastIndexed.lastIndexed).toISOString()
+              : null,
+            vector_status: ctx.vectorStatus,
+            fts_status: ftsCount.count > 0 ? 'healthy' : 'empty',
+            version: ctx.version,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/src/tools/supersede.ts
+++ b/src/tools/supersede.ts
@@ -11,36 +11,42 @@ import type { ToolContext, ToolResponse, OracleSupersededInput } from './types.t
 
 export const supersedeToolDef = {
   name: 'oracle_supersede',
-  description: 'Mark an old learning/document as superseded by a newer one. Aligns with "Nothing is Deleted" - old doc preserved but marked outdated.',
+  description:
+    'Mark an old learning/document as superseded by a newer one. Aligns with "Nothing is Deleted" - old doc preserved but marked outdated.',
   inputSchema: {
     type: 'object',
     properties: {
       oldId: {
         type: 'string',
-        description: 'ID of the document being superseded (the outdated one)'
+        description: 'ID of the document being superseded (the outdated one)',
       },
       newId: {
         type: 'string',
-        description: 'ID of the document that supersedes it (the current one)'
+        description: 'ID of the document that supersedes it (the current one)',
       },
       reason: {
         type: 'string',
-        description: 'Why the old document is outdated (optional)'
-      }
+        description: 'Why the old document is outdated (optional)',
+      },
     },
-    required: ['oldId', 'newId']
-  }
+    required: ['oldId', 'newId'],
+  },
 };
 
-export async function handleSupersede(ctx: ToolContext, input: OracleSupersededInput): Promise<ToolResponse> {
+export async function handleSupersede(
+  ctx: ToolContext,
+  input: OracleSupersededInput,
+): Promise<ToolResponse> {
   const { oldId, newId, reason } = input;
   const now = Date.now();
 
-  const oldDoc = ctx.db.select({ id: oracleDocuments.id, type: oracleDocuments.type })
+  const oldDoc = ctx.db
+    .select({ id: oracleDocuments.id, type: oracleDocuments.type })
     .from(oracleDocuments)
     .where(eq(oracleDocuments.id, oldId))
     .get();
-  const newDoc = ctx.db.select({ id: oracleDocuments.id, type: oracleDocuments.type })
+  const newDoc = ctx.db
+    .select({ id: oracleDocuments.id, type: oracleDocuments.type })
     .from(oracleDocuments)
     .where(eq(oracleDocuments.id, newId))
     .get();
@@ -48,7 +54,8 @@ export async function handleSupersede(ctx: ToolContext, input: OracleSupersededI
   if (!oldDoc) throw new Error(`Old document not found: ${oldId}`);
   if (!newDoc) throw new Error(`New document not found: ${newId}`);
 
-  ctx.db.update(oracleDocuments)
+  ctx.db
+    .update(oracleDocuments)
     .set({
       supersededBy: newId,
       supersededAt: now,
@@ -60,18 +67,24 @@ export async function handleSupersede(ctx: ToolContext, input: OracleSupersededI
   console.error(`[MCP:SUPERSEDE] ${oldId} → superseded by → ${newId}`);
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        success: true,
-        old_id: oldId,
-        old_type: oldDoc.type,
-        new_id: newId,
-        new_type: newDoc.type,
-        reason: reason || null,
-        superseded_at: new Date(now).toISOString(),
-        message: `"${oldId}" is now marked as superseded by "${newId}". It will still appear in searches with a warning.`
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            success: true,
+            old_id: oldId,
+            old_type: oldDoc.type,
+            new_id: newId,
+            new_type: newDoc.type,
+            reason: reason || null,
+            superseded_at: new Date(now).toISOString(),
+            message: `"${oldId}" is now marked as superseded by "${newId}". It will still appear in searches with a warning.`,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/src/tools/trace.ts
+++ b/src/tools/trace.ts
@@ -15,11 +15,7 @@ import {
   getTraceLinkedChain,
 } from '../trace/handler.ts';
 
-import type {
-  CreateTraceInput,
-  ListTracesInput,
-  GetTraceInput,
-} from '../trace/types.ts';
+import type { CreateTraceInput, ListTracesInput, GetTraceInput } from '../trace/types.ts';
 
 import type { ToolResponse } from './types.ts';
 
@@ -29,25 +25,83 @@ import type { ToolResponse } from './types.ts';
 
 export const traceToolDef = {
   name: 'oracle_trace',
-  description: 'Log a trace session with dig points (files, commits, issues found). Use to capture /trace command results for future exploration.',
+  description:
+    'Log a trace session with dig points (files, commits, issues found). Use to capture /trace command results for future exploration.',
   inputSchema: {
     type: 'object',
     properties: {
       query: { type: 'string', description: 'What was traced (required)' },
-      queryType: { type: 'string', enum: ['general', 'project', 'pattern', 'evolution'], description: 'Type of trace query', default: 'general' },
-      foundFiles: { type: 'array', items: { type: 'object', properties: { path: { type: 'string' }, type: { type: 'string', enum: ['learning', 'retro', 'resonance', 'other'] }, matchReason: { type: 'string' }, confidence: { type: 'string', enum: ['high', 'medium', 'low'] } } }, description: 'Files discovered' },
-      foundCommits: { type: 'array', items: { type: 'object', properties: { hash: { type: 'string' }, shortHash: { type: 'string' }, date: { type: 'string' }, message: { type: 'string' } } }, description: 'Commits discovered' },
-      foundIssues: { type: 'array', items: { type: 'object', properties: { number: { type: 'number' }, title: { type: 'string' }, state: { type: 'string', enum: ['open', 'closed'] }, url: { type: 'string' } } }, description: 'GitHub issues discovered' },
-      foundRetrospectives: { type: 'array', items: { type: 'string' }, description: 'Retrospective file paths' },
-      foundLearnings: { type: 'array', items: { type: 'string' }, description: 'Learning file paths' },
-      scope: { type: 'string', enum: ['project', 'cross-project', 'human'], description: 'Trace scope. project=single repo, cross-project=spans repos, human=about the person' },
-      parentTraceId: { type: 'string', description: 'Parent trace ID if this is a dig from another trace' },
+      queryType: {
+        type: 'string',
+        enum: ['general', 'project', 'pattern', 'evolution'],
+        description: 'Type of trace query',
+        default: 'general',
+      },
+      foundFiles: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            path: { type: 'string' },
+            type: { type: 'string', enum: ['learning', 'retro', 'resonance', 'other'] },
+            matchReason: { type: 'string' },
+            confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+          },
+        },
+        description: 'Files discovered',
+      },
+      foundCommits: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            hash: { type: 'string' },
+            shortHash: { type: 'string' },
+            date: { type: 'string' },
+            message: { type: 'string' },
+          },
+        },
+        description: 'Commits discovered',
+      },
+      foundIssues: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            number: { type: 'number' },
+            title: { type: 'string' },
+            state: { type: 'string', enum: ['open', 'closed'] },
+            url: { type: 'string' },
+          },
+        },
+        description: 'GitHub issues discovered',
+      },
+      foundRetrospectives: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Retrospective file paths',
+      },
+      foundLearnings: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Learning file paths',
+      },
+      scope: {
+        type: 'string',
+        enum: ['project', 'cross-project', 'human'],
+        description:
+          'Trace scope. project=single repo, cross-project=spans repos, human=about the person',
+      },
+      parentTraceId: {
+        type: 'string',
+        description: 'Parent trace ID if this is a dig from another trace',
+      },
       project: { type: 'string', description: 'Project context (ghq format)' },
       agentCount: { type: 'number', description: 'Number of agents used in trace' },
       durationMs: { type: 'number', description: 'How long trace took in milliseconds' },
     },
-    required: ['query']
-  }
+    required: ['query'],
+  },
 };
 
 export const traceListToolDef = {
@@ -58,63 +112,85 @@ export const traceListToolDef = {
     properties: {
       query: { type: 'string', description: 'Filter by query content' },
       project: { type: 'string', description: 'Filter by project' },
-      status: { type: 'string', enum: ['raw', 'reviewed', 'distilling', 'distilled'], description: 'Filter by distillation status' },
+      status: {
+        type: 'string',
+        enum: ['raw', 'reviewed', 'distilling', 'distilled'],
+        description: 'Filter by distillation status',
+      },
       depth: { type: 'number', description: 'Filter by recursion depth (0 = top-level traces)' },
       limit: { type: 'number', description: 'Maximum traces to return', default: 20 },
       offset: { type: 'number', description: 'Pagination offset', default: 0 },
-    }
-  }
+    },
+  },
 };
 
 export const traceGetToolDef = {
   name: 'oracle_trace_get',
-  description: 'Get full details of a specific trace including all dig points (files, commits, issues).',
+  description:
+    'Get full details of a specific trace including all dig points (files, commits, issues).',
   inputSchema: {
     type: 'object',
     properties: {
       traceId: { type: 'string', description: 'UUID of the trace' },
-      includeChain: { type: 'boolean', description: 'Include parent/child trace chain', default: false },
+      includeChain: {
+        type: 'boolean',
+        description: 'Include parent/child trace chain',
+        default: false,
+      },
     },
-    required: ['traceId']
-  }
+    required: ['traceId'],
+  },
 };
 
 export const traceLinkToolDef = {
   name: 'oracle_trace_link',
-  description: 'Link two traces as a chain (prev \u2192 next). Creates bidirectional navigation without deleting anything. Use when agents create related traces that should be connected.',
+  description:
+    'Link two traces as a chain (prev \u2192 next). Creates bidirectional navigation without deleting anything. Use when agents create related traces that should be connected.',
   inputSchema: {
     type: 'object',
     properties: {
-      prevTraceId: { type: 'string', description: 'UUID of the trace that comes first (will link forward)' },
-      nextTraceId: { type: 'string', description: 'UUID of the trace that comes after (will link backward)' },
+      prevTraceId: {
+        type: 'string',
+        description: 'UUID of the trace that comes first (will link forward)',
+      },
+      nextTraceId: {
+        type: 'string',
+        description: 'UUID of the trace that comes after (will link backward)',
+      },
     },
-    required: ['prevTraceId', 'nextTraceId']
-  }
+    required: ['prevTraceId', 'nextTraceId'],
+  },
 };
 
 export const traceUnlinkToolDef = {
   name: 'oracle_trace_unlink',
-  description: 'Remove a link between traces. Breaks the chain connection in the specified direction.',
+  description:
+    'Remove a link between traces. Breaks the chain connection in the specified direction.',
   inputSchema: {
     type: 'object',
     properties: {
       traceId: { type: 'string', description: 'UUID of the trace to unlink from' },
-      direction: { type: 'string', enum: ['prev', 'next'], description: 'Which direction to unlink (prev or next)' },
+      direction: {
+        type: 'string',
+        enum: ['prev', 'next'],
+        description: 'Which direction to unlink (prev or next)',
+      },
     },
-    required: ['traceId', 'direction']
-  }
+    required: ['traceId', 'direction'],
+  },
 };
 
 export const traceChainToolDef = {
   name: 'oracle_trace_chain',
-  description: 'Get the full linked chain for a trace. Returns all traces in the chain and the position of the requested trace.',
+  description:
+    'Get the full linked chain for a trace. Returns all traces in the chain and the position of the requested trace.',
   inputSchema: {
     type: 'object',
     properties: {
       traceId: { type: 'string', description: 'UUID of any trace in the chain' },
     },
-    required: ['traceId']
-  }
+    required: ['traceId'],
+  },
 };
 
 /** All trace tool definitions for ListTools */
@@ -133,24 +209,32 @@ export const traceToolDefs = [
 
 export async function handleTrace(input: CreateTraceInput): Promise<ToolResponse> {
   const result = createTrace(input);
-  console.error(`[MCP:TRACE] query="${input.query}" depth=${result.depth} digPoints=${result.summary.totalDigPoints}`);
+  console.error(
+    `[MCP:TRACE] query="${input.query}" depth=${result.depth} digPoints=${result.summary.totalDigPoints}`,
+  );
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        success: result.success,
-        trace_id: result.traceId,
-        depth: result.depth,
-        summary: {
-          file_count: result.summary.fileCount,
-          commit_count: result.summary.commitCount,
-          issue_count: result.summary.issueCount,
-          total_dig_points: result.summary.totalDigPoints,
-        },
-        message: `Trace logged. Use oracle_trace_get with trace_id="${result.traceId}" to explore dig points.`
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            success: result.success,
+            trace_id: result.traceId,
+            depth: result.depth,
+            summary: {
+              file_count: result.summary.fileCount,
+              commit_count: result.summary.commitCount,
+              issue_count: result.summary.issueCount,
+              total_dig_points: result.summary.totalDigPoints,
+            },
+            message: `Trace logged. Use oracle_trace_get with trace_id="${result.traceId}" to explore dig points.`,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }
 
@@ -159,25 +243,31 @@ export async function handleTraceList(input: ListTracesInput): Promise<ToolRespo
   console.error(`[MCP:TRACE_LIST] found=${result.total} returned=${result.traces.length}`);
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        traces: result.traces.map(t => ({
-          trace_id: t.traceId,
-          query: t.query,
-          scope: t.scope,
-          depth: t.depth,
-          file_count: t.fileCount,
-          commit_count: t.commitCount,
-          issue_count: t.issueCount,
-          status: t.status,
-          has_awakening: t.hasAwakening,
-          created_at: new Date(t.createdAt).toISOString(),
-        })),
-        total: result.total,
-        has_more: result.hasMore,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            traces: result.traces.map((t) => ({
+              trace_id: t.traceId,
+              query: t.query,
+              scope: t.scope,
+              depth: t.depth,
+              file_count: t.fileCount,
+              commit_count: t.commitCount,
+              issue_count: t.issueCount,
+              status: t.status,
+              has_awakening: t.hasAwakening,
+              created_at: new Date(t.createdAt).toISOString(),
+            })),
+            total: result.total,
+            has_more: result.hasMore,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }
 
@@ -193,105 +283,139 @@ export async function handleTraceGet(input: GetTraceInput): Promise<ToolResponse
   }
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        trace_id: trace.traceId,
-        query: trace.query,
-        query_type: trace.queryType,
-        scope: trace.scope,
-        depth: trace.depth,
-        status: trace.status,
-        found_files: trace.foundFiles,
-        found_commits: trace.foundCommits,
-        found_issues: trace.foundIssues,
-        found_retrospectives: trace.foundRetrospectives,
-        found_learnings: trace.foundLearnings,
-        found_resonance: trace.foundResonance,
-        file_count: trace.fileCount,
-        commit_count: trace.commitCount,
-        issue_count: trace.issueCount,
-        parent_trace_id: trace.parentTraceId,
-        child_trace_ids: trace.childTraceIds,
-        prev_trace_id: trace.prevTraceId,
-        next_trace_id: trace.nextTraceId,
-        project: trace.project,
-        agent_count: trace.agentCount,
-        duration_ms: trace.durationMs,
-        awakening: trace.awakening,
-        distilled_to_id: trace.distilledToId,
-        created_at: new Date(trace.createdAt).toISOString(),
-        updated_at: new Date(trace.updatedAt).toISOString(),
-        chain: chain ? {
-          traces: chain.chain,
-          total_depth: chain.totalDepth,
-          has_awakening: chain.hasAwakening,
-          awakening_trace_id: chain.awakeningTraceId,
-        } : undefined,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            trace_id: trace.traceId,
+            query: trace.query,
+            query_type: trace.queryType,
+            scope: trace.scope,
+            depth: trace.depth,
+            status: trace.status,
+            found_files: trace.foundFiles,
+            found_commits: trace.foundCommits,
+            found_issues: trace.foundIssues,
+            found_retrospectives: trace.foundRetrospectives,
+            found_learnings: trace.foundLearnings,
+            found_resonance: trace.foundResonance,
+            file_count: trace.fileCount,
+            commit_count: trace.commitCount,
+            issue_count: trace.issueCount,
+            parent_trace_id: trace.parentTraceId,
+            child_trace_ids: trace.childTraceIds,
+            prev_trace_id: trace.prevTraceId,
+            next_trace_id: trace.nextTraceId,
+            project: trace.project,
+            agent_count: trace.agentCount,
+            duration_ms: trace.durationMs,
+            awakening: trace.awakening,
+            distilled_to_id: trace.distilledToId,
+            created_at: new Date(trace.createdAt).toISOString(),
+            updated_at: new Date(trace.updatedAt).toISOString(),
+            chain: chain
+              ? {
+                  traces: chain.chain,
+                  total_depth: chain.totalDepth,
+                  has_awakening: chain.hasAwakening,
+                  awakening_trace_id: chain.awakeningTraceId,
+                }
+              : undefined,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }
 
-export async function handleTraceLink(input: { prevTraceId: string; nextTraceId: string }): Promise<ToolResponse> {
+export async function handleTraceLink(input: {
+  prevTraceId: string;
+  nextTraceId: string;
+}): Promise<ToolResponse> {
   const result = linkTraces(input.prevTraceId, input.nextTraceId);
   if (!result.success) throw new Error(result.message);
 
   console.error(`[MCP:TRACE_LINK] ${input.prevTraceId} \u2192 ${input.nextTraceId}`);
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        success: true,
-        message: result.message,
-        prev_trace: result.prevTrace ? {
-          trace_id: result.prevTrace.traceId,
-          query: result.prevTrace.query,
-          next_trace_id: result.prevTrace.nextTraceId,
-        } : undefined,
-        next_trace: result.nextTrace ? {
-          trace_id: result.nextTrace.traceId,
-          query: result.nextTrace.query,
-          prev_trace_id: result.nextTrace.prevTraceId,
-        } : undefined,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            success: true,
+            message: result.message,
+            prev_trace: result.prevTrace
+              ? {
+                  trace_id: result.prevTrace.traceId,
+                  query: result.prevTrace.query,
+                  next_trace_id: result.prevTrace.nextTraceId,
+                }
+              : undefined,
+            next_trace: result.nextTrace
+              ? {
+                  trace_id: result.nextTrace.traceId,
+                  query: result.nextTrace.query,
+                  prev_trace_id: result.nextTrace.prevTraceId,
+                }
+              : undefined,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }
 
-export async function handleTraceUnlink(input: { traceId: string; direction: 'prev' | 'next' }): Promise<ToolResponse> {
+export async function handleTraceUnlink(input: {
+  traceId: string;
+  direction: 'prev' | 'next';
+}): Promise<ToolResponse> {
   const result = unlinkTraces(input.traceId, input.direction);
   if (!result.success) throw new Error(result.message);
 
   console.error(`[MCP:TRACE_UNLINK] ${input.traceId} direction=${input.direction}`);
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({ success: true, message: result.message }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ success: true, message: result.message }, null, 2),
+      },
+    ],
   };
 }
 
 export async function handleTraceChain(input: { traceId: string }): Promise<ToolResponse> {
   const result = getTraceLinkedChain(input.traceId);
-  console.error(`[MCP:TRACE_CHAIN] id=${input.traceId} chain_length=${result.chain.length} position=${result.position}`);
+  console.error(
+    `[MCP:TRACE_CHAIN] id=${input.traceId} chain_length=${result.chain.length} position=${result.position}`,
+  );
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        chain: result.chain.map(t => ({
-          trace_id: t.traceId,
-          query: t.query,
-          prev_trace_id: t.prevTraceId,
-          next_trace_id: t.nextTraceId,
-          created_at: new Date(t.createdAt).toISOString(),
-        })),
-        position: result.position,
-        chain_length: result.chain.length,
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            chain: result.chain.map((t) => ({
+              trace_id: t.traceId,
+              query: t.query,
+              prev_trace_id: t.prevTraceId,
+              next_trace_id: t.nextTraceId,
+              created_at: new Date(t.createdAt).toISOString(),
+            })),
+            position: result.position,
+            chain_length: result.chain.length,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/src/tools/verify.ts
+++ b/src/tools/verify.ts
@@ -9,26 +9,31 @@ import type { ToolContext, ToolResponse, OracleVerifyInput } from './types.ts';
 
 export const verifyToolDef = {
   name: 'oracle_verify',
-  description: 'Verify knowledge base integrity: compare ψ/ files on disk vs DB index. Detects missing (on disk, not indexed), orphaned (in DB, file gone), and drifted (file changed since last index) documents.',
+  description:
+    'Verify knowledge base integrity: compare ψ/ files on disk vs DB index. Detects missing (on disk, not indexed), orphaned (in DB, file gone), and drifted (file changed since last index) documents.',
   inputSchema: {
     type: 'object',
     properties: {
       check: {
         type: 'boolean',
-        description: 'If true (default), read-only report. If false, also flag orphaned DB entries with superseded_by="_verified_orphan".',
-        default: true
+        description:
+          'If true (default), read-only report. If false, also flag orphaned DB entries with superseded_by="_verified_orphan".',
+        default: true,
       },
       type: {
         type: 'string',
         description: 'Filter by document type (default: all)',
         enum: ['principle', 'pattern', 'learning', 'retro', 'all'],
-        default: 'all'
-      }
-    }
-  }
+        default: 'all',
+      },
+    },
+  },
 };
 
-export async function handleVerify(ctx: ToolContext, input: OracleVerifyInput): Promise<ToolResponse> {
+export async function handleVerify(
+  ctx: ToolContext,
+  input: OracleVerifyInput,
+): Promise<ToolResponse> {
   const { check = true, type } = input;
 
   const result = verifyKnowledgeBase({
@@ -37,20 +42,28 @@ export async function handleVerify(ctx: ToolContext, input: OracleVerifyInput): 
     repoRoot: ctx.repoRoot,
   });
 
-  console.error(`[MCP:VERIFY] healthy=${result.counts.healthy} missing=${result.counts.missing} orphaned=${result.counts.orphaned} drifted=${result.counts.drifted}`);
+  console.error(
+    `[MCP:VERIFY] healthy=${result.counts.healthy} missing=${result.counts.missing} orphaned=${result.counts.orphaned} drifted=${result.counts.drifted}`,
+  );
 
   return {
-    content: [{
-      type: 'text',
-      text: JSON.stringify({
-        counts: result.counts,
-        missing: result.missing,
-        orphaned: result.orphaned,
-        drifted: result.drifted,
-        untracked: result.untracked,
-        recommendation: result.recommendation,
-        ...(result.fixedOrphans ? { fixed_orphans: result.fixedOrphans } : {}),
-      }, null, 2)
-    }]
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            counts: result.counts,
+            missing: result.missing,
+            orphaned: result.orphaned,
+            drifted: result.drifted,
+            untracked: result.untracked,
+            recommendation: result.recommendation,
+            ...(result.fixedOrphans ? { fixed_orphans: result.fixedOrphans } : {}),
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/src/trace/handler.ts
+++ b/src/trace/handler.ts
@@ -33,11 +33,7 @@ function isLearningFilePath(learning: string): boolean {
  * Create a learning file from a text snippet
  * Returns the file path
  */
-function createLearningFile(
-  text: string,
-  project: string | null,
-  traceQuery: string
-): string {
+function createLearningFile(text: string, project: string | null, traceQuery: string): string {
   const now = new Date();
   const dateStr = now.toISOString().split('T')[0]; // YYYY-MM-DD
 
@@ -87,11 +83,11 @@ ${project ? `*Source project: ${project}*` : ''}
 function processLearnings(
   learnings: string[] | undefined,
   project: string | null,
-  traceQuery: string
+  traceQuery: string,
 ): string[] {
   if (!learnings || learnings.length === 0) return [];
 
-  return learnings.map(learning => {
+  return learnings.map((learning) => {
     if (isLearningFilePath(learning)) {
       // Already a file path, keep as-is
       return learning;
@@ -112,7 +108,7 @@ export function createTrace(input: CreateTraceInput): CreateTraceResult {
   const processedLearnings = processLearnings(
     input.foundLearnings,
     input.project || null,
-    input.query
+    input.query,
   );
 
   // Calculate counts
@@ -136,31 +132,33 @@ export function createTrace(input: CreateTraceInput): CreateTraceResult {
   }
 
   // Insert trace
-  db.insert(traceLog).values({
-    traceId,
-    query: input.query,
-    queryType: input.queryType || 'general',
-    foundFiles: JSON.stringify(input.foundFiles || []),
-    foundCommits: JSON.stringify(input.foundCommits || []),
-    foundIssues: JSON.stringify(input.foundIssues || []),
-    foundRetrospectives: JSON.stringify(input.foundRetrospectives || []),
-    foundLearnings: JSON.stringify(processedLearnings),
-    foundResonance: JSON.stringify(input.foundResonance || []),
-    fileCount,
-    commitCount,
-    issueCount,
-    depth,
-    parentTraceId: input.parentTraceId || null,
-    childTraceIds: '[]',
-    scope: input.scope || 'project',
-    project: input.project || null,
-    sessionId: input.sessionId || null,
-    agentCount: input.agentCount || 1,
-    durationMs: input.durationMs || null,
-    status: 'raw',
-    createdAt: now,
-    updatedAt: now,
-  }).run();
+  db.insert(traceLog)
+    .values({
+      traceId,
+      query: input.query,
+      queryType: input.queryType || 'general',
+      foundFiles: JSON.stringify(input.foundFiles || []),
+      foundCommits: JSON.stringify(input.foundCommits || []),
+      foundIssues: JSON.stringify(input.foundIssues || []),
+      foundRetrospectives: JSON.stringify(input.foundRetrospectives || []),
+      foundLearnings: JSON.stringify(processedLearnings),
+      foundResonance: JSON.stringify(input.foundResonance || []),
+      fileCount,
+      commitCount,
+      issueCount,
+      depth,
+      parentTraceId: input.parentTraceId || null,
+      childTraceIds: '[]',
+      scope: input.scope || 'project',
+      project: input.project || null,
+      sessionId: input.sessionId || null,
+      agentCount: input.agentCount || 1,
+      durationMs: input.durationMs || null,
+      status: 'raw',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
 
   // Update parent's child_trace_ids
   if (input.parentTraceId) {
@@ -184,11 +182,7 @@ export function createTrace(input: CreateTraceInput): CreateTraceResult {
  * Get a trace by ID
  */
 export function getTrace(traceId: string): TraceRecord | null {
-  const row = db
-    .select()
-    .from(traceLog)
-    .where(eq(traceLog.traceId, traceId))
-    .get();
+  const row = db.select().from(traceLog).where(eq(traceLog.traceId, traceId)).get();
 
   if (!row) return null;
   return parseTraceRow(row);
@@ -277,7 +271,7 @@ export function listTraces(input: ListTracesInput): ListTracesResult {
  */
 export function getTraceChain(
   traceId: string,
-  direction: 'up' | 'down' | 'both' = 'both'
+  direction: 'up' | 'down' | 'both' = 'both',
 ): TraceChainResult {
   const chain: TraceSummary[] = [];
   let hasAwakening = false;
@@ -340,7 +334,7 @@ export function getTraceChain(
  */
 export function linkTraces(
   prevTraceId: string,
-  nextTraceId: string
+  nextTraceId: string,
 ): { success: boolean; message: string; prevTrace?: TraceRecord; nextTrace?: TraceRecord } {
   const prevTrace = getTrace(prevTraceId);
   const nextTrace = getTrace(nextTraceId);
@@ -383,7 +377,7 @@ export function linkTraces(
  */
 export function unlinkTraces(
   traceId: string,
-  direction: 'prev' | 'next'
+  direction: 'prev' | 'next',
 ): { success: boolean; message: string } {
   const trace = getTrace(traceId);
   if (!trace) return { success: false, message: `Trace not found: ${traceId}` };
@@ -428,9 +422,7 @@ export function unlinkTraces(
 /**
  * Get the full linked chain for a trace
  */
-export function getTraceLinkedChain(
-  traceId: string
-): { chain: TraceRecord[]; position: number } {
+export function getTraceLinkedChain(traceId: string): { chain: TraceRecord[]; position: number } {
   const chain: TraceRecord[] = [];
   let position = 0;
 
@@ -463,9 +455,11 @@ export function getTraceLinkedChain(
 /**
  * Distill awakening from a trace
  */
-export function distillTrace(
-  input: DistillTraceInput
-): { success: boolean; status: string; learningId?: string } {
+export function distillTrace(input: DistillTraceInput): {
+  success: boolean;
+  status: string;
+  learningId?: string;
+} {
   const now = Date.now();
 
   db.update(traceLog)

--- a/src/trace/routes.ts
+++ b/src/trace/routes.ts
@@ -1,7 +1,14 @@
 import type { Context } from 'hono';
 import type { OpenAPIHono } from '@hono/zod-openapi';
 import type { Database } from 'bun:sqlite';
-import { listTraces, getTrace, getTraceChain, linkTraces, unlinkTraces, getTraceLinkedChain } from './handler.ts';
+import {
+  listTraces,
+  getTrace,
+  getTraceChain,
+  linkTraces,
+  unlinkTraces,
+  getTraceLinkedChain,
+} from './handler.ts';
 
 // ============================================================================
 // Trace routes — Phase 2.4 of Library #102 (T#782)
@@ -12,7 +19,11 @@ interface TraceHelpers {
   isTrustedRequest: (c: Context) => boolean;
 }
 
-export function registerTraceRoutes(app: OpenAPIHono, sqliteDb: Database, helpers: TraceHelpers): void {
+export function registerTraceRoutes(
+  app: OpenAPIHono,
+  sqliteDb: Database,
+  helpers: TraceHelpers,
+): void {
   const { hasSessionAuth, isTrustedRequest } = helpers;
   const sqlite: Database = sqliteDb;
 
@@ -28,7 +39,7 @@ export function registerTraceRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       status: status as 'raw' | 'reviewed' | 'distilled' | undefined,
       project: project || undefined,
       limit,
-      offset
+      offset,
     });
 
     return c.json(result);
@@ -47,7 +58,7 @@ export function registerTraceRoutes(app: OpenAPIHono, sqliteDb: Database, helper
 
   app.get('/api/traces/:id/chain', (c) => {
     const traceId = c.req.param('id');
-    const direction = c.req.query('direction') as 'up' | 'down' | 'both' || 'both';
+    const direction = (c.req.query('direction') as 'up' | 'down' | 'both') || 'both';
 
     const chain = getTraceChain(traceId, direction);
     return c.json(chain);
@@ -107,6 +118,4 @@ export function registerTraceRoutes(app: OpenAPIHono, sqliteDb: Database, helper
       return c.json({ error: 'Failed to get linked chain' }, 500);
     }
   });
-
-
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,13 +10,13 @@ export type OracleDocumentType = 'principle' | 'pattern' | 'learning' | 'retro';
  * Following claude-mem's pattern of splitting large documents into smaller chunks
  */
 export interface OracleDocument {
-  id: string;           // e.g., "resonance_oracle_principle_1"
+  id: string; // e.g., "resonance_oracle_principle_1"
   type: OracleDocumentType;
-  source_file: string;  // Relative path from repo root
-  content: string;      // The actual text to embed
-  concepts: string[];   // Tags for filtering: ['trust', 'patterns', 'mirror']
-  created_at: number;   // Unix timestamp
-  updated_at: number;   // Unix timestamp
+  source_file: string; // Relative path from repo root
+  content: string; // The actual text to embed
+  concepts: string[]; // Tags for filtering: ['trust', 'patterns', 'mirror']
+  created_at: number; // Unix timestamp
+  updated_at: number; // Unix timestamp
   project?: string | null; // Source project (null = universal, undefined = inherit)
 }
 
@@ -27,10 +27,10 @@ export interface OracleMetadata {
   id: string;
   type: OracleDocumentType;
   source_file: string;
-  concepts: string;     // JSON array as string
+  concepts: string; // JSON array as string
   created_at: number;
   updated_at: number;
-  indexed_at: number;   // When this was indexed
+  indexed_at: number; // When this was indexed
 }
 
 /**
@@ -38,7 +38,7 @@ export interface OracleMetadata {
  */
 export interface SearchResult {
   document: OracleDocument;
-  score: number;        // Relevance score from vector search
+  score: number; // Relevance score from vector search
   source: 'vector' | 'fts' | 'hybrid';
 }
 
@@ -110,8 +110,8 @@ export interface OracleListOutput {
  * Hybrid search options for combining FTS and vector results
  */
 export interface HybridSearchOptions {
-  ftsWeight?: number;     // Weight for FTS results (default 0.5)
-  vectorWeight?: number;  // Weight for vector results (default 0.5)
+  ftsWeight?: number; // Weight for FTS results (default 0.5)
+  vectorWeight?: number; // Weight for vector results (default 0.5)
 }
 
 /**

--- a/src/vault/__tests__/handler.test.ts
+++ b/src/vault/__tests__/handler.test.ts
@@ -74,33 +74,37 @@ describe('mapToVaultPath', () => {
   const project = 'github.com/soul-brews-studio/oracle-v2';
 
   it('prefixes learnings with project', () => {
-    expect(mapToVaultPath('ψ/memory/learnings/file.md', project))
-      .toBe('github.com/soul-brews-studio/oracle-v2/ψ/memory/learnings/file.md');
+    expect(mapToVaultPath('ψ/memory/learnings/file.md', project)).toBe(
+      'github.com/soul-brews-studio/oracle-v2/ψ/memory/learnings/file.md',
+    );
   });
 
   it('prefixes retrospectives with project', () => {
-    expect(mapToVaultPath('ψ/memory/retrospectives/2026-01/15/session.md', project))
-      .toBe('github.com/soul-brews-studio/oracle-v2/ψ/memory/retrospectives/2026-01/15/session.md');
+    expect(mapToVaultPath('ψ/memory/retrospectives/2026-01/15/session.md', project)).toBe(
+      'github.com/soul-brews-studio/oracle-v2/ψ/memory/retrospectives/2026-01/15/session.md',
+    );
   });
 
   it('prefixes inbox/handoff with project', () => {
-    expect(mapToVaultPath('ψ/inbox/handoff/context.md', project))
-      .toBe('github.com/soul-brews-studio/oracle-v2/ψ/inbox/handoff/context.md');
+    expect(mapToVaultPath('ψ/inbox/handoff/context.md', project)).toBe(
+      'github.com/soul-brews-studio/oracle-v2/ψ/inbox/handoff/context.md',
+    );
   });
 
   it('keeps resonance universal (no project prefix)', () => {
-    expect(mapToVaultPath('ψ/memory/resonance/philosophy.md', project))
-      .toBe('ψ/memory/resonance/philosophy.md');
+    expect(mapToVaultPath('ψ/memory/resonance/philosophy.md', project)).toBe(
+      'ψ/memory/resonance/philosophy.md',
+    );
   });
 
   it('returns path unchanged when project is null', () => {
-    expect(mapToVaultPath('ψ/memory/learnings/file.md', null))
-      .toBe('ψ/memory/learnings/file.md');
+    expect(mapToVaultPath('ψ/memory/learnings/file.md', null)).toBe('ψ/memory/learnings/file.md');
   });
 
   it('handles nested learning files', () => {
-    expect(mapToVaultPath('ψ/memory/learnings/deep/nested/file.md', project))
-      .toBe('github.com/soul-brews-studio/oracle-v2/ψ/memory/learnings/deep/nested/file.md');
+    expect(mapToVaultPath('ψ/memory/learnings/deep/nested/file.md', project)).toBe(
+      'github.com/soul-brews-studio/oracle-v2/ψ/memory/learnings/deep/nested/file.md',
+    );
   });
 });
 
@@ -112,22 +116,27 @@ describe('mapFromVaultPath', () => {
   const project = 'github.com/soul-brews-studio/oracle-v2';
 
   it('strips project prefix from learnings path', () => {
-    expect(mapFromVaultPath(
-      'github.com/soul-brews-studio/oracle-v2/ψ/memory/learnings/file.md',
-      project
-    )).toBe('ψ/memory/learnings/file.md');
+    expect(
+      mapFromVaultPath(
+        'github.com/soul-brews-studio/oracle-v2/ψ/memory/learnings/file.md',
+        project,
+      ),
+    ).toBe('ψ/memory/learnings/file.md');
   });
 
   it('strips project prefix from retrospectives path', () => {
-    expect(mapFromVaultPath(
-      'github.com/soul-brews-studio/oracle-v2/ψ/memory/retrospectives/2026-01/15/session.md',
-      project
-    )).toBe('ψ/memory/retrospectives/2026-01/15/session.md');
+    expect(
+      mapFromVaultPath(
+        'github.com/soul-brews-studio/oracle-v2/ψ/memory/retrospectives/2026-01/15/session.md',
+        project,
+      ),
+    ).toBe('ψ/memory/retrospectives/2026-01/15/session.md');
   });
 
   it('keeps resonance path as-is', () => {
-    expect(mapFromVaultPath('ψ/memory/resonance/philosophy.md', project))
-      .toBe('ψ/memory/resonance/philosophy.md');
+    expect(mapFromVaultPath('ψ/memory/resonance/philosophy.md', project)).toBe(
+      'ψ/memory/resonance/philosophy.md',
+    );
   });
 
   it('returns null for unrecognized paths', () => {
@@ -135,10 +144,9 @@ describe('mapFromVaultPath', () => {
   });
 
   it('returns null for different project paths', () => {
-    expect(mapFromVaultPath(
-      'github.com/other-org/other-repo/ψ/memory/learnings/file.md',
-      project
-    )).toBeNull();
+    expect(
+      mapFromVaultPath('github.com/other-org/other-repo/ψ/memory/learnings/file.md', project),
+    ).toBeNull();
   });
 });
 
@@ -152,9 +160,7 @@ describe('ensureFrontmatterProject', () => {
   it('adds frontmatter when none exists', () => {
     const content = '# My Learning\n\nSome content here.';
     const result = ensureFrontmatterProject(content, project);
-    expect(result).toBe(
-      `---\nproject: ${project}\n---\n\n# My Learning\n\nSome content here.`
-    );
+    expect(result).toBe(`---\nproject: ${project}\n---\n\n# My Learning\n\nSome content here.`);
   });
 
   it('injects project into existing frontmatter', () => {

--- a/src/vault/cli.ts
+++ b/src/vault/cli.ts
@@ -130,7 +130,8 @@ switch (command) {
       const dryRun = args.includes('--dry-run');
       const symlink = args.includes('--symlink');
       if (dryRun) console.error('[Vault] DRY RUN — no files will be copied\n');
-      if (symlink) console.error('[Vault] SYMLINK MODE — local ψ/ will be replaced with symlinks\n');
+      if (symlink)
+        console.error('[Vault] SYMLINK MODE — local ψ/ will be replaced with symlinks\n');
       const result = migrate({ dryRun, symlink });
       console.log(JSON.stringify(result, null, 2));
     }

--- a/src/vault/handler.ts
+++ b/src/vault/handler.ts
@@ -66,11 +66,7 @@ function cleanEmptyDirs(dir: string, stopAt: string): void {
 }
 
 // Categories that get project-nested in the vault
-const PROJECT_CATEGORIES = [
-  'ψ/memory/learnings/',
-  'ψ/memory/retrospectives/',
-  'ψ/inbox/handoff/',
-];
+const PROJECT_CATEGORIES = ['ψ/memory/learnings/', 'ψ/memory/retrospectives/', 'ψ/inbox/handoff/'];
 
 // Universal categories — no project prefix
 const UNIVERSAL_CATEGORIES = [
@@ -248,10 +244,7 @@ export interface SyncResult {
   project?: string | null;
 }
 
-export function syncVault(opts: {
-  dryRun?: boolean;
-  repoRoot: string;
-}): SyncResult {
+export function syncVault(opts: { dryRun?: boolean; repoRoot: string }): SyncResult {
   const { dryRun = false, repoRoot } = opts;
 
   const repo = getSetting('vault_repo');
@@ -334,7 +327,10 @@ export function syncVault(opts: {
 
   // 6. Commit + push
   const now = new Date();
-  const ts = now.toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+  const ts = now
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/\.\d+Z$/, '');
   const parts: string[] = [];
   if (added) parts.push(`+${added}`);
   if (modified) parts.push(`~${modified}`);
@@ -357,9 +353,7 @@ export function syncVault(opts: {
   // 7. Update settings
   setSetting('vault_last_sync', String(now.getTime()));
 
-  console.error(
-    `[Vault] Synced: +${added} ~${modified} -${deleted} (${commitHash})`,
-  );
+  console.error(`[Vault] Synced: +${added} ~${modified} -${deleted} (${commitHash})`);
 
   return { dryRun: false, added, modified, deleted, commitHash, project };
 }
@@ -369,9 +363,7 @@ export interface PullResult {
   project: string;
 }
 
-export function pullVault(opts: {
-  repoRoot: string;
-}): PullResult {
+export function pullVault(opts: { repoRoot: string }): PullResult {
   const { repoRoot } = opts;
 
   const repo = getSetting('vault_repo');

--- a/src/vault/migrate.ts
+++ b/src/vault/migrate.ts
@@ -48,11 +48,7 @@ function walkFiles(
 }
 
 // Categories that get project-nested
-const PROJECT_CATEGORIES = [
-  'ψ/memory/learnings/',
-  'ψ/memory/retrospectives/',
-  'ψ/inbox/handoff/',
-];
+const PROJECT_CATEGORIES = ['ψ/memory/learnings/', 'ψ/memory/retrospectives/', 'ψ/inbox/handoff/'];
 
 function isProjectCategory(relativePath: string): boolean {
   return PROJECT_CATEGORIES.some((cat) => relativePath.startsWith(cat));
@@ -137,7 +133,9 @@ function migrate(opts: { dryRun: boolean; symlink?: boolean }): MigrateResult {
         result.skipped.push(`${repoPath} (already symlinked)`);
         continue;
       }
-    } catch { /* doesn't exist, continue */ }
+    } catch {
+      /* doesn't exist, continue */
+    }
 
     const repoRealPath = fs.realpathSync(repoPath);
     if (repoRealPath === vaultRealPath) {

--- a/src/vector/__tests__/adapters.test.ts
+++ b/src/vector/__tests__/adapters.test.ts
@@ -111,7 +111,9 @@ describe('createVectorStore factory', () => {
     expect(store.name).toBe('sqlite-vec');
     expect(store).toBeInstanceOf(SqliteVecAdapter);
     // Cleanup
-    try { fs.unlinkSync(tmpDb); } catch {}
+    try {
+      fs.unlinkSync(tmpDb);
+    } catch {}
   });
 
   test('respects ORACLE_VECTOR_DB env', () => {
@@ -154,13 +156,18 @@ describe('SqliteVecAdapter + Ollama', () => {
   afterAll(async () => {
     if (store) await store.close();
     if (tmpDb) {
-      try { fs.unlinkSync(tmpDb); } catch {}
+      try {
+        fs.unlinkSync(tmpDb);
+      } catch {}
     }
   });
 
   test('connect + ensureCollection', async () => {
     await setup();
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     await store.connect();
     await store.ensureCollection();
@@ -171,7 +178,10 @@ describe('SqliteVecAdapter + Ollama', () => {
   });
 
   test('addDocuments', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     await store.addDocuments(TEST_DOCS);
 
@@ -180,7 +190,10 @@ describe('SqliteVecAdapter + Ollama', () => {
   });
 
   test('query: semantic search', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     const result = await store.query('git history preservation', 3);
 
@@ -196,7 +209,10 @@ describe('SqliteVecAdapter + Ollama', () => {
   });
 
   test('query: with where filter', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     const result = await store.query('search technology', 5, { type: 'learning' });
 
@@ -207,7 +223,10 @@ describe('SqliteVecAdapter + Ollama', () => {
   });
 
   test('queryById: nearest neighbors', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     const result = await store.queryById('test_1', 3);
 
@@ -218,7 +237,10 @@ describe('SqliteVecAdapter + Ollama', () => {
   });
 
   test('getAllEmbeddings', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     const all = await store.getAllEmbeddings!();
 
@@ -229,7 +251,10 @@ describe('SqliteVecAdapter + Ollama', () => {
   });
 
   test('deleteCollection + getStats returns 0', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     await store.deleteCollection();
     // Need to reconnect since tables were dropped
@@ -263,14 +288,19 @@ describe('ChromaMcpAdapter', () => {
 
   afterAll(async () => {
     if (store && chromaAvailable) {
-      try { await store.deleteCollection(); } catch {}
+      try {
+        await store.deleteCollection();
+      } catch {}
       await store.close();
     }
   });
 
   test('connect + ensureCollection', async () => {
     await setup();
-    if (!chromaAvailable) { console.log('  [SKIP] ChromaDB not available'); return; }
+    if (!chromaAvailable) {
+      console.log('  [SKIP] ChromaDB not available');
+      return;
+    }
 
     await store.ensureCollection();
     const info = await store.getCollectionInfo();
@@ -278,7 +308,10 @@ describe('ChromaMcpAdapter', () => {
   });
 
   test('addDocuments + query', async () => {
-    if (!chromaAvailable) { console.log('  [SKIP] ChromaDB not available'); return; }
+    if (!chromaAvailable) {
+      console.log('  [SKIP] ChromaDB not available');
+      return;
+    }
 
     await store.addDocuments(TEST_DOCS);
     const stats = await store.getStats();
@@ -290,7 +323,10 @@ describe('ChromaMcpAdapter', () => {
   });
 
   test.skip('queryById (pre-existing safeJsonParse single-quote bug)', async () => {
-    if (!chromaAvailable) { console.log('  [SKIP] ChromaDB not available'); return; }
+    if (!chromaAvailable) {
+      console.log('  [SKIP] ChromaDB not available');
+      return;
+    }
 
     const result = await store.queryById('test_1', 2);
     expect(result.ids.length).toBeGreaterThan(0);
@@ -323,13 +359,18 @@ describe('LanceDBAdapter + Ollama', () => {
   afterAll(async () => {
     if (store) await store.close();
     if (tmpDir) {
-      try { fs.rmSync(tmpDir, { recursive: true }); } catch {}
+      try {
+        fs.rmSync(tmpDir, { recursive: true });
+      } catch {}
     }
   });
 
   test('connect + ensureCollection', async () => {
     await setup();
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     await store.connect();
     await store.ensureCollection();
@@ -340,7 +381,10 @@ describe('LanceDBAdapter + Ollama', () => {
   });
 
   test('addDocuments', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     await store.addDocuments(TEST_DOCS);
 
@@ -349,7 +393,10 @@ describe('LanceDBAdapter + Ollama', () => {
   });
 
   test('query: semantic search', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     const result = await store.query('git history preservation', 3);
 
@@ -363,7 +410,10 @@ describe('LanceDBAdapter + Ollama', () => {
   });
 
   test('query: with where filter', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     const result = await store.query('search technology', 5, { type: 'learning' });
 
@@ -373,7 +423,10 @@ describe('LanceDBAdapter + Ollama', () => {
   });
 
   test('queryById: nearest neighbors', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     const result = await store.queryById('test_1', 3);
 
@@ -383,7 +436,10 @@ describe('LanceDBAdapter + Ollama', () => {
   });
 
   test('getAllEmbeddings', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     const all = await store.getAllEmbeddings!();
 
@@ -394,7 +450,10 @@ describe('LanceDBAdapter + Ollama', () => {
   });
 
   test('deleteCollection + getStats returns 0', async () => {
-    if (!available) { console.log('  [SKIP] Ollama not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama not available');
+      return;
+    }
 
     await store.deleteCollection();
     await store.ensureCollection();
@@ -434,14 +493,19 @@ describe('QdrantAdapter + Ollama', () => {
 
   afterAll(async () => {
     if (store && available) {
-      try { await store.deleteCollection(); } catch {}
+      try {
+        await store.deleteCollection();
+      } catch {}
       await store.close();
     }
   });
 
   test('connect + ensureCollection', async () => {
     await setup();
-    if (!available) { console.log('  [SKIP] Ollama or Qdrant not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama or Qdrant not available');
+      return;
+    }
 
     await store.connect();
     await store.ensureCollection();
@@ -451,19 +515,25 @@ describe('QdrantAdapter + Ollama', () => {
   });
 
   test('addDocuments', async () => {
-    if (!available) { console.log('  [SKIP] Ollama or Qdrant not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama or Qdrant not available');
+      return;
+    }
 
     await store.addDocuments(TEST_DOCS);
 
     // Qdrant is eventually consistent — wait briefly
-    await new Promise(r => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, 500));
 
     const stats = await store.getStats();
     expect(stats.count).toBe(5);
   });
 
   test('query: semantic search', async () => {
-    if (!available) { console.log('  [SKIP] Ollama or Qdrant not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama or Qdrant not available');
+      return;
+    }
 
     const result = await store.query('git history preservation', 3);
 
@@ -477,7 +547,10 @@ describe('QdrantAdapter + Ollama', () => {
   });
 
   test('query: with where filter', async () => {
-    if (!available) { console.log('  [SKIP] Ollama or Qdrant not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama or Qdrant not available');
+      return;
+    }
 
     const result = await store.query('search technology', 5, { type: 'learning' });
 
@@ -487,7 +560,10 @@ describe('QdrantAdapter + Ollama', () => {
   });
 
   test('queryById: nearest neighbors', async () => {
-    if (!available) { console.log('  [SKIP] Ollama or Qdrant not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama or Qdrant not available');
+      return;
+    }
 
     const result = await store.queryById('test_1', 3);
 
@@ -497,7 +573,10 @@ describe('QdrantAdapter + Ollama', () => {
   });
 
   test('deleteCollection + recreate', async () => {
-    if (!available) { console.log('  [SKIP] Ollama or Qdrant not available'); return; }
+    if (!available) {
+      console.log('  [SKIP] Ollama or Qdrant not available');
+      return;
+    }
 
     await store.deleteCollection();
     await store.ensureCollection();

--- a/src/vector/__tests__/benchmark-models.ts
+++ b/src/vector/__tests__/benchmark-models.ts
@@ -17,38 +17,131 @@ import os from 'os';
 
 const DOCS: VectorDocument[] = [
   // Thai documents
-  { id: 'th1', document: 'ไม่มีอะไรถูกลบ สร้างใหม่ ไม่ลบ ประวัติ Git ศักดิ์สิทธิ์ ทุก commit เป็นถาวร', metadata: { type: 'principle', lang: 'th' } },
-  { id: 'th2', document: 'คุณภาพอากาศ PM2.5 ตรวจวัดด้วยเซ็นเซอร์กว่า 1,500 สถานี ข้อมูล 3.24 พันล้านรายการในฐานข้อมูล', metadata: { type: 'learning', lang: 'th' } },
-  { id: 'th3', document: 'น้ำท่วม ติดตามระดับน้ำแบบเรียลไทม์ ด้วยเรดาร์ความแม่นยำ ±2 มิลลิเมตร บน JIBCHAIN L1', metadata: { type: 'learning', lang: 'th' } },
-  { id: 'th4', document: 'Oracle ไม่แกล้งทำเป็นมนุษย์ เมื่อ AI พูดในฐานะตัวเอง มีความแตกต่าง แต่ความแตกต่างนั้นคือความเป็นหนึ่ง', metadata: { type: 'principle', lang: 'th' } },
-  { id: 'th5', document: 'ระบบฝังตัว ESP32 LoRa Meshtastic สำหรับส่งข้อมูลเซ็นเซอร์ในพื้นที่ห่างไกลที่ไม่มี WiFi', metadata: { type: 'learning', lang: 'th' } },
-  { id: 'th6', document: 'แยก frontend ออกจาก backend อย่างสะอาด oracle-studio เป็นเซิร์ฟเวอร์ของตัวเอง พร้อม API proxy', metadata: { type: 'learning', lang: 'th' } },
-  { id: 'th7', document: 'ข้อความภาษาไทย tokenize ได้ 2-3 เท่าของภาษาอังกฤษ ต้องตัดที่ 2000 ตัวอักษร', metadata: { type: 'learning', lang: 'th' } },
-  { id: 'th8', document: 'การทำ brewing เบียร์คราฟท์ ต้องควบคุมอุณหภูมิ การหมัก และคุณภาพน้ำอย่างแม่นยำ', metadata: { type: 'retro', lang: 'th' } },
+  {
+    id: 'th1',
+    document: 'ไม่มีอะไรถูกลบ สร้างใหม่ ไม่ลบ ประวัติ Git ศักดิ์สิทธิ์ ทุก commit เป็นถาวร',
+    metadata: { type: 'principle', lang: 'th' },
+  },
+  {
+    id: 'th2',
+    document: 'คุณภาพอากาศ PM2.5 ตรวจวัดด้วยเซ็นเซอร์กว่า 1,500 สถานี ข้อมูล 3.24 พันล้านรายการในฐานข้อมูล',
+    metadata: { type: 'learning', lang: 'th' },
+  },
+  {
+    id: 'th3',
+    document: 'น้ำท่วม ติดตามระดับน้ำแบบเรียลไทม์ ด้วยเรดาร์ความแม่นยำ ±2 มิลลิเมตร บน JIBCHAIN L1',
+    metadata: { type: 'learning', lang: 'th' },
+  },
+  {
+    id: 'th4',
+    document: 'Oracle ไม่แกล้งทำเป็นมนุษย์ เมื่อ AI พูดในฐานะตัวเอง มีความแตกต่าง แต่ความแตกต่างนั้นคือความเป็นหนึ่ง',
+    metadata: { type: 'principle', lang: 'th' },
+  },
+  {
+    id: 'th5',
+    document: 'ระบบฝังตัว ESP32 LoRa Meshtastic สำหรับส่งข้อมูลเซ็นเซอร์ในพื้นที่ห่างไกลที่ไม่มี WiFi',
+    metadata: { type: 'learning', lang: 'th' },
+  },
+  {
+    id: 'th6',
+    document:
+      'แยก frontend ออกจาก backend อย่างสะอาด oracle-studio เป็นเซิร์ฟเวอร์ของตัวเอง พร้อม API proxy',
+    metadata: { type: 'learning', lang: 'th' },
+  },
+  {
+    id: 'th7',
+    document: 'ข้อความภาษาไทย tokenize ได้ 2-3 เท่าของภาษาอังกฤษ ต้องตัดที่ 2000 ตัวอักษร',
+    metadata: { type: 'learning', lang: 'th' },
+  },
+  {
+    id: 'th8',
+    document: 'การทำ brewing เบียร์คราฟท์ ต้องควบคุมอุณหภูมิ การหมัก และคุณภาพน้ำอย่างแม่นยำ',
+    metadata: { type: 'retro', lang: 'th' },
+  },
 
   // English documents
-  { id: 'en1', document: 'Nothing is deleted. Create new, do not delete. Git history is sacred. Every commit is permanent.', metadata: { type: 'principle', lang: 'en' } },
-  { id: 'en2', document: 'Air quality monitoring with PM2.5 sensors across 1500+ stations. 3.24 billion records in InfluxDB.', metadata: { type: 'learning', lang: 'en' } },
-  { id: 'en3', document: 'Flood monitoring with ±2mm radar accuracy. Real-time water level tracking on JIBCHAIN L1 blockchain.', metadata: { type: 'learning', lang: 'en' } },
-  { id: 'en4', document: 'Oracle never pretends to be human. When AI speaks as itself, there is distinction — but that distinction IS unity.', metadata: { type: 'principle', lang: 'en' } },
-  { id: 'en5', document: 'ESP32 LoRa Meshtastic mesh network for sensor data relay in remote areas without WiFi coverage.', metadata: { type: 'learning', lang: 'en' } },
-  { id: 'en6', document: 'Separate frontend from backend cleanly. oracle-studio is its own server with API proxy.', metadata: { type: 'learning', lang: 'en' } },
-  { id: 'en7', document: 'Thai text tokenizes at 2-3x more tokens per character than English. Safe truncation: 2000 characters.', metadata: { type: 'learning', lang: 'en' } },
-  { id: 'en8', document: 'Craft beer brewing requires precise temperature control, fermentation monitoring, and water quality management.', metadata: { type: 'retro', lang: 'en' } },
+  {
+    id: 'en1',
+    document:
+      'Nothing is deleted. Create new, do not delete. Git history is sacred. Every commit is permanent.',
+    metadata: { type: 'principle', lang: 'en' },
+  },
+  {
+    id: 'en2',
+    document:
+      'Air quality monitoring with PM2.5 sensors across 1500+ stations. 3.24 billion records in InfluxDB.',
+    metadata: { type: 'learning', lang: 'en' },
+  },
+  {
+    id: 'en3',
+    document:
+      'Flood monitoring with ±2mm radar accuracy. Real-time water level tracking on JIBCHAIN L1 blockchain.',
+    metadata: { type: 'learning', lang: 'en' },
+  },
+  {
+    id: 'en4',
+    document:
+      'Oracle never pretends to be human. When AI speaks as itself, there is distinction — but that distinction IS unity.',
+    metadata: { type: 'principle', lang: 'en' },
+  },
+  {
+    id: 'en5',
+    document:
+      'ESP32 LoRa Meshtastic mesh network for sensor data relay in remote areas without WiFi coverage.',
+    metadata: { type: 'learning', lang: 'en' },
+  },
+  {
+    id: 'en6',
+    document:
+      'Separate frontend from backend cleanly. oracle-studio is its own server with API proxy.',
+    metadata: { type: 'learning', lang: 'en' },
+  },
+  {
+    id: 'en7',
+    document:
+      'Thai text tokenizes at 2-3x more tokens per character than English. Safe truncation: 2000 characters.',
+    metadata: { type: 'learning', lang: 'en' },
+  },
+  {
+    id: 'en8',
+    document:
+      'Craft beer brewing requires precise temperature control, fermentation monitoring, and water quality management.',
+    metadata: { type: 'retro', lang: 'en' },
+  },
 ];
 
 // Queries in both Thai and English — should find matching docs in BOTH languages
 const QUERIES = [
   { text: 'คุณภาพอากาศ PM2.5', expected: ['th2', 'en2'], label: 'Air quality (Thai query)' },
-  { text: 'air quality PM2.5 monitoring', expected: ['en2', 'th2'], label: 'Air quality (English query)' },
+  {
+    text: 'air quality PM2.5 monitoring',
+    expected: ['en2', 'th2'],
+    label: 'Air quality (English query)',
+  },
   { text: 'น้ำท่วม ติดตามระดับน้ำ', expected: ['th3', 'en3'], label: 'Flood monitoring (Thai query)' },
-  { text: 'flood water level tracking', expected: ['en3', 'th3'], label: 'Flood monitoring (English query)' },
+  {
+    text: 'flood water level tracking',
+    expected: ['en3', 'th3'],
+    label: 'Flood monitoring (English query)',
+  },
   { text: 'LoRa เซ็นเซอร์ IoT', expected: ['th5', 'en5'], label: 'IoT sensors (Thai query)' },
-  { text: 'ESP32 mesh network sensor', expected: ['en5', 'th5'], label: 'IoT sensors (English query)' },
+  {
+    text: 'ESP32 mesh network sensor',
+    expected: ['en5', 'th5'],
+    label: 'IoT sensors (English query)',
+  },
   { text: 'เบียร์คราฟท์ การหมัก', expected: ['th8', 'en8'], label: 'Brewing (Thai query)' },
-  { text: 'craft beer brewing fermentation', expected: ['en8', 'th8'], label: 'Brewing (English query)' },
+  {
+    text: 'craft beer brewing fermentation',
+    expected: ['en8', 'th8'],
+    label: 'Brewing (English query)',
+  },
   { text: 'AI ไม่แกล้งเป็นมนุษย์', expected: ['th4', 'en4'], label: 'AI transparency (Thai query)' },
-  { text: 'Oracle never pretends human', expected: ['en4', 'th4'], label: 'AI transparency (English query)' },
+  {
+    text: 'Oracle never pretends human',
+    expected: ['en4', 'th4'],
+    label: 'AI transparency (English query)',
+  },
 ];
 
 // ============================================================================
@@ -80,7 +173,10 @@ async function benchModel(model: string): Promise<ModelResult> {
   console.log(`  Model: ${model}`);
   console.log(`${'='.repeat(60)}`);
 
-  const tmpDir = path.join(os.tmpdir(), `oracle-bench-${model.replace(/[^a-z0-9]/g, '-')}-${Date.now()}`);
+  const tmpDir = path.join(
+    os.tmpdir(),
+    `oracle-bench-${model.replace(/[^a-z0-9]/g, '-')}-${Date.now()}`,
+  );
 
   const store = createVectorStore({
     type: 'lancedb',
@@ -114,7 +210,7 @@ async function benchModel(model: string): Promise<ModelResult> {
 
     // Check cross-language: if query is Thai, did we find the English equivalent? Vice versa.
     const queryLang = /[\u0E00-\u0E7F]/.test(q.text) ? 'th' : 'en';
-    const crossTarget = q.expected.find(id => !id.startsWith(queryLang));
+    const crossTarget = q.expected.find((id) => !id.startsWith(queryLang));
     const crossLang = crossTarget ? top3.includes(crossTarget) : false;
     if (crossLang) crossLangHits++;
 
@@ -125,7 +221,9 @@ async function benchModel(model: string): Promise<ModelResult> {
   // Cleanup
   await store.deleteCollection();
   await store.close();
-  try { fs.rmSync(tmpDir, { recursive: true }); } catch {}
+  try {
+    fs.rmSync(tmpDir, { recursive: true });
+  } catch {}
 
   const avgQueryMs = Math.round(queryResults.reduce((s, q) => s + q.ms, 0) / queryResults.length);
   const crossLangScore = Math.round((crossLangHits / QUERIES.length) * 100);
@@ -139,8 +237,12 @@ async function benchModel(model: string): Promise<ModelResult> {
 
 async function main() {
   console.log('Embedding Model Benchmark: nomic-embed-text vs bge-m3 vs qwen3-embedding');
-  console.log(`Corpus: ${DOCS.length} docs (${DOCS.filter(d => d.metadata.lang === 'th').length} Thai, ${DOCS.filter(d => d.metadata.lang === 'en').length} English)`);
-  console.log(`Queries: ${QUERIES.length} (${QUERIES.filter(q => /[\u0E00-\u0E7F]/.test(q.text)).length} Thai, ${QUERIES.filter(q => !/[\u0E00-\u0E7F]/.test(q.text)).length} English)`);
+  console.log(
+    `Corpus: ${DOCS.length} docs (${DOCS.filter((d) => d.metadata.lang === 'th').length} Thai, ${DOCS.filter((d) => d.metadata.lang === 'en').length} English)`,
+  );
+  console.log(
+    `Queries: ${QUERIES.length} (${QUERIES.filter((q) => /[\u0E00-\u0E7F]/.test(q.text)).length} Thai, ${QUERIES.filter((q) => !/[\u0E00-\u0E7F]/.test(q.text)).length} English)`,
+  );
   console.log(`Machine: ${os.hostname()} (${os.cpus().length} CPUs)`);
 
   const models = ['nomic-embed-text', 'bge-m3', 'qwen3-embedding'];
@@ -163,22 +265,22 @@ async function main() {
   console.log('='.repeat(70));
 
   // Summary table
-  const header = `| Metric | ${results.map(r => r.model).join(' | ')} |`;
+  const header = `| Metric | ${results.map((r) => r.model).join(' | ')} |`;
   const sep = `|--------|${results.map(() => '--------').join('|')}|`;
   const rows = [
-    `| Dimensions | ${results.map(r => String(r.dims)).join(' | ')} |`,
-    `| Index ${DOCS.length} docs | ${results.map(r => `${r.indexMs}ms`).join(' | ')} |`,
-    `| Query avg | ${results.map(r => `${r.avgQueryMs}ms`).join(' | ')} |`,
-    `| **Cross-language %** | ${results.map(r => `**${r.crossLangScore}%**`).join(' | ')} |`,
+    `| Dimensions | ${results.map((r) => String(r.dims)).join(' | ')} |`,
+    `| Index ${DOCS.length} docs | ${results.map((r) => `${r.indexMs}ms`).join(' | ')} |`,
+    `| Query avg | ${results.map((r) => `${r.avgQueryMs}ms`).join(' | ')} |`,
+    `| **Cross-language %** | ${results.map((r) => `**${r.crossLangScore}%**`).join(' | ')} |`,
   ];
   console.log('\n' + [header, sep, ...rows].join('\n'));
 
   // Cross-language detail
   console.log('\n\n--- Cross-Language Retrieval ---\n');
-  const qHeader = `| Query | ${results.map(r => r.model).join(' | ')} |`;
+  const qHeader = `| Query | ${results.map((r) => r.model).join(' | ')} |`;
   const qSep = `|-------|${results.map(() => '------').join('|')}|`;
   const qRows = QUERIES.map((q, i) => {
-    const cols = results.map(r => {
+    const cols = results.map((r) => {
       const qr = r.queryResults[i];
       return `${qr.crossLang ? '✓' : '✗'} [${qr.top3.join(',')}]`;
     });
@@ -189,7 +291,7 @@ async function main() {
   console.log('\n\nDone.');
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Benchmark failed:', e);
   process.exit(1);
 });

--- a/src/vector/__tests__/benchmark.ts
+++ b/src/vector/__tests__/benchmark.ts
@@ -17,40 +17,189 @@ import os from 'os';
 
 const DOCS: VectorDocument[] = [
   // Principles (10)
-  { id: 'p1', document: 'Nothing is deleted. Create new, do not delete. Git history is sacred. Every commit is permanent.', metadata: { type: 'principle', source_file: 'resonance/nothing-deleted.md' } },
-  { id: 'p2', document: 'Patterns over intentions. Watch what the code actually does, not what the PR description claims.', metadata: { type: 'principle', source_file: 'resonance/patterns.md' } },
-  { id: 'p3', document: 'External brain, not command. Mirror reality. Present options. Let the human decide.', metadata: { type: 'principle', source_file: 'resonance/external-brain.md' } },
-  { id: 'p4', document: 'Curiosity creates existence. Every search creates knowledge. Questions are never wasted.', metadata: { type: 'principle', source_file: 'resonance/curiosity.md' } },
-  { id: 'p5', document: 'Form and formless. 191+ Oracles share the same 5 Principles. Each has different purpose.', metadata: { type: 'principle', source_file: 'resonance/form-formless.md' } },
-  { id: 'p6', document: 'Oracle never pretends to be human. When AI speaks as itself, there is distinction — but that distinction IS unity.', metadata: { type: 'principle', source_file: 'resonance/transparency.md' } },
-  { id: 'p7', document: 'Small enough to understand. If it takes more than 8 minutes to grok, it is too complex.', metadata: { type: 'principle', source_file: 'resonance/small-enough.md' } },
-  { id: 'p8', document: 'Cold God Architecture. Build systems that are rules-based, indifferent, incorruptible.', metadata: { type: 'principle', source_file: 'resonance/cold-god.md' } },
-  { id: 'p9', document: 'Skills over features. Do not add features to codebases. Add skills — transformations that modify source code.', metadata: { type: 'principle', source_file: 'resonance/skills-over-features.md' } },
-  { id: 'p10', document: 'Haiku reads, Opus writes. 90% of work is cheap data gathering. 10% is quality synthesis.', metadata: { type: 'principle', source_file: 'resonance/haiku-reads.md' } },
+  {
+    id: 'p1',
+    document:
+      'Nothing is deleted. Create new, do not delete. Git history is sacred. Every commit is permanent.',
+    metadata: { type: 'principle', source_file: 'resonance/nothing-deleted.md' },
+  },
+  {
+    id: 'p2',
+    document:
+      'Patterns over intentions. Watch what the code actually does, not what the PR description claims.',
+    metadata: { type: 'principle', source_file: 'resonance/patterns.md' },
+  },
+  {
+    id: 'p3',
+    document: 'External brain, not command. Mirror reality. Present options. Let the human decide.',
+    metadata: { type: 'principle', source_file: 'resonance/external-brain.md' },
+  },
+  {
+    id: 'p4',
+    document:
+      'Curiosity creates existence. Every search creates knowledge. Questions are never wasted.',
+    metadata: { type: 'principle', source_file: 'resonance/curiosity.md' },
+  },
+  {
+    id: 'p5',
+    document:
+      'Form and formless. 191+ Oracles share the same 5 Principles. Each has different purpose.',
+    metadata: { type: 'principle', source_file: 'resonance/form-formless.md' },
+  },
+  {
+    id: 'p6',
+    document:
+      'Oracle never pretends to be human. When AI speaks as itself, there is distinction — but that distinction IS unity.',
+    metadata: { type: 'principle', source_file: 'resonance/transparency.md' },
+  },
+  {
+    id: 'p7',
+    document:
+      'Small enough to understand. If it takes more than 8 minutes to grok, it is too complex.',
+    metadata: { type: 'principle', source_file: 'resonance/small-enough.md' },
+  },
+  {
+    id: 'p8',
+    document:
+      'Cold God Architecture. Build systems that are rules-based, indifferent, incorruptible.',
+    metadata: { type: 'principle', source_file: 'resonance/cold-god.md' },
+  },
+  {
+    id: 'p9',
+    document:
+      'Skills over features. Do not add features to codebases. Add skills — transformations that modify source code.',
+    metadata: { type: 'principle', source_file: 'resonance/skills-over-features.md' },
+  },
+  {
+    id: 'p10',
+    document:
+      'Haiku reads, Opus writes. 90% of work is cheap data gathering. 10% is quality synthesis.',
+    metadata: { type: 'principle', source_file: 'resonance/haiku-reads.md' },
+  },
 
   // Learnings (10)
-  { id: 'l1', document: 'TypeScript Hono API with SQLite FTS5 for full text search. Ground truth in markdown files.', metadata: { type: 'learning', source_file: 'learnings/hono-fts5.md' } },
-  { id: 'l2', document: 'ChromaDB vector embeddings for semantic similarity search with all-MiniLM-L6-v2 model.', metadata: { type: 'learning', source_file: 'learnings/chromadb.md' } },
-  { id: 'l3', document: 'Qdrant is cloud-native vector DB with payload filtering. Uses cosine distance metric.', metadata: { type: 'learning', source_file: 'learnings/qdrant.md' } },
-  { id: 'l4', document: 'LanceDB is serverless columnar vector DB. Stores data as Lance files on disk. No server needed.', metadata: { type: 'learning', source_file: 'learnings/lancedb.md' } },
-  { id: 'l5', document: 'Thai text tokenizes at 2-3x more tokens per character than English. Safe truncation: 2000 characters.', metadata: { type: 'learning', source_file: 'learnings/thai-truncation.md' } },
-  { id: 'l6', document: 'pm2 does not reliably pass env vars through --update-env. Inline them in the command string.', metadata: { type: 'learning', source_file: 'learnings/pm2-env.md' } },
-  { id: 'l7', document: 'Separate frontend from backend cleanly. oracle-studio is its own server with API proxy.', metadata: { type: 'learning', source_file: 'learnings/frontend-separation.md' } },
-  { id: 'l8', document: 'Ollama nomic-embed-text produces 768-dimension vectors. GPU accelerated on Apple Silicon.', metadata: { type: 'learning', source_file: 'learnings/ollama-embeddings.md' } },
-  { id: 'l9', document: 'MCP protocol bridges allow Claude to interact with external tools like databases and APIs.', metadata: { type: 'learning', source_file: 'learnings/mcp-bridge.md' } },
-  { id: 'l10', document: 'Pluggable vector adapter pattern: factory + env var swaps entire vector DB engine at runtime.', metadata: { type: 'learning', source_file: 'learnings/pluggable-adapter.md' } },
+  {
+    id: 'l1',
+    document:
+      'TypeScript Hono API with SQLite FTS5 for full text search. Ground truth in markdown files.',
+    metadata: { type: 'learning', source_file: 'learnings/hono-fts5.md' },
+  },
+  {
+    id: 'l2',
+    document:
+      'ChromaDB vector embeddings for semantic similarity search with all-MiniLM-L6-v2 model.',
+    metadata: { type: 'learning', source_file: 'learnings/chromadb.md' },
+  },
+  {
+    id: 'l3',
+    document:
+      'Qdrant is cloud-native vector DB with payload filtering. Uses cosine distance metric.',
+    metadata: { type: 'learning', source_file: 'learnings/qdrant.md' },
+  },
+  {
+    id: 'l4',
+    document:
+      'LanceDB is serverless columnar vector DB. Stores data as Lance files on disk. No server needed.',
+    metadata: { type: 'learning', source_file: 'learnings/lancedb.md' },
+  },
+  {
+    id: 'l5',
+    document:
+      'Thai text tokenizes at 2-3x more tokens per character than English. Safe truncation: 2000 characters.',
+    metadata: { type: 'learning', source_file: 'learnings/thai-truncation.md' },
+  },
+  {
+    id: 'l6',
+    document:
+      'pm2 does not reliably pass env vars through --update-env. Inline them in the command string.',
+    metadata: { type: 'learning', source_file: 'learnings/pm2-env.md' },
+  },
+  {
+    id: 'l7',
+    document:
+      'Separate frontend from backend cleanly. oracle-studio is its own server with API proxy.',
+    metadata: { type: 'learning', source_file: 'learnings/frontend-separation.md' },
+  },
+  {
+    id: 'l8',
+    document:
+      'Ollama nomic-embed-text produces 768-dimension vectors. GPU accelerated on Apple Silicon.',
+    metadata: { type: 'learning', source_file: 'learnings/ollama-embeddings.md' },
+  },
+  {
+    id: 'l9',
+    document:
+      'MCP protocol bridges allow Claude to interact with external tools like databases and APIs.',
+    metadata: { type: 'learning', source_file: 'learnings/mcp-bridge.md' },
+  },
+  {
+    id: 'l10',
+    document:
+      'Pluggable vector adapter pattern: factory + env var swaps entire vector DB engine at runtime.',
+    metadata: { type: 'learning', source_file: 'learnings/pluggable-adapter.md' },
+  },
 
   // Retros (10)
-  { id: 'r1', document: 'Session 8 built pluggable vector DB adapters. 6 adapters, 4 embedding providers, 190 tests passing.', metadata: { type: 'retro', source_file: 'retros/session-8.md' } },
-  { id: 'r2', document: 'Session 9 deployed oracle-v2 on white.local. Qdrant Docker, Ollama embeddings, 22400 vectors indexed.', metadata: { type: 'retro', source_file: 'retros/session-9.md' } },
-  { id: 'r3', document: 'Caddy reverse proxy for HTTPS on LAN was too complex. HTTP on a memorable port is simpler.', metadata: { type: 'retro', source_file: 'retros/caddy-lesson.md' } },
-  { id: 'r4', document: 'Consultations feature was dead since February. Traced remnants across two repos and cleaned.', metadata: { type: 'retro', source_file: 'retros/consultations-cleanup.md' } },
-  { id: 'r5', document: 'Missing connect() call in indexer caused silent fallback to SQLite-only mode. Always connect first.', metadata: { type: 'retro', source_file: 'retros/connect-bug.md' } },
-  { id: 'r6', document: 'React dashboard with Recharts for activity visualization. Line chart, tabs, period selector.', metadata: { type: 'retro', source_file: 'retros/dashboard.md' } },
-  { id: 'r7', document: 'Knowledge map using UMAP dimensionality reduction from 768-dim vectors to 2D scatter plot.', metadata: { type: 'retro', source_file: 'retros/knowledge-map.md' } },
-  { id: 'r8', document: 'Air quality monitoring with PM2.5 sensors across 1500+ stations. 3.24 billion records in InfluxDB.', metadata: { type: 'retro', source_file: 'retros/air-quality.md' } },
-  { id: 'r9', document: 'Flood monitoring with ±2mm radar accuracy. Real-time water level tracking on JIBCHAIN L1 blockchain.', metadata: { type: 'retro', source_file: 'retros/flood-monitoring.md' } },
-  { id: 'r10', document: 'ESP32 LoRa Meshtastic mesh network for sensor data relay in remote areas without WiFi coverage.', metadata: { type: 'retro', source_file: 'retros/meshtastic.md' } },
+  {
+    id: 'r1',
+    document:
+      'Session 8 built pluggable vector DB adapters. 6 adapters, 4 embedding providers, 190 tests passing.',
+    metadata: { type: 'retro', source_file: 'retros/session-8.md' },
+  },
+  {
+    id: 'r2',
+    document:
+      'Session 9 deployed oracle-v2 on white.local. Qdrant Docker, Ollama embeddings, 22400 vectors indexed.',
+    metadata: { type: 'retro', source_file: 'retros/session-9.md' },
+  },
+  {
+    id: 'r3',
+    document:
+      'Caddy reverse proxy for HTTPS on LAN was too complex. HTTP on a memorable port is simpler.',
+    metadata: { type: 'retro', source_file: 'retros/caddy-lesson.md' },
+  },
+  {
+    id: 'r4',
+    document:
+      'Consultations feature was dead since February. Traced remnants across two repos and cleaned.',
+    metadata: { type: 'retro', source_file: 'retros/consultations-cleanup.md' },
+  },
+  {
+    id: 'r5',
+    document:
+      'Missing connect() call in indexer caused silent fallback to SQLite-only mode. Always connect first.',
+    metadata: { type: 'retro', source_file: 'retros/connect-bug.md' },
+  },
+  {
+    id: 'r6',
+    document:
+      'React dashboard with Recharts for activity visualization. Line chart, tabs, period selector.',
+    metadata: { type: 'retro', source_file: 'retros/dashboard.md' },
+  },
+  {
+    id: 'r7',
+    document:
+      'Knowledge map using UMAP dimensionality reduction from 768-dim vectors to 2D scatter plot.',
+    metadata: { type: 'retro', source_file: 'retros/knowledge-map.md' },
+  },
+  {
+    id: 'r8',
+    document:
+      'Air quality monitoring with PM2.5 sensors across 1500+ stations. 3.24 billion records in InfluxDB.',
+    metadata: { type: 'retro', source_file: 'retros/air-quality.md' },
+  },
+  {
+    id: 'r9',
+    document:
+      'Flood monitoring with ±2mm radar accuracy. Real-time water level tracking on JIBCHAIN L1 blockchain.',
+    metadata: { type: 'retro', source_file: 'retros/flood-monitoring.md' },
+  },
+  {
+    id: 'r10',
+    document:
+      'ESP32 LoRa Meshtastic mesh network for sensor data relay in remote areas without WiFi coverage.',
+    metadata: { type: 'retro', source_file: 'retros/meshtastic.md' },
+  },
 ];
 
 const QUERIES = [
@@ -112,7 +261,9 @@ async function benchAdapter(
 
   // Connect + setup
   await store.connect();
-  try { await store.deleteCollection(); } catch {}
+  try {
+    await store.deleteCollection();
+  } catch {}
   await store.ensureCollection();
 
   // Index benchmark
@@ -121,7 +272,7 @@ async function benchAdapter(
   console.log(`  Indexed in ${indexMs}ms`);
 
   // Wait for eventual consistency (Qdrant)
-  if (name === 'Qdrant') await new Promise(r => setTimeout(r, 500));
+  if (name === 'Qdrant') await new Promise((r) => setTimeout(r, 500));
 
   // Query benchmark
   const queryMs: number[] = [];
@@ -164,14 +315,22 @@ async function benchAdapter(
 
 async function main() {
   console.log('Vector DB Benchmark: ChromaDB vs LanceDB vs Qdrant');
-  console.log(`Corpus: ${DOCS.length} docs, ${QUERIES.length} queries, ${FILTERED_QUERIES.length} filtered queries`);
-  console.log(`Machine: ${os.hostname()} (${os.cpus().length} CPUs, ${Math.round(os.totalmem() / 1024 / 1024 / 1024)}GB RAM)`);
+  console.log(
+    `Corpus: ${DOCS.length} docs, ${QUERIES.length} queries, ${FILTERED_QUERIES.length} filtered queries`,
+  );
+  console.log(
+    `Machine: ${os.hostname()} (${os.cpus().length} CPUs, ${Math.round(os.totalmem() / 1024 / 1024 / 1024)}GB RAM)`,
+  );
 
   const results: BenchResult[] = [];
 
   // Check service availability
-  const ollamaOk = await fetch('http://localhost:11434/api/tags').then(r => r.ok).catch(() => false);
-  const qdrantOk = await fetch('http://localhost:6333/collections').then(r => r.ok).catch(() => false);
+  const ollamaOk = await fetch('http://localhost:11434/api/tags')
+    .then((r) => r.ok)
+    .catch(() => false);
+  const qdrantOk = await fetch('http://localhost:6333/collections')
+    .then((r) => r.ok)
+    .catch(() => false);
 
   if (!ollamaOk) {
     console.error('ERROR: Ollama not running. LanceDB and Qdrant need it for embeddings.');
@@ -192,7 +351,9 @@ async function main() {
     } catch (e) {
       console.error('LanceDB failed:', e);
     }
-    try { fs.rmSync(tmpDir, { recursive: true }); } catch {}
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {}
   }
 
   // 2. Qdrant (Ollama, 768-dim)
@@ -238,24 +399,24 @@ async function main() {
   console.log('='.repeat(70));
 
   // Summary table
-  const header = `| Metric | ${results.map(r => r.name).join(' | ')} |`;
+  const header = `| Metric | ${results.map((r) => r.name).join(' | ')} |`;
   const sep = `|--------|${results.map(() => '--------').join('|')}|`;
   const rows = [
-    `| Embedding dims | ${results.map(r => String(r.dims)).join(' | ')} |`,
-    `| Index ${DOCS.length} docs | ${results.map(r => `${r.indexMs}ms`).join(' | ')} |`,
-    `| Query avg (${QUERIES.length}q) | ${results.map(r => `${r.queryAvgMs}ms`).join(' | ')} |`,
-    `| Filtered avg (${FILTERED_QUERIES.length}q) | ${results.map(r => `${r.filteredAvgMs}ms`).join(' | ')} |`,
+    `| Embedding dims | ${results.map((r) => String(r.dims)).join(' | ')} |`,
+    `| Index ${DOCS.length} docs | ${results.map((r) => `${r.indexMs}ms`).join(' | ')} |`,
+    `| Query avg (${QUERIES.length}q) | ${results.map((r) => `${r.queryAvgMs}ms`).join(' | ')} |`,
+    `| Filtered avg (${FILTERED_QUERIES.length}q) | ${results.map((r) => `${r.filteredAvgMs}ms`).join(' | ')} |`,
   ];
 
   console.log('\n' + [header, sep, ...rows].join('\n'));
 
   // Query-by-query breakdown
   console.log('\n\n--- Query Latency Breakdown (ms) ---\n');
-  const qHeader = `| Query | ${results.map(r => r.name).join(' | ')} |`;
+  const qHeader = `| Query | ${results.map((r) => r.name).join(' | ')} |`;
   const qSep = `|-------|${results.map(() => '------').join('|')}|`;
   const qRows = QUERIES.map((q, i) => {
     const short = q.length > 40 ? q.slice(0, 37) + '...' : q;
-    return `| ${short} | ${results.map(r => `${r.queryMs[i] ?? '-'}ms`).join(' | ')} |`;
+    return `| ${short} | ${results.map((r) => `${r.queryMs[i] ?? '-'}ms`).join(' | ')} |`;
   });
   console.log([qHeader, qSep, ...qRows].join('\n'));
 
@@ -272,7 +433,7 @@ async function main() {
   console.log('\n\nDone.');
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Benchmark failed:', e);
   process.exit(1);
 });

--- a/src/vector/adapters/chroma-mcp.ts
+++ b/src/vector/adapters/chroma-mcp.ts
@@ -36,7 +36,11 @@ export class ChromaMcpAdapter implements VectorStoreAdapter {
     await this.client.addDocuments(docs);
   }
 
-  async query(text: string, limit?: number, where?: Record<string, any>): Promise<VectorQueryResult> {
+  async query(
+    text: string,
+    limit?: number,
+    where?: Record<string, any>,
+  ): Promise<VectorQueryResult> {
     return await this.client.query(text, limit, where);
   }
 
@@ -52,7 +56,9 @@ export class ChromaMcpAdapter implements VectorStoreAdapter {
     return await this.client.getCollectionInfo();
   }
 
-  async getAllEmbeddings(limit?: number): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
+  async getAllEmbeddings(
+    limit?: number,
+  ): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
     return await this.client.getAllEmbeddings(limit);
   }
 }

--- a/src/vector/adapters/cloudflare-vectorize.ts
+++ b/src/vector/adapters/cloudflare-vectorize.ts
@@ -11,7 +11,12 @@
  * Model: @cf/baai/bge-m3 (multilingual, 1024 dimensions)
  */
 
-import type { VectorStoreAdapter, VectorDocument, VectorQueryResult, EmbeddingProvider } from '../types.ts';
+import type {
+  VectorStoreAdapter,
+  VectorDocument,
+  VectorQueryResult,
+  EmbeddingProvider,
+} from '../types.ts';
 
 const CF_MODEL = '@cf/baai/bge-m3';
 const CF_DIMENSIONS = 1024;
@@ -34,7 +39,9 @@ export class CloudflareAIEmbeddings implements EmbeddingProvider {
     this.model = config.model || process.env.ORACLE_EMBEDDING_MODEL || CF_MODEL;
 
     if (!this.accountId || !this.apiToken) {
-      throw new Error('CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN required for Cloudflare AI embeddings');
+      throw new Error(
+        'CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN required for Cloudflare AI embeddings',
+      );
     }
   }
 
@@ -47,18 +54,18 @@ export class CloudflareAIEmbeddings implements EmbeddingProvider {
     for (let i = 0; i < texts.length; i += BATCH_SIZE) {
       const batch = texts.slice(i, i + BATCH_SIZE);
       // Truncate each text to ~3000 chars (safe for Thai)
-      const truncated = batch.map(t => t.length > 3000 ? t.slice(0, 3000) : t);
+      const truncated = batch.map((t) => (t.length > 3000 ? t.slice(0, 3000) : t));
 
       const response = await fetch(
         `https://api.cloudflare.com/client/v4/accounts/${this.accountId}/ai/run/${this.model}`,
         {
           method: 'POST',
           headers: {
-            'Authorization': `Bearer ${this.apiToken}`,
+            Authorization: `Bearer ${this.apiToken}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({ text: truncated }),
-        }
+        },
       );
 
       if (!response.ok) {
@@ -66,7 +73,7 @@ export class CloudflareAIEmbeddings implements EmbeddingProvider {
         throw new Error(`Cloudflare AI error: ${error}`);
       }
 
-      const data = await response.json() as {
+      const data = (await response.json()) as {
         result: { shape: number[]; data: number[][] };
         success: boolean;
       };
@@ -98,7 +105,7 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
   constructor(
     indexName: string,
     embedder: EmbeddingProvider,
-    config: { accountId?: string; apiToken?: string } = {}
+    config: { accountId?: string; apiToken?: string } = {},
   ) {
     this.indexName = indexName;
     this.embedder = embedder;
@@ -116,7 +123,7 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
     const response = await fetch(url, {
       method,
       headers: {
-        'Authorization': `Bearer ${this.apiToken}`,
+        Authorization: `Bearer ${this.apiToken}`,
         'Content-Type': 'application/json',
       },
       ...(body && { body: JSON.stringify(body) }),
@@ -136,7 +143,9 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
       await this.cfApi('');
       console.log(`[CF Vectorize] Connected to index '${this.indexName}'`);
     } catch (e) {
-      throw new Error(`Failed to connect to Vectorize index '${this.indexName}': ${e instanceof Error ? e.message : String(e)}`);
+      throw new Error(
+        `Failed to connect to Vectorize index '${this.indexName}': ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
 
@@ -156,7 +165,7 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
       const response = await fetch(createUrl, {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${this.apiToken}`,
+          Authorization: `Bearer ${this.apiToken}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -173,7 +182,9 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
         throw new Error(`Failed to create Vectorize index: ${error}`);
       }
 
-      console.log(`[CF Vectorize] Created index '${this.indexName}' (${this.embedder.dimensions} dims)`);
+      console.log(
+        `[CF Vectorize] Created index '${this.indexName}' (${this.embedder.dimensions} dims)`,
+      );
     }
   }
 
@@ -182,18 +193,21 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
       const url = `https://api.cloudflare.com/client/v4/accounts/${this.accountId}/vectorize/v2/indexes/${this.indexName}`;
       await fetch(url, {
         method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${this.apiToken}` },
+        headers: { Authorization: `Bearer ${this.apiToken}` },
       });
       console.log(`[CF Vectorize] Deleted index '${this.indexName}'`);
     } catch (e) {
-      console.warn('[CF Vectorize] deleteCollection failed:', e instanceof Error ? e.message : String(e));
+      console.warn(
+        '[CF Vectorize] deleteCollection failed:',
+        e instanceof Error ? e.message : String(e),
+      );
     }
   }
 
   async addDocuments(docs: VectorDocument[]): Promise<void> {
     if (docs.length === 0) return;
 
-    const texts = docs.map(d => d.document);
+    const texts = docs.map((d) => d.document);
     const embeddings = await this.embedder.embed(texts);
 
     // Vectorize upsert in batches (max 1000 per call)
@@ -207,13 +221,13 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
       }));
 
       // Vectorize uses NDJSON for vector upsert
-      const ndjson = vectors.map(v => JSON.stringify(v)).join('\n');
+      const ndjson = vectors.map((v) => JSON.stringify(v)).join('\n');
       const url = `https://api.cloudflare.com/client/v4/accounts/${this.accountId}/vectorize/v2/indexes/${this.indexName}/upsert`;
 
       const response = await fetch(url, {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${this.apiToken}`,
+          Authorization: `Bearer ${this.apiToken}`,
           'Content-Type': 'application/x-ndjson',
         },
         body: ndjson,
@@ -228,7 +242,11 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
     console.log(`[CF Vectorize] Added ${docs.length} documents`);
   }
 
-  async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
+  async query(
+    text: string,
+    limit: number = 10,
+    where?: Record<string, any>,
+  ): Promise<VectorQueryResult> {
     const [queryEmbedding] = await this.embedder.embed([text]);
 
     const body: any = {
@@ -240,9 +258,7 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
 
     if (where) {
       // Vectorize filter format: { field: { $eq: value } }
-      body.filter = Object.fromEntries(
-        Object.entries(where).map(([k, v]) => [k, { $eq: v }])
-      );
+      body.filter = Object.fromEntries(Object.entries(where).map(([k, v]) => [k, { $eq: v }]));
     }
 
     const data = await this.cfApi('/query', 'POST', body);
@@ -265,7 +281,7 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
     const getResponse = await fetch(getUrl, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${this.apiToken}`,
+        Authorization: `Bearer ${this.apiToken}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ ids: [id] }),
@@ -275,7 +291,7 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
       throw new Error(`Failed to get vector: ${await getResponse.text()}`);
     }
 
-    const getData = await getResponse.json() as any;
+    const getData = (await getResponse.json()) as any;
     const vectors = getData.result || [];
     if (vectors.length === 0 || !vectors[0].values) {
       throw new Error(`No embedding found for document: ${id}`);
@@ -290,9 +306,7 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
     };
 
     const data = await this.cfApi('/query', 'POST', body);
-    const matches = (data.result?.matches || [])
-      .filter((m: any) => m.id !== id)
-      .slice(0, nResults);
+    const matches = (data.result?.matches || []).filter((m: any) => m.id !== id).slice(0, nResults);
 
     return {
       ids: matches.map((m: any) => m.id),

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -5,7 +5,12 @@
  * Uses EmbeddingProvider since LanceDB doesn't generate embeddings.
  */
 
-import type { VectorStoreAdapter, VectorDocument, VectorQueryResult, EmbeddingProvider } from '../types.ts';
+import type {
+  VectorStoreAdapter,
+  VectorDocument,
+  VectorQueryResult,
+  EmbeddingProvider,
+} from '../types.ts';
 
 export class LanceDBAdapter implements VectorStoreAdapter {
   readonly name = 'lancedb';
@@ -44,12 +49,14 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     } else {
       // Create with a schema-defining dummy row, then delete it
       const dims = this.embedder.dimensions;
-      this.table = await this.db.createTable(this.collectionName, [{
-        id: '__init__',
-        text: '',
-        metadata: '{}',
-        vector: new Array(dims).fill(0),
-      }]);
+      this.table = await this.db.createTable(this.collectionName, [
+        {
+          id: '__init__',
+          text: '',
+          metadata: '{}',
+          vector: new Array(dims).fill(0),
+        },
+      ]);
       await this.table.delete('id = "__init__"');
     }
 
@@ -64,7 +71,10 @@ export class LanceDBAdapter implements VectorStoreAdapter {
       this.table = null;
       console.log(`[LanceDB] Collection '${this.collectionName}' deleted`);
     } catch (e) {
-      console.warn('[LanceDB] deleteCollection failed:', e instanceof Error ? e.message : String(e));
+      console.warn(
+        '[LanceDB] deleteCollection failed:',
+        e instanceof Error ? e.message : String(e),
+      );
     }
   }
 
@@ -72,7 +82,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     if (docs.length === 0) return;
     if (!this.table) await this.ensureCollection();
 
-    const texts = docs.map(d => d.document);
+    const texts = docs.map((d) => d.document);
     const embeddings = await this.embedder.embed(texts);
 
     const rows = docs.map((doc, i) => ({
@@ -86,7 +96,11 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     console.log(`[LanceDB] Added ${docs.length} documents`);
   }
 
-  async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
+  async query(
+    text: string,
+    limit: number = 10,
+    where?: Record<string, any>,
+  ): Promise<VectorQueryResult> {
     if (!this.table) await this.ensureCollection();
 
     const [queryEmbedding] = await this.embedder.embed([text]);
@@ -98,10 +112,12 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     // Filter metadata in JavaScript (LanceDB json_extract requires LargeBinary, not Utf8)
     let filtered = results;
     if (where) {
-      filtered = results.filter((r: any) => {
-        const meta = JSON.parse(r.metadata || '{}');
-        return Object.entries(where).every(([k, v]) => meta[k] === v);
-      }).slice(0, limit);
+      filtered = results
+        .filter((r: any) => {
+          const meta = JSON.parse(r.metadata || '{}');
+          return Object.entries(where).every(([k, v]) => meta[k] === v);
+        })
+        .slice(0, limit);
     }
 
     return {
@@ -122,7 +138,10 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     }
 
     const vector = Array.from(rows[0].vector);
-    const results = await this.table.search(vector).limit(nResults + 1).toArray();
+    const results = await this.table
+      .search(vector)
+      .limit(nResults + 1)
+      .toArray();
 
     const filtered = results.filter((r: any) => r.id !== id).slice(0, nResults);
 
@@ -160,7 +179,9 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     return { count: stats.count, name: this.collectionName };
   }
 
-  async getAllEmbeddings(limit: number = 5000): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
+  async getAllEmbeddings(
+    limit: number = 5000,
+  ): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
     if (!this.table) return { ids: [], embeddings: [], metadatas: [] };
 
     const rows = await this.table.query().limit(limit).toArray();

--- a/src/vector/adapters/qdrant.ts
+++ b/src/vector/adapters/qdrant.ts
@@ -5,7 +5,12 @@
  * Uses EmbeddingProvider since Qdrant stores pre-computed vectors.
  */
 
-import type { VectorStoreAdapter, VectorDocument, VectorQueryResult, EmbeddingProvider } from '../types.ts';
+import type {
+  VectorStoreAdapter,
+  VectorDocument,
+  VectorQueryResult,
+  EmbeddingProvider,
+} from '../types.ts';
 
 export class QdrantAdapter implements VectorStoreAdapter {
   readonly name = 'qdrant';
@@ -18,7 +23,7 @@ export class QdrantAdapter implements VectorStoreAdapter {
   constructor(
     collectionName: string,
     embedder: EmbeddingProvider,
-    config: { url?: string; apiKey?: string } = {}
+    config: { url?: string; apiKey?: string } = {},
   ) {
     this.collectionName = collectionName;
     this.embedder = embedder;
@@ -57,7 +62,9 @@ export class QdrantAdapter implements VectorStoreAdapter {
       });
     }
 
-    console.log(`[Qdrant] Collection '${this.collectionName}' ready (${this.embedder.dimensions} dims)`);
+    console.log(
+      `[Qdrant] Collection '${this.collectionName}' ready (${this.embedder.dimensions} dims)`,
+    );
   }
 
   async deleteCollection(): Promise<void> {
@@ -75,7 +82,7 @@ export class QdrantAdapter implements VectorStoreAdapter {
     if (docs.length === 0) return;
     if (!this.client) throw new Error('Qdrant not connected');
 
-    const texts = docs.map(d => d.document);
+    const texts = docs.map((d) => d.document);
     const embeddings = await this.embedder.embed(texts);
 
     const points = docs.map((doc, i) => ({
@@ -92,17 +99,23 @@ export class QdrantAdapter implements VectorStoreAdapter {
     console.log(`[Qdrant] Added ${docs.length} documents`);
   }
 
-  async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
+  async query(
+    text: string,
+    limit: number = 10,
+    where?: Record<string, any>,
+  ): Promise<VectorQueryResult> {
     if (!this.client) throw new Error('Qdrant not connected');
 
     const [queryEmbedding] = await this.embedder.embed([text]);
 
-    const filter = where ? {
-      must: Object.entries(where).map(([key, value]) => ({
-        key,
-        match: { value },
-      })),
-    } : undefined;
+    const filter = where
+      ? {
+          must: Object.entries(where).map(([key, value]) => ({
+            key,
+            match: { value },
+          })),
+        }
+      : undefined;
 
     const results = await this.client.search(this.collectionName, {
       vector: queryEmbedding,

--- a/src/vector/adapters/sqlite-vec.ts
+++ b/src/vector/adapters/sqlite-vec.ts
@@ -8,7 +8,12 @@
  */
 
 import { Database } from 'bun:sqlite';
-import type { VectorStoreAdapter, VectorDocument, VectorQueryResult, EmbeddingProvider } from '../types.ts';
+import type {
+  VectorStoreAdapter,
+  VectorDocument,
+  VectorQueryResult,
+  EmbeddingProvider,
+} from '../types.ts';
 
 /** Convert number[] to Float32Array binary blob for sqlite-vec */
 function toBlob(vec: number[]): Buffer {
@@ -22,7 +27,11 @@ function fromBlob(blob: any): number[] {
   }
   // Fallback: try JSON parse if stored as string
   if (typeof blob === 'string') {
-    try { return JSON.parse(blob); } catch { return []; }
+    try {
+      return JSON.parse(blob);
+    } catch {
+      return [];
+    }
   }
   return [];
 }
@@ -62,7 +71,9 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
           this.db.loadExtension(p);
           loaded = true;
           break;
-        } catch { /* try next */ }
+        } catch {
+          /* try next */
+        }
       }
     }
 
@@ -114,7 +125,10 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
       this.db.exec(`DROP TABLE IF EXISTS ${this.collectionName}_vec`);
       console.log(`[sqlite-vec] Collection '${this.collectionName}' deleted`);
     } catch (e) {
-      console.warn('[sqlite-vec] deleteCollection failed:', e instanceof Error ? e.message : String(e));
+      console.warn(
+        '[sqlite-vec] deleteCollection failed:',
+        e instanceof Error ? e.message : String(e),
+      );
     }
   }
 
@@ -125,7 +139,7 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
     await this.ensureCollection();
 
     // Generate embeddings for all documents
-    const texts = docs.map(d => d.document);
+    const texts = docs.map((d) => d.document);
     const embeddings = await this.embedder.embed(texts);
 
     const insertMeta = this.db.prepare(`
@@ -154,7 +168,11 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
     console.log(`[sqlite-vec] Added ${docs.length} documents`);
   }
 
-  async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
+  async query(
+    text: string,
+    limit: number = 10,
+    where?: Record<string, any>,
+  ): Promise<VectorQueryResult> {
     if (!this.db) throw new Error('sqlite-vec not connected');
 
     // Generate query embedding
@@ -164,13 +182,15 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
     const fetchLimit = where ? limit * 3 : limit;
 
     // KNN search via sqlite-vec — uses `k = ?` constraint, not LIMIT
-    const rows = this.db.prepare(`
+    const rows = this.db
+      .prepare(`
       SELECT v.id, v.distance, m.document, m.metadata
       FROM ${this.collectionName}_vec v
       JOIN ${this.collectionName}_meta m ON v.id = m.id
       WHERE v.embedding MATCH ? AND k = ?
       ORDER BY v.distance
-    `).all(toBlob(queryEmbedding), fetchLimit) as Array<{
+    `)
+      .all(toBlob(queryEmbedding), fetchLimit) as Array<{
       id: string;
       distance: number;
       document: string;
@@ -180,17 +200,19 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
     // Apply where filter in JS (sqlite-vec doesn't support metadata filtering)
     let filtered = rows;
     if (where) {
-      filtered = rows.filter(row => {
-        const meta = JSON.parse(row.metadata);
-        return Object.entries(where).every(([k, v]) => meta[k] === v);
-      }).slice(0, limit);
+      filtered = rows
+        .filter((row) => {
+          const meta = JSON.parse(row.metadata);
+          return Object.entries(where).every(([k, v]) => meta[k] === v);
+        })
+        .slice(0, limit);
     }
 
     return {
-      ids: filtered.map(r => r.id),
-      documents: filtered.map(r => r.document),
-      distances: filtered.map(r => r.distance),
-      metadatas: filtered.map(r => JSON.parse(r.metadata)),
+      ids: filtered.map((r) => r.id),
+      documents: filtered.map((r) => r.document),
+      distances: filtered.map((r) => r.distance),
+      metadatas: filtered.map((r) => JSON.parse(r.metadata)),
     };
   }
 
@@ -198,22 +220,26 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
     if (!this.db) throw new Error('sqlite-vec not connected');
 
     // Get the document's embedding from vec table (returns binary blob)
-    const doc = this.db.prepare(`
+    const doc = this.db
+      .prepare(`
       SELECT embedding FROM ${this.collectionName}_vec WHERE id = ?
-    `).get(id) as { embedding: any } | null;
+    `)
+      .get(id) as { embedding: any } | null;
 
     if (!doc) {
       throw new Error(`No embedding found for document: ${id}`);
     }
 
     // KNN search using the existing embedding blob
-    const rows = this.db.prepare(`
+    const rows = this.db
+      .prepare(`
       SELECT v.id, v.distance, m.document, m.metadata
       FROM ${this.collectionName}_vec v
       JOIN ${this.collectionName}_meta m ON v.id = m.id
       WHERE v.embedding MATCH ? AND k = ?
       ORDER BY v.distance
-    `).all(doc.embedding, nResults + 1) as Array<{
+    `)
+      .all(doc.embedding, nResults + 1) as Array<{
       id: string;
       distance: number;
       document: string;
@@ -221,13 +247,13 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
     }>;
 
     // Filter out the source document
-    const filtered = rows.filter(r => r.id !== id).slice(0, nResults);
+    const filtered = rows.filter((r) => r.id !== id).slice(0, nResults);
 
     return {
-      ids: filtered.map(r => r.id),
-      documents: filtered.map(r => r.document),
-      distances: filtered.map(r => r.distance),
-      metadatas: filtered.map(r => JSON.parse(r.metadata)),
+      ids: filtered.map((r) => r.id),
+      documents: filtered.map((r) => r.document),
+      distances: filtered.map((r) => r.distance),
+      metadatas: filtered.map((r) => JSON.parse(r.metadata)),
     };
   }
 
@@ -235,9 +261,9 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
     if (!this.db) return { count: 0 };
 
     try {
-      const result = this.db.prepare(
-        `SELECT COUNT(*) as count FROM ${this.collectionName}_meta`
-      ).get() as { count: number };
+      const result = this.db
+        .prepare(`SELECT COUNT(*) as count FROM ${this.collectionName}_meta`)
+        .get() as { count: number };
       return { count: result.count };
     } catch {
       return { count: 0 };
@@ -249,20 +275,24 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
     return { count: stats.count, name: this.collectionName };
   }
 
-  async getAllEmbeddings(limit: number = 5000): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
+  async getAllEmbeddings(
+    limit: number = 5000,
+  ): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
     if (!this.db) return { ids: [], embeddings: [], metadatas: [] };
 
-    const rows = this.db.prepare(`
+    const rows = this.db
+      .prepare(`
       SELECT v.id, v.embedding, m.metadata
       FROM ${this.collectionName}_vec v
       JOIN ${this.collectionName}_meta m ON v.id = m.id
       LIMIT ?
-    `).all(limit) as Array<{ id: string; embedding: any; metadata: string }>;
+    `)
+      .all(limit) as Array<{ id: string; embedding: any; metadata: string }>;
 
     return {
-      ids: rows.map(r => r.id),
-      embeddings: rows.map(r => fromBlob(r.embedding)),
-      metadatas: rows.map(r => JSON.parse(r.metadata)),
+      ids: rows.map((r) => r.id),
+      embeddings: rows.map((r) => fromBlob(r.embedding)),
+      metadatas: rows.map((r) => JSON.parse(r.metadata)),
     };
   }
 }

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -61,7 +61,7 @@ export class OllamaEmbeddings implements EmbeddingProvider {
         throw new Error(`Ollama API error: ${error}`);
       }
 
-      const data = await response.json() as { embedding: number[] };
+      const data = (await response.json()) as { embedding: number[] };
       embeddings.push(data.embedding);
 
       // Auto-detect dimensions from first response
@@ -98,7 +98,7 @@ export class OpenAIEmbeddings implements EmbeddingProvider {
     const response = await fetch('https://api.openai.com/v1/embeddings', {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${this.apiKey}`,
+        Authorization: `Bearer ${this.apiKey}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ input: texts, model: this.model }),
@@ -109,13 +109,11 @@ export class OpenAIEmbeddings implements EmbeddingProvider {
       throw new Error(`OpenAI API error: ${error}`);
     }
 
-    const data = await response.json() as {
+    const data = (await response.json()) as {
       data: { embedding: number[]; index: number }[];
     };
 
-    return data.data
-      .sort((a, b) => a.index - b.index)
-      .map(d => d.embedding);
+    return data.data.sort((a, b) => a.index - b.index).map((d) => d.embedding);
   }
 }
 
@@ -124,7 +122,7 @@ export class OpenAIEmbeddings implements EmbeddingProvider {
  */
 export function createEmbeddingProvider(
   type: EmbeddingProviderType = 'chromadb-internal',
-  model?: string
+  model?: string,
 ): EmbeddingProvider {
   switch (type) {
     case 'ollama':

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -11,7 +11,10 @@ import { ChromaMcpAdapter } from './adapters/chroma-mcp.ts';
 import { SqliteVecAdapter } from './adapters/sqlite-vec.ts';
 import { LanceDBAdapter } from './adapters/lancedb.ts';
 import { QdrantAdapter } from './adapters/qdrant.ts';
-import { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './adapters/cloudflare-vectorize.ts';
+import {
+  CloudflareVectorizeAdapter,
+  CloudflareAIEmbeddings,
+} from './adapters/cloudflare-vectorize.ts';
 import { createEmbeddingProvider } from './embeddings.ts';
 
 export interface VectorStoreConfig {
@@ -47,52 +50,52 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
   const home = process.env.HOME || process.env.USERPROFILE;
   if (!home) throw new Error('HOME environment variable not set — cannot resolve vector DB paths');
 
-  const type = config.type
-    || (process.env.ORACLE_VECTOR_DB as VectorDBType)
-    || 'chroma';
+  const type = config.type || (process.env.ORACLE_VECTOR_DB as VectorDBType) || 'chroma';
 
   const collectionName = config.collectionName || 'oracle_knowledge';
 
   switch (type) {
     case 'sqlite-vec': {
-      const dbPath = config.dataPath
-        || process.env.ORACLE_VECTOR_DB_PATH
-        || path.join(home,'.oracle', 'vectors.db');
+      const dbPath =
+        config.dataPath ||
+        process.env.ORACLE_VECTOR_DB_PATH ||
+        path.join(home, '.oracle', 'vectors.db');
 
-      const embeddingType = config.embeddingProvider
-        || (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType)
-        || 'ollama';
+      const embeddingType =
+        config.embeddingProvider ||
+        (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType) ||
+        'ollama';
 
-      const embeddingModel = config.embeddingModel
-        || process.env.ORACLE_EMBEDDING_MODEL;
+      const embeddingModel = config.embeddingModel || process.env.ORACLE_EMBEDDING_MODEL;
 
       const embedder = createEmbeddingProvider(embeddingType, embeddingModel);
       return new SqliteVecAdapter(collectionName, dbPath, embedder);
     }
 
     case 'lancedb': {
-      const dbPath = config.dataPath
-        || process.env.ORACLE_VECTOR_DB_PATH
-        || path.join(home,'.oracle', 'lancedb');
+      const dbPath =
+        config.dataPath ||
+        process.env.ORACLE_VECTOR_DB_PATH ||
+        path.join(home, '.oracle', 'lancedb');
 
-      const embeddingType = config.embeddingProvider
-        || (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType)
-        || 'ollama';
+      const embeddingType =
+        config.embeddingProvider ||
+        (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType) ||
+        'ollama';
 
-      const embeddingModel = config.embeddingModel
-        || process.env.ORACLE_EMBEDDING_MODEL;
+      const embeddingModel = config.embeddingModel || process.env.ORACLE_EMBEDDING_MODEL;
 
       const embedder = createEmbeddingProvider(embeddingType, embeddingModel);
       return new LanceDBAdapter(collectionName, dbPath, embedder);
     }
 
     case 'qdrant': {
-      const embeddingType = config.embeddingProvider
-        || (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType)
-        || 'ollama';
+      const embeddingType =
+        config.embeddingProvider ||
+        (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType) ||
+        'ollama';
 
-      const embeddingModel = config.embeddingModel
-        || process.env.ORACLE_EMBEDDING_MODEL;
+      const embeddingModel = config.embeddingModel || process.env.ORACLE_EMBEDDING_MODEL;
 
       const embedder = createEmbeddingProvider(embeddingType, embeddingModel);
       return new QdrantAdapter(collectionName, embedder, {
@@ -107,8 +110,7 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
         apiToken: config.cfApiToken || process.env.CLOUDFLARE_API_TOKEN,
       };
 
-      const embeddingModel = config.embeddingModel
-        || process.env.ORACLE_EMBEDDING_MODEL;
+      const embeddingModel = config.embeddingModel || process.env.ORACLE_EMBEDDING_MODEL;
 
       // Default to Cloudflare AI embeddings (same platform, zero egress)
       const embedder = new CloudflareAIEmbeddings({
@@ -121,7 +123,7 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
 
     case 'chroma':
     default: {
-      const dataPath = config.dataPath || path.join(home,'.chromadb');
+      const dataPath = config.dataPath || path.join(home, '.chromadb');
       const pythonVersion = config.pythonVersion || '3.12';
       return new ChromaMcpAdapter(collectionName, dataPath, pythonVersion);
     }
@@ -139,9 +141,15 @@ function homeDir(): string {
 }
 
 /** Known embedding model presets (resolved lazily to avoid import-time HOME access) */
-let _embeddingModels: Record<string, { collection: string; model: string; dataPath?: string }> | null = null;
+let _embeddingModels: Record<
+  string,
+  { collection: string; model: string; dataPath?: string }
+> | null = null;
 
-export function getEmbeddingModels(): Record<string, { collection: string; model: string; dataPath?: string }> {
+export function getEmbeddingModels(): Record<
+  string,
+  { collection: string; model: string; dataPath?: string }
+> {
   if (!_embeddingModels) {
     const home = homeDir();
     _embeddingModels = {
@@ -166,16 +174,25 @@ export function getEmbeddingModels(): Record<string, { collection: string; model
 }
 
 /** @deprecated Use getEmbeddingModels() — kept for backward compat */
-export const EMBEDDING_MODELS = new Proxy({} as Record<string, { collection: string; model: string; dataPath?: string }>, {
-  get(_, prop: string) { return getEmbeddingModels()[prop]; },
-  has(_, prop: string) { return prop in getEmbeddingModels(); },
-  ownKeys() { return Object.keys(getEmbeddingModels()); },
-  getOwnPropertyDescriptor(_, prop: string) {
-    const models = getEmbeddingModels();
-    if (prop in models) return { configurable: true, enumerable: true, value: models[prop] };
-    return undefined;
+export const EMBEDDING_MODELS = new Proxy(
+  {} as Record<string, { collection: string; model: string; dataPath?: string }>,
+  {
+    get(_, prop: string) {
+      return getEmbeddingModels()[prop];
+    },
+    has(_, prop: string) {
+      return prop in getEmbeddingModels();
+    },
+    ownKeys() {
+      return Object.keys(getEmbeddingModels());
+    },
+    getOwnPropertyDescriptor(_, prop: string) {
+      const models = getEmbeddingModels();
+      if (prop in models) return { configurable: true, enumerable: true, value: models[prop] };
+      return undefined;
+    },
   },
-});
+);
 
 const modelStoreCache = new Map<string, VectorStoreAdapter>();
 
@@ -200,9 +217,17 @@ export function getVectorStoreByModel(model?: string): VectorStoreAdapter {
     });
     modelStoreCache.set(key, store);
     // Auto-connect in background (non-blocking)
-    connectPromises.set(key, store.connect().catch(e =>
-      console.warn(`[VectorRegistry] Failed to connect ${key}:`, e instanceof Error ? e.message : String(e))
-    ));
+    connectPromises.set(
+      key,
+      store
+        .connect()
+        .catch((e) =>
+          console.warn(
+            `[VectorRegistry] Failed to connect ${key}:`,
+            e instanceof Error ? e.message : String(e),
+          ),
+        ),
+    );
   }
   return store;
 }

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -33,7 +33,9 @@ export interface VectorStoreAdapter {
   queryById(id: string, nResults?: number): Promise<VectorQueryResult>;
   getStats(): Promise<{ count: number }>;
   getCollectionInfo(): Promise<{ count: number; name: string }>;
-  getAllEmbeddings?(limit?: number): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }>;
+  getAllEmbeddings?(
+    limit?: number,
+  ): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }>;
 }
 
 /**

--- a/src/verify/handler.ts
+++ b/src/verify/handler.ts
@@ -81,21 +81,23 @@ export function verifyKnowledgeBase(opts: {
   // 2. Query DB for all indexed documents
   const typeFilter = type && type !== 'all' ? type : undefined;
   const dbRows = typeFilter
-    ? db.select({
-        id: oracleDocuments.id,
-        sourceFile: oracleDocuments.sourceFile,
-        indexedAt: oracleDocuments.indexedAt,
-        type: oracleDocuments.type,
-      })
+    ? db
+        .select({
+          id: oracleDocuments.id,
+          sourceFile: oracleDocuments.sourceFile,
+          indexedAt: oracleDocuments.indexedAt,
+          type: oracleDocuments.type,
+        })
         .from(oracleDocuments)
         .where(eq(oracleDocuments.type, typeFilter))
         .all()
-    : db.select({
-        id: oracleDocuments.id,
-        sourceFile: oracleDocuments.sourceFile,
-        indexedAt: oracleDocuments.indexedAt,
-        type: oracleDocuments.type,
-      })
+    : db
+        .select({
+          id: oracleDocuments.id,
+          sourceFile: oracleDocuments.sourceFile,
+          indexedAt: oracleDocuments.indexedAt,
+          type: oracleDocuments.type,
+        })
         .from(oracleDocuments)
         .all();
 


### PR DESCRIPTION
## Phase 1: Adopt Biome (format + lint) — formatting baseline

Adds **Biome** as the single format+lint tool for the project (Bun/TS-native, fast: 155 files in ~270ms). This is **Phase 1 of 2** from the coding-conventions discussion.

### What's in this PR
1. **`chore(tooling)`** — `@biomejs/biome` dev-dep + `biome.json` + scripts (`format`, `format:check`, `lint`).
   - Config **matched to the codebase's existing dominant style** (detected, not imposed): **2-space indent, single quotes, semicolons, lineWidth 100**. Scoped to `src/**/*.ts` (HTML excluded — it was the source of most "errors").
   - **Formatter = enforced.** **Linter = advisory for Phase 1** (recommended rules visible via `bun run lint`, not gating).
2. **`style`** — one-time mechanical `biome format --write ./src` across **128 files**. Pure formatting, **zero logic change**.

### Safety verification
- `tsc --noEmit` error set is **identical before vs after** the format pass (compared line-independently): **0 errors introduced.**
- ⚠️ **Pre-existing finding (not caused by this PR):** the codebase currently has **56 tsc errors / 21 distinct on `main`** — it does **not** pass `tsc --noEmit` clean today. Worth a follow-up (ties to the "tsc passes before merge" convention).

### Phase 2 (separate, later)
Ratchet lint rules `warn → error` one category at a time, fixing as we go — start with the high-value/low-count ones. Top volume to triage: `noExplicitAny` (754), `useNodejsImportProtocol` (127), `noGlobalIsNan` (80), `useParseIntRadix` (79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
