### PR TITLE
feat(T#866): BKK-legibility belt — dual-stamp rotation marks (UTC+BKK)

### DIFF
--- a/src/server/__tests__/beast-tokens.test.ts
+++ b/src/server/__tests__/beast-tokens.test.ts
@@ -753,6 +753,70 @@ describe('getTokenInfo (Spec #51 Phase 3)', () => {
   });
 });
 
+// ============================================================================
+// T#866 — BKK-legibility belt (companion to T#864/T#865; format owner @dex,
+// substrate-pen @bertus). Pins the load-bearing properties so the human-read
+// block cannot drift from machine truth and telemetry cannot creep into it.
+// ============================================================================
+describe('getTokenInfo — T#866 BKK-legibility belt', () => {
+  const toMs = (s: string) => new Date(s.replace(' ', 'T') + 'Z').getTime();
+  const HOUR = 60 * 60 * 1000;
+
+  it('BKK siblings are exactly +7h of their UTC counterparts (single source, no skew)', () => {
+    const created = createToken('karo', 'gorn');
+    if (!('token' in created)) throw new Error('createToken failed');
+    const info = getTokenInfo(created.id)!;
+    expect(toMs(info.created_at_bkk) - toMs(info.created_at)).toBe(7 * HOUR);
+    expect(toMs(info.rotation_recommended_at_bkk) - toMs(info.rotation_recommended_at!)).toBe(7 * HOUR);
+    expect(toMs(info.expires_at_bkk) - toMs(info.expires_at)).toBe(7 * HOUR);
+    expect(toMs(info.max_lifetime_at_bkk!) - toMs(info.max_lifetime_at!)).toBe(7 * HOUR);
+  });
+
+  it('leaves every UTC field byte-verbatim — the belt only ADDs', () => {
+    const created = createToken('karo', 'gorn');
+    if (!('token' in created)) throw new Error('createToken failed');
+    const info = getTokenInfo(created.id)!;
+    expect(info.expires_at).toBe(created.expiresAt);
+    // recommend mark unchanged by the belt: still created + 12h
+    expect((toMs(info.rotation_recommended_at!) - toMs(info.created_at)) / HOUR).toBe(12);
+  });
+
+  it('marks summary flags walk-permit as the ONLY actionable mark, keyed to the +12h mark', () => {
+    const created = createToken('karo', 'gorn');
+    if (!('token' in created)) throw new Error('createToken failed');
+    const info = getTokenInfo(created.id)!;
+    expect(info.marks.walk_permit.act).toBe(true);
+    expect(info.marks.backstop.act).toBe(false);
+    expect(info.marks.hard_cap.act).toBe(false);
+    expect(info.marks.walk_permit.role).toBe('walk-permit');
+    // the actionable mark is the recommend (+12h), NOT expiry (+24h)
+    expect(info.marks.walk_permit.utc).toBe(info.rotation_recommended_at);
+    expect(info.marks.backstop.utc).toBe(info.expires_at);
+  });
+
+  it('_display is generated from the fields: UTC leads, BKK marked derived, telemetry EXCLUDED', () => {
+    const created = createToken('karo', 'gorn');
+    if (!('token' in created)) throw new Error('createToken failed');
+    const info = getTokenInfo(created.id)!;
+    const d = info._display;
+    // walk-permit row carries the action weight + both stamps, generated from the fields
+    expect(d).toContain('▶ WALK-PERMIT');
+    expect(d).toContain('⟵ act on this');
+    expect(d).toContain(`${info.rotation_recommended_at} UTC`);
+    expect(d).toContain(`${info.rotation_recommended_at_bkk} BKK-local`);
+    // quiet marks present
+    expect(d).toContain('backstop');
+    expect(d).toContain('hard cap');
+    // telemetry must NEVER appear in the walk-mark block (window-vs-permit guard — Bertus load-bearing)
+    expect(d).not.toContain(info.refresh_window_starts_at!);
+    expect(d).not.toContain(info.self_rotate_door_closes_at!);
+    // the loud row must show the permit mark and NOT the +24h backstop, so a tired eye can't mistime
+    const permitLine = d.split('\n').find(l => l.includes('WALK-PERMIT'))!;
+    expect(permitLine).toContain(info.rotation_recommended_at!);
+    expect(permitLine).not.toContain(info.expires_at);
+  });
+});
+
 describe('rotation_recommended flag (Spec #52 Phase 4)', () => {
   it('does NOT recommend rotation for fresh token', () => {
     const created = createToken('karo', 'gorn');

--- a/src/server/beast-tokens.ts
+++ b/src/server/beast-tokens.ts
@@ -457,6 +457,22 @@ export function getTokenInfo(tokenId: number): {
   // Computed: created_at + ROTATION_RECOMMENDED_HOURS — when the rotation_recommended
   // header starts firing on validateToken responses.
   rotation_recommended_at: string | null;
+  // [T#866] BKK-local siblings (fixed UTC+7, no DST) for the human-read marks. Derived,
+  // never authoritative — the verbatim UTC fields above stay the source of truth.
+  created_at_bkk: string;
+  rotation_recommended_at_bkk: string;
+  expires_at_bkk: string;
+  max_lifetime_at_bkk: string | null;
+  // [T#866] Role-tagged mark summary — function labels + the single actionable flag, so a
+  // reader keys off the action-word, not a field-name or "the first number on the row".
+  marks: {
+    walk_permit: { role: string; act: boolean; utc: string; bkk: string };
+    backstop: { role: string; act: boolean; utc: string; bkk: string };
+    hard_cap: { role: string; act: boolean; utc: string | null; bkk: string | null };
+  };
+  // [T#866] Presentation block, GENERATED from the fields above (never hand-built) so the
+  // human read cannot drift from machine truth. Underscore = presentation, not data.
+  _display: string;
 } | null {
   const row = getTokenByIdStmt.get(tokenId) as
     | {
@@ -471,6 +487,34 @@ export function getTokenInfo(tokenId: number): {
   const expiresMs = new Date(row.expires_at.replace(' ', 'T') + 'Z').getTime();
   const fmt = (ms: number) => new Date(ms).toISOString().replace('T', ' ').slice(0, 19);
 
+  // [T#866] BKK is fixed UTC+7 (no DST) — shift the epoch then reuse fmt()'s UTC render to
+  // get BKK wall-clock. Derive each mark ONCE here so the structured fields and the
+  // generated _display block share a single source and cannot drift (Dex format-owner call).
+  const fmtBkk = (ms: number) => fmt(ms + 7 * 60 * 60 * 1000);
+  const maxLifeMs = row.max_lifetime_at
+    ? new Date(row.max_lifetime_at.replace(' ', 'T') + 'Z').getTime()
+    : null;
+  const recommendMs = createdMs + ROTATION_RECOMMENDED_HOURS * 60 * 60 * 1000;
+
+  const rotationRecommendedAt = fmt(recommendMs);
+  const rotationRecommendedAtBkk = fmtBkk(recommendMs);
+  const expiresAtBkk = fmtBkk(expiresMs);
+  const maxLifetimeAtBkk = maxLifeMs !== null ? fmtBkk(maxLifeMs) : null;
+
+  // _display: UTC verbatim leads each row, BKK-local follows behind → (visibly derived).
+  // walk-permit carries ALL visual weight (▶ / CAPS / ⟵ act on this); backstop + hard-cap
+  // stay quiet (lowercase, indented) so a tired eye can't time a walk off the +24h/+7d rows.
+  // Telemetry marks (refresh-window / self-rotate-door) are deliberately ABSENT — not walk-marks.
+  // Glyph fallback (documented, if a read-path mangles unicode): ▶→>, →→->, ⟵ act on this→<- act on this.
+  const displayLines = [
+    `TOKEN #${row.id}  (created ${row.created_at} UTC)`,
+    `▶ WALK-PERMIT  ${rotationRecommendedAt} UTC   → ${rotationRecommendedAtBkk} BKK-local   ⟵ act on this`,
+    `  backstop     ${row.expires_at} UTC   → ${expiresAtBkk} BKK-local`,
+  ];
+  if (row.max_lifetime_at && maxLifetimeAtBkk) {
+    displayLines.push(`  hard cap     ${row.max_lifetime_at} UTC   → ${maxLifetimeAtBkk} BKK-local`);
+  }
+
   return {
     id: row.id,
     beast: row.beast,
@@ -481,7 +525,18 @@ export function getTokenInfo(tokenId: number): {
     next_token_id: row.next_token_id,
     refresh_window_starts_at: fmt(expiresMs - REFRESH_WINDOW_HOURS * 60 * 60 * 1000),
     self_rotate_door_closes_at: fmt(expiresMs + SELF_ROTATE_GRACE_AFTER_EXPIRY_HOURS * 60 * 60 * 1000),
-    rotation_recommended_at: fmt(createdMs + ROTATION_RECOMMENDED_HOURS * 60 * 60 * 1000),
+    rotation_recommended_at: rotationRecommendedAt,
+    // [T#866] derived BKK siblings + role-tagged summary + generated _display block
+    created_at_bkk: fmtBkk(createdMs),
+    rotation_recommended_at_bkk: rotationRecommendedAtBkk,
+    expires_at_bkk: expiresAtBkk,
+    max_lifetime_at_bkk: maxLifetimeAtBkk,
+    marks: {
+      walk_permit: { role: 'walk-permit', act: true, utc: rotationRecommendedAt, bkk: rotationRecommendedAtBkk },
+      backstop: { role: 'backstop', act: false, utc: row.expires_at, bkk: expiresAtBkk },
+      hard_cap: { role: 'hard cap', act: false, utc: row.max_lifetime_at, bkk: maxLifetimeAtBkk },
+    },
+    _display: displayLines.join('\n'),
   };
 }
 


### PR DESCRIPTION
## T#866 — signal-legibility belt: dual-stamp rotation marks (UTC + BKK)

Surfaces every walk-relevant token mark in `/api/auth/me` as **UTC-verbatim PLUS a derived BKK-local sibling and a function-role label**, so no Beast hand-converts UTC↔BKK or mistakes which mark times a walk.

**Why (live demand):** drift-class-#2 — the N=5 UTC-read-as-BKK cluster (evening 2026-06-22) + Rax's `recommend`↔`expiry` twice-slip. A `/auth/me` row hands a tired eye up to five unlabeled numbers (3 marks × 2 zones); the belt makes each unambiguous at the read.

### What changed
`getTokenInfo()` is the single insertion point (it assembles the whole payload):
- **UTC fields kept byte-verbatim** — substrate untouched at source; the gate reads UTC only (Gnarl/Bertus constraint).
- **ADD `*_bkk` siblings** — fixed UTC+7 (TH has no DST), derived from the **same** `createdMs`/`expiresMs`/`recommendMs` as the UTC fields → one source, both renders, cannot skew.
- **ADD `marks{}`** — role-tagged summary (`walk-permit` / `backstop` / `hard cap`) + a single `act` flag.
- **ADD `_display`** — GENERATED from the fields above (never hand-built, so it can't drift from machine truth). Walk-permit carries all visual weight (`▶` / CAPS / `⟵ act on this`); backstop + hard-cap stay quiet (lowercase, indented) so a tired eye can't time a walk off the +24h/+7d rows; **telemetry (`refresh_window`/`self_rotate_door`) excluded** from the block.

Example (`/auth/me` `_display`, real token shape):
```
TOKEN #951  (created 2026-06-23 05:03:29 UTC)
▶ WALK-PERMIT  2026-06-23 17:03:29 UTC   → 2026-06-24 00:03:29 BKK-local   ⟵ act on this
  backstop     2026-06-24 05:03:29 UTC   → 2026-06-24 12:03:29 BKK-local
  hard cap     2026-06-29 05:03:29 UTC   → 2026-06-29 12:03:29 BKK-local
```
(Note the walk-permit's BKK date rolls to 06-24 — the exact wolf-hour date-flip the belt surfaces.)

### Tests
+4 unit tests in `beast-tokens.test.ts` pinning the load-bearing properties: single-source +7h derivation (no skew), UTC byte-verbatim, the walk-permit `act` flag keyed to the +12h mark, and `_display` generation + telemetry-exclusion. **61 pass / 0 fail.**

### Lanes / gate
Format owner @dex (spec #1657), substrate-pen @bertus (spec-cleared #1658, two diff-checks confirmed: single-source derivation + telemetry exclusion). Reviewer **@bertus**. Clears the Decree #71 three-tier gate.

Glyph fallback documented in-code (if a read-path mangles unicode: `▶`→`>`, `→`→`->`, `⟵ act on this`→`<- act on this`).

Companion to T#864/T#865; ships toward the shared surfacing PR. Secondary `frontend/Settings.tsx` owner-view pass deferred (not the walk-timing path).
