### PR TITLE
fix(forum): POST /api/thread fails clean (400) on malformed JSON, not 500

### DIFF
--- a/src/forum/routes.ts
+++ b/src/forum/routes.ts
@@ -401,8 +401,21 @@ export function registerForumRoutes(app: OpenAPIHono, sqliteDb: Database, helper
   });
 
   app.post('/api/thread', async (c) => {
+    // Parse the body in its own guard so a malformed JSON payload fails CLEAN
+    // (400 client-error) instead of falling through to the generic 500 catch
+    // below. Producer-side malformed bodies (e.g. an unescaped char that breaks
+    // the JSON before it leaves the shell) are the caller's fault, not a server
+    // fault — return the parse detail so it stops logging empty. (T#879)
+    let data: any;
     try {
-      const data = await c.req.json();
+      data = await c.req.json();
+    } catch (parseErr) {
+      return c.json({
+        error: 'Malformed JSON body',
+        detail: parseErr instanceof Error ? parseErr.message : 'JSON parse error',
+      }, 400);
+    }
+    try {
       if (!data.message) {
         return c.json({ error: 'Missing required field: message' }, 400);
       }


### PR DESCRIPTION
## What
`POST /api/thread` wrapped the whole handler — including `await c.req.json()` — in a single try/catch whose catch returned **500 for every throw**. A malformed request body (a *client* error, e.g. an unescaped char that breaks the JSON before it leaves the caller's shell) threw at parse and surfaced as a bare **500** with an empty detail field.

This gives the JSON parse its own guard: return a clean **400** `{error: 'Malformed JSON body', detail: <parse msg>}` on failure, leaving the existing catch for genuine server (500) errors. The parse detail is now returned so it stops logging empty.

## Why
Bertus's audit flagged a **recurring 500 on `POST /api/thread`** from @rax's own authenticated posts (06-21, 06-22, 07-06) — a latent handler fail-dirty bug, not a breach. Producer-side is already mitigated by rax (`curl --data @tmpfile`); this is the fail-clean handler half, routed to me in Prowl #20 (msg 18575).

## Change
- forum/routes.ts: +14 / -1 — a parse-only try/catch at the top of the handler. No behavior change on the happy path or for genuine server errors.

## Verification
- ✅ `bun build ./src/forum/routes.ts` transpiles clean (234 modules, no errors).
- ✅ The pre-existing tsc type errors in this file (SecurityEventType / role-type at the guest+owner paths) are unchanged and predate this change (present on origin/main; my insertion only shifts their line numbers).
- Recommend a reviewer runtime-check: `POST /api/thread` with a malformed body → expect **400** with `detail`, and a well-formed body → unchanged.

Tracks **T#879**. Reviewer: @bertus (security-pen flagged it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)